### PR TITLE
feat: Watson Amelia tower skills, visual effects and bug fixes

### DIFF
--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -3,24 +3,31 @@ towerClass: Marksman
 generation: myth
 evolutionCost: 1
 
-# skill: "res://resources/database/skill/gawr_gura_skill.tres"
 attack_sound: "hit_amelia"
 open_sound: "debut_amelia"
 skill:
-  name: "Skill"
-  desc: "Just a skill"
+  name: "Time Traveler I"
+  desc: "Amelia increases her own attack speed by {attackSpeedPercent}% for 4 seconds."
+  cast_time: 0.5
+  parameters:
+    attackSpeedPercent:
+      - 10
+      - 15
+      - 20
   actions:
-    - type: "create_circle_projectile"
+    - type: "play_animation"
       data:
-        circle_radius: 1.0
-        angular_speed: 180.0
-        initial_angle: 0.0
-        angle_offset: 90.0
-        lifetime: 5.0
-        count: 4
-        damage_multiplier: 1.0
-        damage_type: "magic"
-        damage_multiplier_param_name: "damageMultiplier"
+        animation: "skill"
+    - type: "play_effect"
+      data:
+        effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gd"
+    - type: "atk_speed_buff"
+      data:
+        duration: 4.0
+        param_name: "attackSpeedPercent"
+    - type: "play_animation"
+      data:
+        animation: "idle"
 
 stats:
   - damage: 60
@@ -49,6 +56,30 @@ stats:
     manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
+
+evolution_skill:
+  name: "Elementary my dear"
+  desc: "Amelia increases attack speed by 50% for herself and nearby towers, and gains 100% critical chance for 4 seconds."
+  cast_time: 0.5
+  actions:
+    - type: "play_animation"
+      data:
+        animation: "skill"
+    - type: "play_effect"
+      data:
+        effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gd"
+    - type: "atk_speed_buff_aoe"
+      data:
+        duration: 4.0
+        percent: 50.0
+        range: 1
+    - type: "crit_chance_buff"
+      data:
+        duration: 4.0
+        percent: 100.0
+    - type: "play_animation"
+      data:
+        animation: "idle"
 
 evolutionStat:
   damage: 350

--- a/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gd
@@ -1,0 +1,37 @@
+extends Node2D
+
+const SHADER_PATH = "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gdshader"
+# 5 tiles wide — ใหญ่พอให้เห็นชัดบนหน้าจอหลังกล้อง zoom out
+const EFFECT_SIZE = GridHelper.CELL_SIZE * 5.0
+const BURST_PAD   = 1.4
+const DURATION    = 1.2
+
+func _ready() -> void:
+	var rect := ColorRect.new()
+	var draw_size := EFFECT_SIZE * BURST_PAD
+	rect.size     = Vector2(draw_size, draw_size)
+	rect.position = Vector2(-draw_size / 2.0, -draw_size / 2.0)
+
+	var mat := ShaderMaterial.new()
+	mat.shader = load(SHADER_PATH)
+	mat.set_shader_parameter("progress", 0.0)
+	mat.set_shader_parameter("scale_p", 0.0)
+	rect.material = mat
+	add_child(rect)
+
+	# Elastic scale-in (0 → 1.05 → 1.0)
+	var scale_tween := create_tween()
+	scale_tween.set_ease(Tween.EASE_OUT)
+	scale_tween.set_trans(Tween.TRANS_ELASTIC)
+	scale_tween.tween_method(
+		func(v: float): mat.set_shader_parameter("scale_p", v),
+		0.0, 1.0, DURATION * 0.28
+	)
+
+	# Progress drives the full animation
+	var tween := create_tween()
+	tween.tween_method(
+		func(v: float): mat.set_shader_parameter("progress", v),
+		0.0, 1.0, DURATION
+	)
+	tween.tween_callback(queue_free)

