### PR TITLE
feat: damage type + defense factor

### DIFF
--- a/resources/database/towers/axel_syrios.yaml
+++ b/resources/database/towers/axel_syrios.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: warrior
 generation: tempus
+attackType: physic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/takanashi_kiara_skill.tres"

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: warrior
 generation: tempus
+attackType: physic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/takanashi_kiara_skill.tres"

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3 # tower max level
 towerClass: diva # tower class (Assassin, Diva, Hero, King, Marksman, Robotic, SpellCaster, Warrior)
 generation: tempus # tower generation (Myth, Tempus, Gen0, Gen1, Indo1)
+attackType: physic
 evolutionCost: 1 # ค่า evolution
 
 # skill: "res://resources/database/skill/gawr_gura_skill.tres" #tower skill file path (เดี๋ยวอัปเดตเป็น yaml ให้อีกที)

--- a/resources/database/towers/gavis_bettel.yaml
+++ b/resources/database/towers/gavis_bettel.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: spellcaster
 generation: tempus
+attackType: magic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/takanashi_kiara_skill.tres"

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: SpellCaster
 generation: myth
+attackType: magic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/gawr_gura_skill.tres"

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: marksman
 generation: tempus
+attackType: physic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/takanashi_kiara_skill.tres"

--- a/resources/database/towers/machina_x_flayon.yaml
+++ b/resources/database/towers/machina_x_flayon.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: robotic
 generation: tempus
+attackType: magic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/takanashi_kiara_skill.tres"

--- a/resources/database/towers/mori_calliope.yaml
+++ b/resources/database/towers/mori_calliope.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: Assassin
 generation: myth
+attackType: physic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/gawr_gura_skill.tres"

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: SpellCaster
 generation: myth
+attackType: magic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/gawr_gura_skill.tres"

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: hero
 generation: tempus
+attackType: physic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/takanashi_kiara_skill.tres"

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: warrior
 generation: myth
+attackType: physic
 evolutionCost: 1
 
 # skill: "res://resources/database/skill/takanashi_kiara_skill.tres"

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -1,6 +1,7 @@
 maxLevel: 3
 towerClass: Marksman
 generation: myth
+attackType: physic
 evolutionCost: 1
 
 attack_sound: "hit_amelia"

