### PR TITLE
fix: P2-F damage debuff + migrate damage to BuffInstance (Phase 1)

### DIFF
--- a/scripts/buff/buff_instance.gd
+++ b/scripts/buff/buff_instance.gd
@@ -7,6 +7,8 @@ enum StatType {
 	CRIT,
 	RANGE,
 	MANA_REGEN,
+	ATTACK_FLAT,
+	ATTACK_MULT,
 }
 
 enum Category {

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -251,9 +251,21 @@ func processActiveBuff(buff: Dictionary, extraKey: String = ""):
 		var value = buff[key]
 		match key:
 			"attack_bonus":
-				data.addPhysicDamageBuff(value, str(synergy_id) + extraKey)
+				var b := BuffInstance.new(
+					str(synergy_id) + extraKey + "_atk_flat",
+					BuffInstance.StatType.ATTACK_FLAT,
+					float(value),
+					BuffInstance.Category.BUFF,
+				)
+				data.buffs.add(b)
 			"attack_bonus_percent":
-				data.addAttackBonusPercentBuff(value, str(synergy_id) + extraKey)
+				var b := BuffInstance.new(
+					str(synergy_id) + extraKey + "_atk_mult",
+					BuffInstance.StatType.ATTACK_MULT,
+					float(value),
+					BuffInstance.Category.BUFF,
+				)
+				data.buffs.add(b)
 			"rangeBuff":
 				data.addAttackRangeBuff(value, str(synergy_id) + extraKey)
 			"mana_regen":
@@ -294,10 +306,10 @@ func clearSynergyBuffs(synergy_id: int):
 				continue
 			var value = buff[key]
 			match key:
-				"damageBuff":
-					data.removePhysicDamageBuff(synergy_id)
+				"attack_bonus":
+					data.buffs.remove(str(synergy_id) + "_atk_flat")
 				"attack_bonus_percent":
-					data.removeAttackBonusPercentBuff(synergy_id);
+					data.buffs.remove(str(synergy_id) + "_atk_mult")
 				"rangeBuff":
 					data.removeAttackRangeBuff(synergy_id)
 				"phys_atk_bonus_percent":
@@ -367,10 +379,17 @@ func removeDecreaseAtkSpeed(key: String):
 	data.buffs.remove(key)
 
 func addDecreaseDmgAllPercent(value: float, key: String = ""):
-	data.addAttackBonusPercentBuff(value, key);
+	# value is decimal (0.10 = 10%), BuffInstance ATTACK_MULT expects percent (-10)
+	var buff := BuffInstance.new(
+		key,
+		BuffInstance.StatType.ATTACK_MULT,
+		-value * 100.0,
+		BuffInstance.Category.DEBUFF,
+	)
+	data.buffs.add(buff)
 
 func removeDecreaseDmgAllPercent(key: String):
-	data.removeDecreaseDmgAllPercent(key);
+	data.buffs.remove(key)
 
 signal onReceiveMission(mission: MissionDetail);
 signal on_animation_finished(name: String);

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -11,9 +11,6 @@ var _level: int = 1;
 var _evolutionCost: int = 1;
 var _isEvolved: bool = false;
 
-var _damageBuff: int = 0;
-var _damagePercentBuff: float = 0;
-var _damagePercentDebuff: float = 0;
 var _rangeBuff: float = 0;
 var _manaRegenBuff: float = 0.0
 var _critChanceBuff: float = 0.0
@@ -55,56 +52,19 @@ func getStat():
 	get:
 		return _evolutionCost;
 
+func getTotalAttack() -> int:
+	var base: float = float(getStat().damage)
+	var flat: float = buffs.aggregate(BuffInstance.StatType.ATTACK_FLAT)
+	var mult: float = buffs.aggregate(BuffInstance.StatType.ATTACK_MULT)
+	var total: float = (base + flat) * (1.0 + mult / 100.0)
+	return int(clampf(total, 1.0, INF))
+
 func getDamage(enemy: Enemy, source: Node2D) -> Damage:
 	if(enemy == null):
-		return Damage.new(source, getStat().damage + _damageBuff, Damage.DamageType.MAGIC);
+		return Damage.new(source, getTotalAttack(), Damage.DamageType.MAGIC);
 
-	var finalDamage = calculateFinalDamage(getStat().damage + _damageBuff, enemy);
+	var finalDamage = calculateFinalDamage(getTotalAttack(), enemy);
 	return finalDamage;
-
-func addPhysicDamageBuff(amount: int, key):
-	if(key):
-		if(_modifiers.has(key)):
-			removePhysicDamageBuff(key)
-
-	_damageBuff += amount;
-	applyBuff(key, amount);
-
-func removePhysicDamageBuff(key):
-	var amount := 0;
-	if(_modifiers.has(key)):
-		amount = _modifiers.get(key, 0)
-		removeBuff(key, amount);
-
-	_damageBuff -= amount;
-
-func addAttackBonusPercentBuff(amount: int, key):
-	if key && _modifiers.has(key):
-		removeAttackBonusPercentBuff(key);
-
-	_damagePercentBuff += amount;
-	applyBuff(key, amount);
-
-func removeAttackBonusPercentBuff(key):
-	var amount = 0;
-	if(_modifiers.has(key)):
-		amount = _modifiers[key]
-		removeBuff(key, amount);
-	_damagePercentBuff -= amount
-
-func addAttackBonusPercentDebuff(amount: int, key):
-	if key && _modifiers.has(key):
-		removeAttackBonusPercentDebuff(key);
-
-	_damagePercentDebuff += amount;
-	applyBuff(key, amount);
-
-func removeAttackBonusPercentDebuff(key):
-	var amount = 0;
-	if(_modifiers.has(key)):
-		amount = _modifiers[key]
-		removeBuff(key, amount);
-	_damagePercentDebuff -= amount
 
 func calculateFinalDamage(baseDamage: float, enemy: Enemy) -> Damage:
 	var finalDamage = baseDamage
@@ -112,9 +72,6 @@ func calculateFinalDamage(baseDamage: float, enemy: Enemy) -> Damage:
 	# Apply each modifier in the array
 	for modifier in _attackModifierBuff:
 		finalDamage = modifier.call(finalDamage, enemy)
-
-	#Apply percent buff
-	finalDamage += (finalDamage * _damagePercentBuff / 100) * (1 - _damagePercentDebuff)
 
 	var critChance = getCritChance();
 	var isCrit = false;


### PR DESCRIPTION
- Add ATTACK_FLAT, ATTACK_MULT to BuffInstance.StatType
- TowerData.getTotalAttack() = clampf((Base + ΣFlat) × (1 + ΣMult/100), 1, INF)
- Wire synergy attack_bonus / attack_bonus_percent to BuffInstance
- addDecreaseDmgAllPercent now creates ATTACK_MULT debuff (decimal × 100)
- Remove legacy _damageBuff / _damagePercentBuff / _damagePercentDebuff + 6 methods
- Fix removeDecreaseDmgAllPercent calling nonexistent method
- Fix clearSynergyBuffs matching wrong key "damageBuff"