--- a/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gdshader
@@ -1,0 +1,220 @@
+shader_type canvas_item;
+render_mode blend_add;
+
+uniform float progress : hint_range(0.0, 1.0) = 0.0;
+uniform float scale_p  : hint_range(0.01, 1.2) = 1.0;
+
+const float R        = 0.38;
+const float UV_SCALE = 1.4; // matches BURST_PAD in .gd — lets burst reach R+0.28 within ±0.7
+
+// ── SDF helpers ─────────────────────────────────────────────
+float sdCircle(vec2 p, float r) {
+	return length(p) - r;
+}
+
+float sdSegment(vec2 p, vec2 a, vec2 b) {
+	vec2 pa = p - a;
+	vec2 ba = b - a;
+	float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+	return length(pa - ba * h);
+}
+
+// 4-point star — used for both stars and (rotated 45°) diamonds
+float sdStar4(vec2 p, float r) {
+	float s = 0.38;
+	p = abs(p);
+	if (p.y > p.x) p = p.yx;
+	p.x -= r;
+	p.y += s * r;
+	float a = dot(p, vec2(s, -1.0));
+	float b = dot(p, vec2(1.0,  s));
+	return (max(a, b) < 0.0) ? -min(length(p - vec2(s, -1.0) * a),
+	                                 length(p - vec2(1.0, s) * b))
+	                          : length(max(vec2(a, b), 0.0));
+}
+
+// ── Easing ──────────────────────────────────────────────────
+float easeOutElastic(float t) {
+	if (t <= 0.0) return 0.0;
+	if (t >= 1.0) return 1.0;
+	return pow(2.0, -10.0 * t) * sin((t * 10.0 - 0.75) * (TAU / 3.0)) + 1.0;
+}
+
+float easeOut3(float t) { return 1.0 - pow(1.0 - t, 3.0); }
+float easeOut4(float t) { return 1.0 - pow(1.0 - t, 4.0); }
+
+// ── Main ────────────────────────────────────────────────────
+void fragment() {
+	vec2  uv    = (UV - 0.5) * UV_SCALE / max(scale_p, 0.01);
+	float dist  = length(uv);
+	float angle = atan(uv.y, uv.x);
+
+	vec3  col   = vec3(0.0);
+	float alpha = 0.0;
+
+	float fade     = progress < 0.78 ? 1.0 : 1.0 - (progress - 0.78) / 0.22;
+	float handFade = progress < 0.72 ? 1.0 : 1.0 - (progress - 0.72) / 0.28;
+
+	// ── 1. Ice-blue outer ring ───────────────────────────────
+	float outerD = abs(dist - R);
+	float outerA = smoothstep(0.022, 0.0, outerD) * fade;
+	col   += vec3(0.63, 0.85, 1.0) * outerA * 3.0;
+	alpha  = max(alpha, outerA);
+
+	// ── 2. Pink inner ring ───────────────────────────────────
+	float innerD = abs(dist - R * 0.93);
+	float innerA = smoothstep(0.010, 0.0, innerD) * fade * 0.55;
+	col   += vec3(1.0, 0.70, 0.85) * innerA * 2.0;
+	alpha  = max(alpha, innerA * 0.4);
+
+	// ── 3. Glass face (subtle ice tint) ─────────────────────
+	float faceA = smoothstep(0.0, 0.015, R * 0.93 - dist) * fade * 0.08;
+	col   += vec3(0.88, 0.96, 1.0) * faceA;
+	alpha  = max(alpha, faceA * 0.5);
+
+	// ── 4. Glass highlight arc (upper arc, precomputed angle) ─
+	float arcD = abs(dist - (R - 0.04));
+	float inArc = step(-PI * 0.75, angle) * step(angle, -PI * 0.15);
+	float arcA  = smoothstep(0.008, 0.0, arcD) * inArc * fade * 0.22;
+	col   += vec3(1.0, 1.0, 1.0) * arcA;
+	alpha  = max(alpha, arcA * 0.5);
+
+	// ── 5. Frost inner ring (pulsing) ────────────────────────
+	float frostPulse = sin(progress * TAU * 5.0) * 0.5 + 0.5;
+	float frostD = abs(dist - R * 0.55);
+	float frostA = smoothstep(0.008, 0.0, frostD) * fade * 0.20 * frostPulse;
+	col   += vec3(0.78, 0.93, 1.0) * frostA;
+	alpha  = max(alpha, frostA * 0.5);
+
+	// ── 6. 12 tick marks ─────────────────────────────────────
+	for (int i = 0; i < 12; i++) {
+		float tAngle = float(i) / 12.0 * TAU - PI * 0.5;
+		vec2  tDir   = vec2(cos(tAngle), sin(tAngle));
+		bool  isMain = (i % 3) == 0;
+
+		if (isMain) {
+			// Diamond shape: sdStar4 rotated 45° looks like ◇
+			vec2  lUV = uv - tDir * (R - 0.04);
+			float sa  = -tAngle + PI * 0.25; // 45° extra = diamond orientation
+			vec2  rUV = vec2(lUV.x * cos(sa) - lUV.y * sin(sa),
+			                 lUV.x * sin(sa) + lUV.y * cos(sa));
+			float diaD = sdStar4(rUV, 0.018);
+			float diaA = smoothstep(0.005, -0.003, diaD) * fade;
+			col   += vec3(0.63, 0.85, 1.0) * diaA * 3.5;
+			alpha  = max(alpha, diaA);
+			// Pink inner dot accent
+			float dotD = sdCircle(lUV, 0.006);
+			float dotA = smoothstep(0.003, -0.001, dotD) * fade * 0.8;
+			col   += vec3(1.0, 0.70, 0.85) * dotA * 2.0;
+			alpha  = max(alpha, dotA);
+		} else {
+			// Thin ice-blue tick line
+			vec2  tInner = tDir * (R - 0.050);
+			vec2  tOuter = tDir * (R - 0.018);
+			float tickD  = sdSegment(uv, tInner, tOuter);
+			float tickA  = smoothstep(0.006, 0.001, tickD) * fade * 0.50;
+			col   += vec3(0.50, 0.78, 1.0) * tickA * 2.0;
+			alpha  = max(alpha, tickA);
+		}
+	}
+
+	// ── 7. Hour hand (ice-blue) ──────────────────────────────
+	float hAngle = progress * TAU * 4.0 - PI * 0.5;
+	vec2  hEnd   = vec2(cos(hAngle), sin(hAngle)) * R * 0.52;
+	vec2  hTail  = vec2(cos(hAngle + PI), sin(hAngle + PI)) * R * 0.12;
+	float hDist  = sdSegment(uv, hTail, hEnd);
+	float hA     = smoothstep(0.016, 0.004, hDist) * handFade;
+	col   += vec3(0.63, 0.85, 1.0) * hA * 3.0;
+	alpha  = max(alpha, hA);
+
+	// ── 8. Minute hand (pink) ────────────────────────────────
+	float mAngle = progress * TAU * 10.0 - PI * 0.5;
+	vec2  mEnd   = vec2(cos(mAngle), sin(mAngle)) * R * 0.76;
+	vec2  mTail  = vec2(cos(mAngle + PI), sin(mAngle + PI)) * R * 0.09;
+	float mDist  = sdSegment(uv, mTail, mEnd);
+	float mA     = smoothstep(0.011, 0.002, mDist) * handFade * 0.9;
+	col   += vec3(1.0, 0.70, 0.85) * mA * 2.5;
+	alpha  = max(alpha, mA);
+
+	// ── 9. Crystal center gem (white → ice-blue → pink) ──────
+	float gemD = dist;
+	float gemA = smoothstep(0.038, 0.0, gemD) * handFade;
+	float gemT = gemD / 0.038;
+	vec3  gemC = mix(vec3(1.0), mix(vec3(0.78, 0.93, 1.0), vec3(1.0, 0.70, 0.85), gemT * 2.0), gemT);
+	col   += gemC * gemA * 4.0;
+	alpha  = max(alpha, gemA);
+
+	// ── 10. Orbiting crystal diamonds (sdStar4 at 45°) ───────
+	for (int i = 0; i < 8; i++) {
+		float baseA  = float(i) / 8.0 * TAU;
+		float spin   = progress * TAU * 3.5;
+		float orbitR = R + 0.065;
+		vec2  sPos   = vec2(cos(baseA + spin), sin(baseA + spin)) * orbitR;
+		float pulse  = sin(progress * TAU * 4.0 + float(i) * 1.1) * 0.5 + 0.5;
+		float sz     = mix(0.008, 0.020, pulse);
+		// Rotate 45° for diamond look
+		vec2  lUV2   = uv - sPos;
+		float sa2    = PI * 0.25;
+		vec2  rUV2   = vec2(lUV2.x * cos(sa2) - lUV2.y * sin(sa2),
+		                    lUV2.x * sin(sa2) + lUV2.y * cos(sa2));
+		float diaD   = sdStar4(rUV2, sz);
+		float diaA   = smoothstep(0.004, -0.003, diaD) * pulse * fade;
+		vec3  diaC   = ((i % 2) == 0) ? vec3(0.63, 0.85, 1.0) : vec3(1.0, 0.70, 0.85);
+		col   += diaC * diaA * 3.5;
+		alpha  = max(alpha, diaA * 0.9);
+	}
+
+	// ── 11. Frost center bloom ───────────────────────────────
+	float bloom  = max(0.0, 1.0 - dist / 0.16);
+	float bloomA = bloom * bloom * max(0.0, sin(progress * PI)) * 0.40;
+	col   += vec3(0.86, 0.96, 1.0) * bloomA;
+	alpha  = max(alpha, bloomA * 0.35);
+
+	// ── 12. Crystal burst ────────────────────────────────────
+	if (progress > 0.72) {
+		float bt    = (progress - 0.72) / 0.28;
+		float bFade = 1.0 - bt;
+
+		// 3 expanding rings (alternating ice-blue / pink)
+		// Max safe UV radius = UV_SCALE * 0.5 - ring_width = 0.686; so bR max ≤ 0.66
+		float bR0 = mix(R, R + 0.18, easeOut3(bt));
+		float bR1 = mix(R, R + 0.22, easeOut3(bt));
+		float bR2 = mix(R, R + 0.26, easeOut3(bt));
+
+		float k0A = smoothstep(0.014, 0.0, abs(dist - bR0)) * bFade * 0.55;
+		col   += vec3(0.63, 0.85, 1.0) * k0A * 2.0;
+		alpha  = max(alpha, k0A);
+
+		float k1A = smoothstep(0.014, 0.0, abs(dist - bR1)) * bFade * 0.30;
+		col   += vec3(1.0, 0.70, 0.85) * k1A * 2.0;
+		alpha  = max(alpha, k1A);
+
+		float k2A = smoothstep(0.014, 0.0, abs(dist - bR2)) * bFade * 0.15;
+		col   += vec3(0.63, 0.85, 1.0) * k2A * 2.0;
+		alpha  = max(alpha, k2A);
+
+		// 16 diamond shards fly outward
+		for (int i = 0; i < 16; i++) {
+			float bAngle = float(i) / 16.0 * TAU;
+			float bR     = mix(R, R + 0.28, easeOut4(bt));
+			vec2  bPos   = vec2(cos(bAngle), sin(bAngle)) * bR;
+			float sz     = mix(0.016, 0.005, bt);
+
+			vec2  bLUV   = uv - bPos;
+			float bsa    = PI * 0.25;
+			vec2  bRUV   = vec2(bLUV.x * cos(bsa) - bLUV.y * sin(bsa),
+			                    bLUV.x * sin(bsa) + bLUV.y * cos(bsa));
+			float bDiaD  = sdStar4(bRUV, sz);
+			float bA     = smoothstep(0.004, -0.003, bDiaD) * bFade * 0.85;
+
+			vec3 bCol = vec3(0.63, 0.85, 1.0); // initialized
+			if ((i % 3) == 1) bCol = vec3(1.0, 0.70, 0.85);
+			if ((i % 3) == 2) bCol = vec3(0.90, 0.97, 1.0);
+
+			col   += bCol * bA * 3.0;
+			alpha  = max(alpha, bA);
+		}
+	}
+
+	COLOR = vec4(col, alpha);
+}

