### PR TITLE
fix: await Hitbox.create in AOE skill target finder (P2-D)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//c/Users/User/AppData/Roaming/Claude/local-agent-mode-sessions/skills-plugin/ffdf0642-950b-4b6e-8cbd-be8887f40c26/ba61f24f-4308-4cb4-80d3-44a72f5d0eea/skills/docx/**)",
+      "Bash(python scripts/office/unpack.py \"C:\\\\Users\\\\User\\\\Downloads\\\\HoloVe_GDD_v2.docx\" \"C:\\\\Temp\\\\gdd_unpacked\")",
+      "Bash(pip install *)",
+      "Bash(python -c ' *)",
+      "Bash(node -e \"require\\('docx'\\)\")",
+      "Bash(npm install *)",
+      "Bash(node gen_report.js)",
+      "Bash(npm list *)",
+      "Bash(npm root *)",
+      "Bash(node -e \"require.resolve\\('docx'\\)\")",
+      "Bash(NODE_PATH=\"C:\\\\Users\\\\User\\\\AppData\\\\Roaming\\\\npm\\\\node_modules\" node -e \"require.resolve\\('docx'\\)\")",
+      "Bash(mkdir C:\\\\Temp\\\\docxproj)",
+      "Bash(npm init *)",
+      "Bash(dir \"C:\\\\Users\\\\User\\\\Downloads\\\\HoloVe_BugReport_ForLeadProgrammer.docx\")",
+      "Skill(update-config)",
+      "Skill(update-config:*)",
+      "Bash(node build_report.js)",
+      "Bash(python scripts/office/unpack.py \"D:/Godot/holo.ve/QA Bug Report/HoloVe_BugReport_ForLeadProgrammer.docx\" unpacked_ref/)",
+      "Bash(extract-text \"D:/Godot/holo.ve/QA Bug Report/HoloVe_BugReport_ForLeadProgrammer.docx\")",
+      "Bash(pandoc unpacked_ref/word/document.xml -o -)",
+      "Read(//usr/local/**)",
+      "Read(//usr/**)",
+      "Bash(command -v nodejs)",
+      "PowerShell(Get-Command node -ErrorAction SilentlyContinue; Get-Command \"node.exe\" -ErrorAction SilentlyContinue; \\(Get-Command npm -ErrorAction SilentlyContinue\\).Source)",
+      "PowerShell($env:PATH -split \";\" | Where-Object { $_ -match \"node|npm\" })",
+      "PowerShell($skillBase = \"C:\\\\Users\\\\User\\\\AppData\\\\Roaming\\\\Claude\\\\local-agent-mode-sessions\\\\skills-plugin\\\\ffdf0642-950b-4b6e-8cbd-be8887f40c26\\\\ba61f24f-4308-4cb4-80d3-44a72f5d0eea\"; ls \"$skillBase\\\\bin\\\\\")",
+      "PowerShell(Get-ChildItem \"D:\\\\Godot\\\\holo.ve\\\\QA Bug Report\\\\\" | Select-Object Name, LastWriteTime, @{N='Size\\(KB\\)';E={[math]::Round\\($_.Length/1KB,1\\)}})",
+      "PowerShell(Copy-Item \"C:\\\\Users\\\\User\\\\AppData\\\\Roaming\\\\Claude\\\\local-agent-mode-sessions\\\\skills-plugin\\\\ffdf0642-950b-4b6e-8cbd-be8887f40c26\\\\ba61f24f-4308-4cb4-80d3-44a72f5d0eea\\\\skills\\\\docx\\\\HoloVe_BugReport_20260424.docx\" -Destination \"D:\\\\Godot\\\\holo.ve\\\\QA Bug Report\\\\HoloVe_BugReport_20260424.docx\")",
+      "PowerShell(Copy-Item \"C:\\\\Users\\\\User\\\\AppData\\\\Roaming\\\\Claude\\\\local-agent-mode-sessions\\\\skills-plugin\\\\ffdf0642-950b-4b6e-8cbd-be8887f40c26\\\\ba61f24f-4308-4cb4-80d3-44a72f5d0eea\\\\skills\\\\docx\\\\HoloVe_BugReport_20260424.docx\" -Destination \"D:\\\\Godot\\\\holo.ve\\\\QA Bug Report\\\\HoloVe_BugReport_20260424.docx\" -Force)",
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)",
+      "Bash(git push *)",
+      "Bash(gh --version)"
+    ]
+  }
+}

--- a/project.godot
+++ b/project.godot
@@ -10,7 +10,7 @@ config_version=5
 
 [application]
 
-config/name="holo.ve"
+config/name="holo.ve[Test]"
 run/main_scene="res://scenes/main_menu.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"

--- a/project.godot
+++ b/project.godot
@@ -1,16 +1,8 @@
-; Engine configuration file.
-; It's best edited using the editor UI and not directly,
-; since the parameters that go here are not all obvious.
-;
-; Format:
-;   [section] ; section goes between []
-;   param=value ; assign values to parameters
-
 config_version=5
 
 [application]
 
-config/name="holo.ve"
+config/name="holo.ve[Test]"
 run/main_scene="res://scenes/main_menu.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"

--- a/project.godot
+++ b/project.godot
@@ -10,7 +10,7 @@ config_version=5
 
 [application]
 
-config/name="holo.ve[Test]"
+config/name="holo.ve"
 run/main_scene="res://scenes/main_menu.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"

--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -14,7 +14,7 @@ func execute(context: SkillContext):
 	context.target = [] # Assuming context has a targets array property
 
 	while context.target.is_empty() && attempt < max_attempt:
-		find_targets_in_rotated_range(context)
+		await find_targets_in_rotated_range(context)
 
 		if context.target.is_empty():
 			attempt += 1
@@ -50,7 +50,7 @@ func find_targets_in_rotated_range(context: SkillContext):
 	var parent_node = context.user.get_parent() if context.user.get_parent() else context.user.get_tree().current_scene
 
 	var callback = Callable(self, "_on_hitbox_detected").bind(context, user_position)
-	Hitbox.create(actual_width, actual_height, callback, hitbox_position, parent_node, user_rotation, local_offset)
+	await Hitbox.create(actual_width, actual_height, callback, hitbox_position, parent_node, user_rotation, local_offset)
 
 func _on_hitbox_detected(enemies: Array, context: SkillContext, user_position: Vector2):
 	if not context:


### PR DESCRIPTION
SkillActionFindMultipleInRange called Hitbox.create() without await, but Hitbox.create is async (awaits process_frame internally before running _detect() and firing the callback). The caller checked context.target immediately after, found it empty, and cancelled the skill.

Add await in two places so the coroutine propagates correctly:
- find_targets_in_rotated_range: await Hitbox.create(...)
- execute loop: await find_targets_in_rotated_range(context)

Verified: Kiara's 3x1 AOE now reliably damages all enemies in range.