### PR TITLE
fix: await Hitbox.create in AOE skill target finder

### DIFF
--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -14,7 +14,7 @@ func execute(context: SkillContext):
 	context.target = [] # Assuming context has a targets array property
 
 	while context.target.is_empty() && attempt < max_attempt:
-		find_targets_in_rotated_range(context)
+		await find_targets_in_rotated_range(context)
 
 		if context.target.is_empty():
 			attempt += 1
@@ -50,7 +50,7 @@ func find_targets_in_rotated_range(context: SkillContext):
 	var parent_node = context.user.get_parent() if context.user.get_parent() else context.user.get_tree().current_scene
 
 	var callback = Callable(self, "_on_hitbox_detected").bind(context, user_position)
-	Hitbox.create(actual_width, actual_height, callback, hitbox_position, parent_node, user_rotation, local_offset)
+	await Hitbox.create(actual_width, actual_height, callback, hitbox_position, parent_node, user_rotation, local_offset)
 
 func _on_hitbox_detected(enemies: Array, context: SkillContext, user_position: Vector2):
 	if not context:


### PR DESCRIPTION
SkillActionFindMultipleInRange called Hitbox.create() without await, but Hitbox.create is async (awaits process_frame internally before running _detect() and firing the callback). The caller checked context.target immediately after, found it empty, and cancelled the skill.

Add await in two places so the coroutine propagates correctly:
- find_targets_in_rotated_range: await Hitbox.create(...)
- execute loop: await find_targets_in_rotated_range(context)

Verified: Kiara's 3x1 AOE now reliably damages all enemies in range.