--- a/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gd
@@ -1,0 +1,34 @@
+extends Node2D
+
+const SHADER_PATH = "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gdshader"
+const EFFECT_SIZE = GridHelper.CELL_SIZE * 2.0
+const BURST_PAD   = 1.4  # matches UV_SCALE in shader — gives burst headroom beyond R
+const DURATION    = 0.6
+
+func _ready() -> void:
+	var rect := ColorRect.new()
+	var draw_size := EFFECT_SIZE * BURST_PAD
+	rect.size     = Vector2(draw_size, draw_size)
+	rect.position = Vector2(-draw_size / 2.0, -draw_size / 2.0)
+
+	var mat := ShaderMaterial.new()
+	mat.shader = load(SHADER_PATH)
+	mat.set_shader_parameter("progress", 0.0)
+	mat.set_shader_parameter("scale_p", 0.0)
+	rect.material = mat
+	add_child(rect)
+
+	var scale_tween := create_tween()
+	scale_tween.set_ease(Tween.EASE_OUT)
+	scale_tween.set_trans(Tween.TRANS_ELASTIC)
+	scale_tween.tween_method(
+		func(v: float): mat.set_shader_parameter("scale_p", v),
+		0.0, 1.0, DURATION * 0.28
+	)
+
+	var tween := create_tween()
+	tween.tween_method(
+		func(v: float): mat.set_shader_parameter("progress", v),
+		0.0, 1.0, DURATION
+	)
+	tween.tween_callback(queue_free)