--- a/scripts/buff/buff_instance.gd
+++ b/scripts/buff/buff_instance.gd
@@ -9,6 +9,8 @@ enum StatType {
 	MANA_REGEN,
 	ATTACK_FLAT,
 	ATTACK_MULT,
+	MAGIC_FLAT,
+	MAGIC_MULT,
 }
 
 enum Category {

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -70,10 +70,18 @@ func recvDamage(damage: Damage) -> int:
 	var timer := get_tree().create_timer(0.3)
 	timer.timeout.connect(_on_damage_flash_timeout)
 
+	var defense_factor: float
+	match damage.type:
+		Damage.DamageType.MAGIC:
+			defense_factor = stats.getMagicResistFactor()
+		_:
+			defense_factor = stats.getArmorFactor()
+
+	var damageVal := int(damage.damage * defense_factor)
+
 	var reduction = stats.getDamageReduction();
-	var damageVal = damage.damage;
 	if reduction > 0:
-		damageVal = int(damage.damage * (1 - reduction))
+		damageVal = int(damageVal * (1 - reduction))
 	var currentHp = stats.updateHealth(-damageVal)
 
 	updateHealthBar(currentHp);
@@ -81,7 +89,13 @@ func recvDamage(damage: Damage) -> int:
 	if currentHp <= 0:
 		dead(damage)
 
-	var dmgColor = Color(1, 1, 1) if not damage.isCritical else Color(1, 0.15, 0)
+	var dmgColor: Color
+	match damage.type:
+		Damage.DamageType.MAGIC:
+			# vivid purple (normal) → pink-magenta (crit, rare event)
+			dmgColor = Color(1.0, 0.3, 0.85) if damage.isCritical else Color(0.85, 0.45, 1.0)
+		_:
+			dmgColor = Color(1, 0.15, 0) if damage.isCritical else Color(1, 1, 1)
 
 	Utility.show_damage_text(global_position, get_parent(), damageVal, dmgColor)
 	return damageVal

--- a/scripts/entity/enemy_stats.gd
+++ b/scripts/entity/enemy_stats.gd
@@ -86,8 +86,16 @@ func removeMArmorPercent(key: String):
 	extraMArmorPercent -= buffs[key];
 	buffs.erase(key);
 
+const ARMOR_MAX := 95
+
 func getTotalArmor() -> int:
-	return armor + int(armor * extraArmorPercent);
+	return clampi(armor + int(armor * extraArmorPercent), 0, ARMOR_MAX);
 
 func getTotalMArmor() -> int:
-	return mArmor + int(mArmor * extraMArmorPercent);
+	return clampi(mArmor + int(mArmor * extraMArmorPercent), 0, ARMOR_MAX);
+
+func getArmorFactor() -> float:
+	return 1.0 - float(getTotalArmor()) / 100.0
+
+func getMagicResistFactor() -> float:
+	return 1.0 - float(getTotalMArmor()) / 100.0

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -23,6 +23,7 @@ var buffs: TowerBuffContainer = TowerBuffContainer.new()
 @export var maxLevel: int = 3;
 @export var towerClass: TowerClass;
 @export var generation: TowerGeneration;
+@export var attackType: Damage.DamageType = Damage.DamageType.PHYSIC;
 
 @export var stats: Array[TowerStat];
 @export var evolutionStat: TowerStat;
@@ -54,14 +55,21 @@ func getStat():
 
 func getTotalAttack() -> int:
 	var base: float = float(getStat().damage)
-	var flat: float = buffs.aggregate(BuffInstance.StatType.ATTACK_FLAT)
-	var mult: float = buffs.aggregate(BuffInstance.StatType.ATTACK_MULT)
+	var flat: float
+	var mult: float
+	match attackType:
+		Damage.DamageType.MAGIC:
+			flat = buffs.aggregate(BuffInstance.StatType.MAGIC_FLAT)
+			mult = buffs.aggregate(BuffInstance.StatType.MAGIC_MULT)
+		_:
+			flat = buffs.aggregate(BuffInstance.StatType.ATTACK_FLAT)
+			mult = buffs.aggregate(BuffInstance.StatType.ATTACK_MULT)
 	var total: float = (base + flat) * (1.0 + mult / 100.0)
 	return int(clampf(total, 1.0, INF))
 
 func getDamage(enemy: Enemy, source: Node2D) -> Damage:
 	if(enemy == null):
-		return Damage.new(source, getTotalAttack(), Damage.DamageType.MAGIC);
+		return Damage.new(source, getTotalAttack(), attackType);
 
 	var finalDamage = calculateFinalDamage(getTotalAttack(), enemy);
 	return finalDamage;
@@ -80,7 +88,7 @@ func calculateFinalDamage(baseDamage: float, enemy: Enemy) -> Damage:
 			finalDamage *= getStat().critMultiplier
 			isCrit = true
 
-	return Damage.new(null, int(finalDamage), Damage.DamageType.PHYSIC, isCrit)
+	return Damage.new(null, int(finalDamage), attackType, isCrit)
 
 func getAttackRange():
 	return getStat().attackRange + _rangeBuff;

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -27,6 +27,11 @@ static func load_data(prefix: String, name: String) -> TowerData:
 	# Parse enum safely (string or int)
 	tower.towerClass = Utility.parse_string_to_enum(TowerData.TowerClass, data.get("towerClass", "Assassin"))
 	tower.generation = Utility.parse_string_to_enum(TowerData.TowerGeneration, data.get("generation", "Myth"))
+	if data.has("attackType"):
+		tower.attackType = Utility.parse_string_to_enum(Damage.DamageType, data["attackType"])
+	else:
+		push_warning("Tower YAML '" + name + "': missing 'attackType' field — defaulting to PHYSIC. Add 'attackType: physic' or 'attackType: magic' to suppress this warning.")
+		tower.attackType = Damage.DamageType.PHYSIC
 
 	tower.evolutionCost = data.get("evolutionCost", 1)
 


### PR DESCRIPTION
## Problem
หลังจาก Phase 1 (PR #6) ย้าย flat/% damage buffs เข้า BuffInstance แล้ว ยังเหลือ 2 ก้อนของ Master Formula §2 ที่ยังไม่ทำ:
- **Damage Type:** Tower ทุกตัวคำนวณเป็น physic หมด ไม่มี channel แยก magic — buff ที่ควรจะเข้าเฉพาะ magic dmg ก็เข้า phys ด้วย
- **Defense Factor:** สูตรเดิม `armor / (armor + 100)` ไม่ตรง spec, ไม่มี cap, และไม่ได้แตกตามชนิด damage

## Impact
- ✅ Tower แยก channel attack ได้: `attackType: physic` หรือ `magic` — buff คนละกระเป๋า
- ✅ Enemy ลด damage ตามชนิด: `1 - clamp(armor, 0, 95)/100` (cap 95) แตกตาม PHYS/MAGIC
- ✅ Damage text: physic ขาว/แดง-ส้ม (crit) | magic ม่วงสด/ชมพู-magenta (crit)
- ✅ ลด silent-fallback bug — YAML ลืม `attackType:` มี warning ใน log

## Fix
**P2-G — Tower Damage Type**
- เพิ่ม `attackType: Damage.DamageType` (export) ใน `TowerData`
- `getTotalAttack()` branch buff bucket ตาม `attackType` (MAGIC_FLAT/MULT vs ATTACK_FLAT/MULT)
- เพิ่ม `MAGIC_FLAT`, `MAGIC_MULT` ใน `BuffInstance.StatType`
- YAML 12 ไฟล์: ใส่ `attackType:` ครบ (7 PHYS + 4 MAGIC + default PHYS)
- `TowerDataLoader`: ถ้า YAML ไม่มี field → `push_warning` แล้ว fallback PHYSIC

**P2-H — Defense Factor + Armor Cap**
- `EnemyStat`: `const ARMOR_MAX = 95`, `getTotalArmor()` / `getTotalMArmor()` clamp 0–95
- เพิ่ม `getArmorFactor()` / `getMagicResistFactor()` = `1 - armor/100`
- `Enemy.recvDamage`: match `damage.type` แล้วเลือก defense factor + สี dmg text