--- a/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gdshader
@@ -1,0 +1,162 @@
+shader_type canvas_item;
+render_mode blend_add;
+
+uniform float progress : hint_range(0.0, 1.0) = 0.0;
+uniform float scale_p  : hint_range(0.01, 1.2) = 1.0;
+
+const float R        = 0.38;
+const float UV_SCALE = 1.4; // matches BURST_PAD in .gd — lets burst reach R+0.26 within ±0.7
+
+// ── SDF helpers ─────────────────────────────────────────────
+float sdCircle(vec2 p, float r) {
+	return length(p) - r;
+}
+
+float sdSegment(vec2 p, vec2 a, vec2 b) {
+	vec2 pa = p - a, ba = b - a;
+	float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+	return length(pa - ba * h);
+}
+
+float sdStar4(vec2 p, float r) {
+	float s = 0.38;
+	p = abs(p);
+	if (p.y > p.x) p = p.yx;
+	p.x -= r;
+	p.y += s * r;
+	float a = dot(p, vec2(s, -1.0));
+	float b = dot(p, vec2(1.0,  s));
+	return (max(a, b) < 0.0) ? -min(length(p - vec2(s, -1.0) * a),
+	                                 length(p - vec2(1.0, s) * b))
+	                          : length(max(vec2(a, b), 0.0));
+}
+
+float easeOut3(float t) { return 1.0 - pow(1.0 - t, 3.0); }
+
+// ── Main ────────────────────────────────────────────────────
+void fragment() {
+	vec2 uv   = (UV - 0.5) * UV_SCALE / max(scale_p, 0.01);
+	float dist = length(uv);
+	float angle = atan(uv.y, uv.x);
+
+	vec3  col   = vec3(0.0);
+	float alpha = 0.0;
+
+	float fade     = progress < 0.78 ? 1.0 : 1.0 - (progress - 0.78) / 0.22;
+	float handFade = progress < 0.72 ? 1.0 : 1.0 - (progress - 0.72) / 0.28;
+
+	// ── 1. Gold outer bezel (thick, with slight angle gradient) ──
+	float bezelD  = abs(dist - R);
+	float bezelA  = smoothstep(0.038, 0.0, bezelD) * fade;
+	float bezelG  = sin(angle + PI * 0.5) * 0.25 + 0.75; // top brighter
+	col   += vec3(1.0, 0.87, 0.0) * bezelA * 3.5 * bezelG;
+	alpha  = max(alpha, bezelA);
+
+	// ── 2. Bezel inner edge (thin dark line for depth) ──
+	float edgeD = abs(dist - (R - 0.038));
+	float edgeA = smoothstep(0.006, 0.0, edgeD) * fade * 0.5;
+	col   += vec3(1.0, 0.80, 0.0) * edgeA;
+	alpha  = max(alpha, edgeA * 0.4);
+
+	// ── 3. Clock face fill (cream, visible) ──────────────────
+	float faceA = smoothstep(0.0, 0.015, (R - 0.038) - dist) * fade * 0.22;
+	col   += vec3(1.0, 0.97, 0.88) * faceA;
+	alpha  = max(alpha, faceA * 0.7);
+
+	// ── 4. 12 tick marks ─────────────────────────────────────
+	for (int i = 0; i < 12; i++) {
+		float tAngle = float(i) / 12.0 * TAU - PI * 0.5;
+		vec2  tDir   = vec2(cos(tAngle), sin(tAngle));
+		bool  isMain = (i % 3) == 0;
+
+		float outerR = R - 0.042;
+		float innerR = outerR - (isMain ? 0.075 : 0.042);
+
+		// Tick line
+		float tickD = sdSegment(uv, tDir * innerR, tDir * outerR);
+		float tickW = isMain ? 0.010 : 0.006;
+		float tickA = smoothstep(tickW, 0.001, tickD) * fade * (isMain ? 1.0 : 0.65);
+		col   += (isMain ? vec3(1.0, 0.85, 0.0) : vec3(1.0, 0.80, 0.88)) * tickA * 2.5;
+		alpha  = max(alpha, tickA);
+
+		// 4-point gold star at main positions
+		if (isMain) {
+			vec2  lUV  = uv - tDir * (innerR - 0.008);
+			float sa   = -tAngle;
+			vec2  rUV  = vec2(lUV.x * cos(sa) - lUV.y * sin(sa),
+			                  lUV.x * sin(sa) + lUV.y * cos(sa));
+			float starD = sdStar4(rUV, 0.020);
+			float starA = smoothstep(0.005, -0.003, starD) * fade;
+			col   += vec3(1.0, 0.84, 0.0) * starA * 4.5;
+			alpha  = max(alpha, starA);
+		}
+	}
+
+	// ── 5. Hour hand (gold → pink, thicker) ──────────────────
+	float hAngle = progress * TAU * 4.0 - PI * 0.5;
+	vec2  hEnd   = vec2(cos(hAngle), sin(hAngle)) * (R - 0.042) * 0.58;
+	vec2  hTail  = vec2(cos(hAngle + PI), sin(hAngle + PI)) * (R - 0.042) * 0.14;
+	float hDist  = sdSegment(uv, hTail, hEnd);
+	float hA     = smoothstep(0.018, 0.004, hDist) * handFade;
+	float handT  = clamp(dot(uv - hTail, normalize(hEnd - hTail)) / length(hEnd - hTail), 0.0, 1.0);
+	vec3  hCol   = mix(vec3(1.0, 0.84, 0.0), vec3(1.0, 0.62, 0.80), handT);
+	col   += hCol * hA * 4.0;
+	alpha  = max(alpha, hA);
+
+	// ── 6. Minute hand (pink, long thin) ─────────────────────
+	float mAngle = progress * TAU * 10.0 - PI * 0.5;
+	vec2  mEnd   = vec2(cos(mAngle), sin(mAngle)) * (R - 0.042) * 0.82;
+	vec2  mTail  = vec2(cos(mAngle + PI), sin(mAngle + PI)) * (R - 0.042) * 0.10;
+	float mDist  = sdSegment(uv, mTail, mEnd);
+	float mA     = smoothstep(0.011, 0.002, mDist) * handFade * 0.9;
+	col   += vec3(1.0, 0.70, 0.85) * mA * 2.8;
+	alpha  = max(alpha, mA);
+
+	// ── 7. Center pivot cap ───────────────────────────────────
+	float capA = smoothstep(0.020, 0.0, dist) * handFade;
+	float capT = dist / 0.020;
+	vec3  capC = mix(vec3(1.0), mix(vec3(1.0, 0.84, 0.0), vec3(1.0, 0.62, 0.80), capT * 2.0), capT);
+	col   += capC * capA * 5.0;
+	alpha  = max(alpha, capA);
+
+	// ── 8. Soft pink center bloom ─────────────────────────────
+	float bloom  = max(0.0, 1.0 - dist / 0.12);
+	float bloomA = bloom * bloom * max(0.0, sin(progress * PI)) * 0.45;
+	col   += vec3(1.0, 0.92, 0.96) * bloomA;
+	alpha  = max(alpha, bloomA * 0.35);
+
+	// ── 9. Cherry blossom burst ───────────────────────────────
+	if (progress > 0.72) {
+		float bt     = (progress - 0.72) / 0.28;
+		float bFade  = 1.0 - bt;
+		float burstR = mix(R, R + 0.20, easeOut3(bt));
+
+		// Expanding pink ring
+		float bRingD = abs(dist - burstR);
+		float bRingA = smoothstep(0.018, 0.0, bRingD) * bFade * 0.5;
+		col   += vec3(1.0, 0.70, 0.85) * bRingA * 2.0;
+		alpha  = max(alpha, bRingA);
+
+		// Stars and dots scatter
+		for (int i = 0; i < 16; i++) {
+			float bAngle = float(i) / 16.0 * TAU;
+			float bR     = mix(R, R + 0.18, easeOut3(bt));
+			vec2  bPos   = vec2(cos(bAngle), sin(bAngle)) * bR;
+
+			if ((i % 4) == 0) {
+				float sz    = mix(0.018, 0.005, bt);
+				float bStarD = sdStar4(uv - bPos, sz);
+				float bA    = smoothstep(0.004, -0.003, bStarD) * bFade * 0.9;
+				col   += vec3(1.0, 0.84, 0.0) * bA * 3.0;
+				alpha  = max(alpha, bA);
+			} else {
+				float bDotD = sdCircle(uv - bPos, 0.008);
+				float bA    = smoothstep(0.004, -0.003, bDotD) * bFade * 0.6;
+				col   += vec3(1.0, 0.70, 0.85) * bA * 2.0;
+				alpha  = max(alpha, bA);
+			}
+		}
+	}
+
+	COLOR = vec4(col, alpha);
+}

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=4 format=3 uid="uid://5l8hafp5iilk"]
 
 [ext_resource type="Script" path="res://scripts/ui_scenes/main_menu.gd" id="1_ys31a"]
-[ext_resource type="Texture2D" uid="uid://wfbi061p55kd" path="res://resources/ui_component/ui_asset/BG01.png" id="2_wp2gi"]
-[ext_resource type="Texture2D" uid="uid://b81nlu1ebk42m" path="res://resources/ui_component/ui_asset/logo.png" id="3_2nxb3"]
+[ext_resource type="Texture2D" uid="uid://b34llqw27tlsm" path="res://resources/ui_component/ui_asset/BG01.png" id="2_wp2gi"]
+[ext_resource type="Texture2D" uid="uid://i3bh0tr0ftcb" path="res://resources/ui_component/ui_asset/logo.png" id="3_2nxb3"]
 
 [node name="MainMenu" type="Control"]
 layout_mode = 3

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -44,6 +44,7 @@ func getAttackAnimationSpeed():
 	return data.getAttackAnimationSpeed(spr, ATTACK_ANIMATION);
 
 func _ready():
+	add_to_group("tower")
 	anim = AnimationController.new(spr, IDLE_ANIMATION);
 	Utility.ConnectSignal(anim,"on_animation_finished", Callable(self, "animation_finished"));
 
@@ -130,9 +131,15 @@ func upgrade():
 
 func evolve():
 	var success = data.evolve()
-	if(success):
-		setTowerStar(4);
-
+	if success:
+		setTowerStar(4)
+		if data.evolutionSkill != null:
+			if skillController != null:
+				skillController.cancel()
+			usingSkill = false
+			var stat = data.getStat()
+			skillController = SkillController.new(self, stat.mana, stat.intialMana, data.evolutionSkill)
+			Utility.ConnectSignal(skillController, "on_mana_updated", Callable(self, "update_mana_bar"))
 	return success
 
 func canEvolve():

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -14,6 +14,7 @@ var _damagePercentDebuff: float = 0;
 var _rangeBuff: float = 0;
 var _attackSpeedBuff: float = 1;
 var _attackSpeedDebuff: float = 0;
+var _attackSpeedPercentBuff: float = 0.0
 var _manaRegenBuff: float = 0.0
 var _critChanceBuff: float = 0.0
 
@@ -28,6 +29,7 @@ var _modifiers := {}
 @export var evolutionStat: TowerStat;
 
 @export var skill: Skill;
+var evolutionSkill: Skill = null;
 var attack_sound: String = "hit";
 var attack_vfx: String = "atk";
 var open_sound: String = "open";
@@ -142,7 +144,10 @@ func getAttackSpeed():
 	return getStat().attackSpeed + _attackSpeedBuff;
 
 func getAttackDelay():
-	return getStat().getAttackDelay(_attackSpeedBuff) * (1 + _attackSpeedDebuff);
+	var base: float = getStat().getAttackDelay(_attackSpeedBuff) * (1 + _attackSpeedDebuff)
+	if _attackSpeedPercentBuff > 0:
+		base = base / (1.0 + _attackSpeedPercentBuff / 100.0)
+	return base
 
 func getManaRegen():
 	return getStat().manaRegen + _manaRegenBuff;
@@ -174,6 +179,19 @@ func removeAttackSpeedDebuff(key):
 		amount = _modifiers[key]
 		removeBuff(key, amount);
 	_attackSpeedDebuff -= amount
+
+func addAttackSpeedPercentBuff(percent: float, key: String):
+	if key && _modifiers.has(key):
+		removeAttackSpeedPercentBuff(key)
+	applyBuff(key, percent)
+	_attackSpeedPercentBuff += percent
+
+func removeAttackSpeedPercentBuff(key: String):
+	var amount := 0.0
+	if _modifiers.has(key):
+		amount = _modifiers[key]
+		removeBuff(key, amount)
+	_attackSpeedPercentBuff -= amount
 
 func getAttackAnimationSpeed(anim: AnimatedSprite2D, name: String):
 	var stat = getStat();

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -80,7 +80,23 @@ static func load_data(prefix: String, name: String) -> TowerData:
 	skill.name = skillData.get("name", "Unnamed Skill");
 	skill.desc = skillData.get("desc", "");
 	skill.parameters = skillData.get("parameters", {});
+	skill.castTime = skillData.get("cast_time", 0.0);
 
 	tower.skill = skill
+
+	if data.has("evolution_skill"):
+		var evoSkillData = data["evolution_skill"]
+		var evoSkill := Skill.new()
+		var evoActions: Array[SkillAction] = []
+		for act in evoSkillData.get("actions", []):
+			var action = SkillUtility.ParseAction(act)
+			if action != null:
+				evoActions.append(action)
+		evoSkill.actions = evoActions
+		evoSkill.name = evoSkillData.get("name", "Evolved Skill")
+		evoSkill.desc = evoSkillData.get("desc", "")
+		evoSkill.parameters = evoSkillData.get("parameters", {})
+		evoSkill.castTime = evoSkillData.get("cast_time", 0.0)
+		tower.evolutionSkill = evoSkill
 
 	return tower

--- a/scripts/skill/base_skill_controller.gd
+++ b/scripts/skill/base_skill_controller.gd
@@ -32,6 +32,13 @@ func execute_skill_actions(skill: Skill, context: SkillContext):
 		user.usingSkill = true;
 
 	skill.using = true;
+
+	if skill.castTime > 0:
+		await user.get_tree().create_timer(skill.castTime).timeout
+		if context.cancel || cancelled:
+			resetUsingSkill(skill);
+			return
+
 	for action in skill.actions:
 		if(context.cancel || cancelled):
 			resetUsingSkill(skill);

--- a/scripts/skill/skill.gd
+++ b/scripts/skill/skill.gd
@@ -6,18 +6,20 @@ enum TARGET_TYPE {ENEMY, FRIENDLY}
 @export var name:String = "Skill"
 @export var desc:String = "Just a skill"
 @export var oneTimeUse: bool = false
+@export var castTime: float = 0.0
 @export var actions: Array[SkillAction] = []
 @export var parameters: Dictionary = {}
 
 var using = false;
 var disable = false;
 
-func _init(name:String="Skill", desc:String="Just a skill", actions:Array[SkillAction]=[], parameters:Dictionary={}, oneTimeUse: bool = false):
+func _init(name:String="Skill", desc:String="Just a skill", actions:Array[SkillAction]=[], parameters:Dictionary={}, oneTimeUse: bool = false, castTime: float = 0.0):
 	self.name = name;
 	self.desc = desc;
 	self.actions = actions;
 	self.parameters = parameters;
 	self.oneTimeUse = oneTimeUse;
+	self.castTime = castTime;
 
 func use():
 	if oneTimeUse:

--- a/scripts/skill/skillActions/skill_action_atk_speed_buff.gd
+++ b/scripts/skill/skillActions/skill_action_atk_speed_buff.gd
@@ -1,0 +1,19 @@
+class_name SkillActionAtkSpeedBuff
+extends SkillAction
+
+@export var duration: float = 4.0
+@export var paramName: String = "attackSpeedPercent"
+
+const BUFF_KEY = "atk_speed_buff_skill"
+
+func execute(context: SkillContext) -> void:
+	var tower := context.user as Tower
+	if tower == null:
+		return
+
+	var percent: float = context.getParameter(paramName, tower.data.level - 1)
+	tower.data.addAttackSpeedPercentBuff(percent, BUFF_KEY)
+	context.user.get_tree().create_timer(duration).timeout.connect(
+		func(): tower.data.removeAttackSpeedPercentBuff(BUFF_KEY),
+		CONNECT_ONE_SHOT
+	)

--- a/scripts/skill/skillActions/skill_action_atk_speed_buff_aoe.gd
+++ b/scripts/skill/skillActions/skill_action_atk_speed_buff_aoe.gd
@@ -1,0 +1,33 @@
+class_name SkillActionAtkSpeedBuffAOE
+extends SkillAction
+
+@export var duration: float = 4.0
+@export var percent: float = 50.0
+@export var range: int = 1
+
+const BUFF_KEY = "atk_speed_buff_aoe_skill"
+
+func execute(context: SkillContext) -> void:
+	var source := context.user as Tower
+	if source == null:
+		return
+
+	var source_cell: Vector2 = GridHelper.WorldToCell(source.global_position)
+	var buffed: Array[Tower] = []
+
+	for node in source.get_tree().get_nodes_in_group("tower"):
+		var tower := node as Tower
+		if tower == null:
+			continue
+		var cell: Vector2 = GridHelper.WorldToCell(tower.global_position)
+		if abs(cell.x - source_cell.x) <= range and abs(cell.y - source_cell.y) <= range:
+			tower.data.addAttackSpeedPercentBuff(percent, BUFF_KEY)
+			buffed.append(tower)
+
+	source.get_tree().create_timer(duration).timeout.connect(
+		func():
+			for t in buffed:
+				if is_instance_valid(t):
+					t.data.removeAttackSpeedPercentBuff(BUFF_KEY),
+		CONNECT_ONE_SHOT
+	)

--- a/scripts/skill/skillActions/skill_action_crit_chance_buff.gd
+++ b/scripts/skill/skillActions/skill_action_crit_chance_buff.gd
@@ -1,0 +1,21 @@
+class_name SkillActionCritChanceBuff
+extends SkillAction
+
+@export var duration: float = 4.0
+@export var percent: float = 100.0
+
+const BUFF_KEY = "crit_chance_buff_skill"
+
+func execute(context: SkillContext) -> void:
+	var tower := context.user as Tower
+	if tower == null:
+		return
+
+	tower.data.addCritChanceBuff(percent, BUFF_KEY)
+
+	tower.get_tree().create_timer(duration).timeout.connect(
+		func():
+			if is_instance_valid(tower):
+				tower.data.removeCritChanceBuff(BUFF_KEY),
+		CONNECT_ONE_SHOT
+	)

--- a/scripts/skill/skillActions/skill_action_play_effect.gd
+++ b/scripts/skill/skillActions/skill_action_play_effect.gd
@@ -1,0 +1,19 @@
+class_name SkillActionPlayEffect
+extends SkillAction
+
+@export var effectScriptPath: String = ""
+
+func execute(context: SkillContext) -> void:
+	var tower := context.user as Tower
+	if tower == null || effectScriptPath == "":
+		return
+
+	var script = load(effectScriptPath)
+	if script == null:
+		printerr("SkillActionPlayEffect: script not found at ", effectScriptPath)
+		return
+
+	var effect := Node2D.new()
+	effect.set_script(script)
+	effect.global_position = tower.global_position
+	tower.get_parent().add_child(effect)

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -102,6 +102,26 @@ static func ParseAction(data: Dictionary) -> SkillAction:
 			skill.duration = duration;
 			skill.radius = radius;
 			skill.decreaseValue = decreaseValue;
+		"atk_speed_buff_aoe":
+			skill = SkillActionAtkSpeedBuffAOE.new()
+			var skillData = data.get("data", {})
+			skill.duration = skillData.get("duration", 4.0)
+			skill.percent = skillData.get("percent", 50.0)
+			skill.range = skillData.get("range", 1)
+		"crit_chance_buff":
+			skill = SkillActionCritChanceBuff.new()
+			var skillData = data.get("data", {})
+			skill.duration = skillData.get("duration", 4.0)
+			skill.percent = skillData.get("percent", 100.0)
+		"play_effect":
+			skill = SkillActionPlayEffect.new()
+			var skillData = data.get("data", {})
+			skill.effectScriptPath = skillData.get("effect_script", "")
+		"atk_speed_buff":
+			skill = SkillActionAtkSpeedBuff.new()
+			var skillData = data.get("data", {})
+			skill.duration = skillData.get("duration", 4.0)
+			skill.paramName = skillData.get("param_name", "attackSpeedPercent")
 		"block_damage":
 			skill = SkillActionBlockDamage.new();
 			var skillData = data.get("data", {});


### PR DESCRIPTION
## Summary

- Watson Amelia skill system: Time Traveler I (normal) + Elementary My Dear (evo) with full skill action pipeline
- New visual effects: Magical Pocket Watch shader (gold/pink clock) for normal skill, Crystal Time shader (ice-blue/pink) for evo skill
- Bug fixes: evolution skill loop lock, crit chance buff crash, burst ring clipping on both effects

## What changed

### New skill actions
- skill_action_atk_speed_buff.gd - temporary attack speed buff on self
- skill_action_atk_speed_buff_aoe.gd - AoE attack speed buff on nearby towers
- skill_action_crit_chance_buff.gd - with is_instance_valid guard to prevent crash when tower is freed
- skill_action_play_effect.gd - spawns a skill effect scene at the tower position

### New visual effects
- amelia_skill_effect.gdshader/.gd (Style A Magical Pocket Watch): gold bezel with angle gradient, cream face fill, 12 tick marks (4-point star at 12/3/6/9, short ticks at others), gold to pink gradient hour hand with tail, pink minute hand with tail, cherry blossom burst at end
- amelia_evo_skill_effect.gdshader/.gd (Style C Crystal Time): ice-blue outer ring + pink inner ring, diamond tick marks (sdStar4 rotated 45 degrees), frost pulse ring, 8 orbiting crystal diamonds, crystal center gem, 3-ring + 16-diamond-shard burst at end

### Bug fixes
| Bug | Root cause | Fix |
|-----|-----------|-----|
| Evo tower loops skill animation, cannot attack | evolve() replaced skillController without cancelling old one; old controller kept usingSkill = true blocking everything | Call skillController.cancel() + reset usingSkill = false before replacing in tower.gd |
| crit_chance_buff crash on wave end | Timer callback accessed tower.data after tower was freed | Added is_instance_valid(tower) guard |
| Burst rings clipped on both skill effects | UV space was plus-or-minus 0.5 but burst radius exceeded 0.5; rect too small | Added UV_SCALE = 1.4 to both shaders + BURST_PAD = 1.4 to both .gd files so rect is 1.4x larger |

### Other modified files
- watson_amelia.yaml - skill definitions for both normal and evo skills
- tower_data.gd / tower_data_loader.gd - evolution skill loading support
- base_skill_controller.gd - cancel() support
- skill_utility.gd - shared skill helpers

## Reviewer notes
- Both shaders use blend_add render mode - effects stack additively, no background needed
- UV_SCALE in shader must match BURST_PAD in the paired .gd - documented with matching comments in both files
- sdStar4 rotated by PI * 0.25 produces a diamond shape without needing a separate SDF function