### PR TITLE
Damage migration

### DIFF
--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -51,6 +51,35 @@ skill:
       data:
         damage: 100
         damage_type: physic
+        # ─────────────────────────────────────────────────────────────────
+        # Phase 3 Block C — Skill Multiplier (สำหรับ skill tower เท่านั้น)
+        #
+        # damage_multiplier:
+        #   - scalar  → ใช้ค่าเดียว ทุก level     เช่น 2.0 (200% Total Attack)
+        #   - array   → ค่าแต่ละ level [L1, L2, L3]  เช่น [1.4, 1.5, 1.7]
+        #
+        # damage_type ถ้าไม่ใส่ → ใช้ tower.attackType (default ตาม design 1 tower 1 type)
+        #
+        # can_crit:
+        #   - true (default) → skill roll crit ตามเลขของ tower
+        #   - false           → skill ไม่ crit (เช่น skill Kiara ตามดีไซน์)
+        #
+        # hit_distribution: [r1, r2, ...]  ← multi-hit, แบ่ง 100% ของ final damage
+        #   ⚠️ caution: ผลรวม ratio ต้อง = 1.0 ไม่งั้น push_warning
+        #   ⚠️ ใช้ได้กับ skill ของ tower เท่านั้น (normal attack ไม่มี multi-hit)
+        #
+        # ตัวอย่าง 4-hit skill ความเสียหาย 200% รวม:
+        #   - type: attack
+        #     data:
+        #       damage_multiplier: 2.0
+        #       hit_distribution: [0.2, 0.2, 0.1, 0.5]   # รวม = 1.0 ✓
+        #
+        # ตัวอย่าง skill non-crit ที่ scale ตาม level:
+        #   - type: attack
+        #     data:
+        #       damage_multiplier: [1.4, 1.5, 1.7]
+        #       can_crit: false
+        # ─────────────────────────────────────────────────────────────────
     - type: play_animation
       data:
         animation: "idle"

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -13,8 +13,8 @@ skill:
   actions:
     - type: find_multi_enemy
       data:
-        width: 1
-        height: 3
+        width: 3
+        height: 1
     - type: play_animation
       data:
         animation: "skill"

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -8,20 +8,41 @@ evolutionCost: 1
 attack_sound: "hit_kiara"
 open_sound: "debut_kiara"
 skill:
-  name: "Skill"
-  desc: "Just a skill"
+  name: "Kiara ฟันดาบเปลวเพลิง"
+  desc: "สร้างความเสียหายกายภาพ 140% / 150% / 170% (ตามเลเวล) แก่ศัตรูในระยะ 3×1"
   actions:
     - type: find_multi_enemy
       data:
-        width: 3
-        height: 1
+        width: 1
+        height: 3
     - type: play_animation
       data:
         animation: "skill"
     - type: attack
       data:
-        damage: 100
-        damage_type: physical
+        # Skill Multiplier ต่อ level — uses tower.attackType (physic) by default
+        damage_multiplier: [1.4, 1.5, 1.7]
+        can_crit: false   # Kiara ตามดีไซน์: skill ไม่สามารถ crit
+    - type: play_animation
+      data:
+        animation: "idle"
+
+# Evolution skill — overrides base skill when tower is evolved
+evolution_skill:
+  name: "Kiara ฟันดาบเปลวเพลิงสุดยอด"
+  desc: "สร้างความเสียหายกายภาพ 300% แก่ศัตรูในระยะ 6×3"
+  actions:
+    - type: find_multi_enemy
+      data:
+        width: 3
+        height: 6
+    - type: play_animation
+      data:
+        animation: "skill"
+    - type: attack
+      data:
+        damage_multiplier: 3.0   # 300% physic damage (uses tower.attackType)
+        can_crit: false
     - type: play_animation
       data:
         animation: "idle"

--- a/scripts/buff/buff_instance.gd
+++ b/scripts/buff/buff_instance.gd
@@ -12,6 +12,8 @@ enum StatType {
 	MAGIC_FLAT,
 	MAGIC_MULT,
 	CRIT_DAMAGE_BONUS,
+	DAMAGE_AMPLIFIER,    # additive decimal — final pipeline × (1 + ΣAmp)
+	DAMAGE_REDUCTION,    # additive decimal — final pipeline × (1 − ΣRed)
 }
 
 enum Category {

--- a/scripts/buff/buff_instance.gd
+++ b/scripts/buff/buff_instance.gd
@@ -4,13 +4,14 @@ extends Resource
 enum StatType {
 	ATTACK_SPEED,
 	DAMAGE,
-	CRIT,
+	CRIT_CHANCE,
 	RANGE,
 	MANA_REGEN,
 	ATTACK_FLAT,
 	ATTACK_MULT,
 	MAGIC_FLAT,
 	MAGIC_MULT,
+	CRIT_DAMAGE_BONUS,
 }
 
 enum Category {

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -77,11 +77,15 @@ func recvDamage(damage: Damage) -> int:
 		_:
 			defense_factor = stats.getArmorFactor()
 
-	var damageVal := int(damage.damage * defense_factor)
+	# Master Formula §2 final pipeline: × armor_factor × (1 + ΣAmp) × (1 − ΣRed)
+	var sigmaAmp: float = 0.0
+	if damage.source != null and damage.source is Tower:
+		var towerData: TowerData = (damage.source as Tower).data
+		if towerData != null:
+			sigmaAmp = towerData.buffs.aggregate(BuffInstance.StatType.DAMAGE_AMPLIFIER)
 
-	var reduction = stats.getDamageReduction();
-	if reduction > 0:
-		damageVal = int(damageVal * (1 - reduction))
+	var sigmaRed: float = stats.getDamageReduction()  # already clamped + handles blockCount
+	var damageVal: int = int(damage.damage * defense_factor * (1.0 + sigmaAmp) * (1.0 - sigmaRed))
 	var currentHp = stats.updateHealth(-damageVal)
 
 	updateHealthBar(currentHp);

--- a/scripts/entity/enemy_stats.gd
+++ b/scripts/entity/enemy_stats.gd
@@ -4,12 +4,14 @@ extends Resource
 @export var maxHp: int = 0;
 @export var currentHp: int = 0;
 @export var armor: int = 0;
-var extraArmorPercent: float = 0; # Additional armor from buffs/debuffs
+var extraArmorFlat: int = 0; # Additional armor (flat) from buffs/debuffs — ΣFlat in §4.1
+var extraArmorPercent: float = 0; # Additional armor (%) from buffs/debuffs — ΣMult in §4.1
 @export var mArmor: int = 0;
-var extraMArmorPercent: float = 0; # Additional magic armor from buffs/debuffs
+var extraMArmorFlat: int = 0; # Additional magic armor (flat) from buffs/debuffs
+var extraMArmorPercent: float = 0; # Additional magic armor (%) from buffs/debuffs
 @export var moveSpeed: float = 0;
 var moveSpeedMultiplier: float = 1;
-@export var damageReduction: float = 0.0; # Percentage (0.0 to 1.0)
+@export var damageReduction: float = 0.0; # Σ Damage Reduction (additive 0.0–0.9) — §6 final pipeline
 
 var blockCount: int = 0; # Number of damage blocks available
 
@@ -86,13 +88,58 @@ func removeMArmorPercent(key: String):
 	extraMArmorPercent -= buffs[key];
 	buffs.erase(key);
 
+func addArmorFlat(value: int, key: String):
+	if buffs.has(key):
+		removeArmorFlat(key);
+
+	extraArmorFlat += value;
+	buffs[key] = value;
+
+func removeArmorFlat(key: String):
+	if(!buffs.has(key)):
+		return;
+
+	extraArmorFlat -= int(buffs[key]);
+	buffs.erase(key);
+
+func addMArmorFlat(value: int, key: String):
+	if buffs.has(key):
+		removeMArmorFlat(key);
+
+	extraMArmorFlat += value;
+	buffs[key] = value;
+
+func removeMArmorFlat(key: String):
+	if(!buffs.has(key)):
+		return;
+
+	extraMArmorFlat -= int(buffs[key]);
+	buffs.erase(key);
+
+func addDamageReduction(value: float, key: String):
+	if buffs.has(key):
+		removeDamageReduction(key);
+
+	damageReduction += value;
+	buffs[key] = value;
+
+func removeDamageReduction(key: String):
+	if(!buffs.has(key)):
+		return;
+
+	damageReduction -= float(buffs[key]);
+	buffs.erase(key);
+
 const ARMOR_MAX := 95
 
+# §4.1 / §4.2: Total = (Base + ΣFlat) × (1 + ΣMult), clamp 0–95
 func getTotalArmor() -> int:
-	return clampi(armor + int(armor * extraArmorPercent), 0, ARMOR_MAX);
+	var withFlat: int = armor + extraArmorFlat
+	return clampi(int(withFlat * (1.0 + extraArmorPercent)), 0, ARMOR_MAX);
 
 func getTotalMArmor() -> int:
-	return clampi(mArmor + int(mArmor * extraMArmorPercent), 0, ARMOR_MAX);
+	var withFlat: int = mArmor + extraMArmorFlat
+	return clampi(int(withFlat * (1.0 + extraMArmorPercent)), 0, ARMOR_MAX);
 
 func getArmorFactor() -> float:
 	return 1.0 - float(getTotalArmor()) / 100.0

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -269,7 +269,7 @@ func processActiveBuff(buff: Dictionary, extraKey: String = ""):
 			"rangeBuff":
 				data.addAttackRangeBuff(value, str(synergy_id) + extraKey)
 			"mana_regen":
-				data.addManaRegen(value, str(synergy_id) + extraKey)
+				data.addManaRegenBuff(value, str(synergy_id) + extraKey)
 			"crit_chance_bonus_percent":
 				data.addCritChanceBuff(value, str(synergy_id) + extraKey)
 			"on_skill_cast":
@@ -317,7 +317,7 @@ func clearSynergyBuffs(synergy_id: int):
 				"magic_atk_bonus_percent":
 					data.removeMagicDamagePercentBuff(synergy_id)
 				"mana_regen":
-					data.removeManaRegen(synergy_id)
+					data.removeManaRegenBuff(synergy_id)
 				"meteor_proc_chance_percent":
 					data.removeMeteorProcChance(synergy_id)
 				"meteor_damage_percent":

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -81,12 +81,11 @@ func calculateFinalDamage(baseDamage: float, enemy: Enemy) -> Damage:
 	for modifier in _attackModifierBuff:
 		finalDamage = modifier.call(finalDamage, enemy)
 
-	var critChance = getCritChance();
-	var isCrit = false;
-	if(critChance > 0):
-		if(randi_range(0, 100) <= critChance):
-			finalDamage *= getStat().critMultiplier
-			isCrit = true
+	var critChance: float = getCritChance()
+	var isCrit: bool = critChance > 0 and randi_range(0, 100) <= critChance
+	var sigmaCD: float = getStat().critMultiplier + buffs.aggregate(BuffInstance.StatType.CRIT_DAMAGE_BONUS)
+	var critCheck: float = 1.0 if isCrit else 0.0
+	finalDamage *= 1.0 + (critCheck * (sigmaCD - 1.0))
 
 	return Damage.new(null, int(finalDamage), attackType, isCrit)
 

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -11,12 +11,7 @@ var _level: int = 1;
 var _evolutionCost: int = 1;
 var _isEvolved: bool = false;
 
-var _rangeBuff: float = 0;
-var _manaRegenBuff: float = 0.0
-var _critChanceBuff: float = 0.0
-
 var _attackModifierBuff: Array[Callable] = []
-var _modifiers := {}
 
 var buffs: TowerBuffContainer = TowerBuffContainer.new()
 
@@ -90,21 +85,14 @@ func calculateFinalDamage(baseDamage: float, enemy: Enemy) -> Damage:
 	return Damage.new(null, int(finalDamage), attackType, isCrit)
 
 func getAttackRange():
-	return getStat().attackRange + _rangeBuff;
+	return getStat().attackRange + buffs.aggregate(BuffInstance.StatType.RANGE)
 
-func addAttackRangeBuff(amount: int, key):
-	if(key):
-		if(_modifiers.has(key)):
-			removeAttackRangeBuff(key)
-		applyBuff(key, amount);
-	_rangeBuff += amount;
+func addAttackRangeBuff(amount, key):
+	_addBuffByStat(BuffInstance.StatType.RANGE, float(amount), key)
 
 func removeAttackRangeBuff(key):
-	var amount = 0;
-	if(_modifiers.has(key)):
-		amount = _modifiers[key]
-		removeBuff(key, amount);
-	_rangeBuff -= amount
+	if key:
+		buffs.remove(str(key))
 
 func getAttackSpeed() -> float:
 	var sigma := 1.0 + (buffs.aggregate(BuffInstance.StatType.ATTACK_SPEED) / 100.0)
@@ -114,41 +102,37 @@ func getAttackDelay() -> float:
 	return 100.0 / getAttackSpeed()
 
 func getManaRegen():
-	return getStat().manaRegen + _manaRegenBuff;
+	return getStat().manaRegen + buffs.aggregate(BuffInstance.StatType.MANA_REGEN)
 
 func getAttackAnimationSpeed(anim: AnimatedSprite2D, name: String) -> float:
 	return getStat().getAttackAnimationSpeed(anim, name, getAttackDelay())
 
 func addManaRegenBuff(amount: float, key):
-	if(key):
-		if(_modifiers.has(key)):
-			removeManaRegenBuff(key)
-		applyBuff(key, amount);
-	_manaRegenBuff += amount
+	_addBuffByStat(BuffInstance.StatType.MANA_REGEN, amount, key)
 
 func removeManaRegenBuff(key):
-	var amount := 0;
-	if(_modifiers.has(key)):
-		amount = _modifiers.get(key, 0)
-		removeBuff(key, amount);
-	_manaRegenBuff -= amount
+	if key:
+		buffs.remove(str(key))
 
 func getCritChance():
-	return _critChanceBuff + getStat().critChance
+	return getStat().critChance + buffs.aggregate(BuffInstance.StatType.CRIT_CHANCE)
 
 func addCritChanceBuff(amount: float, key):
-	if(key):
-		if(_modifiers.has(key)):
-			removeCritChanceBuff(key)
-		applyBuff(key, amount);
-	_critChanceBuff += amount
+	_addBuffByStat(BuffInstance.StatType.CRIT_CHANCE, amount, key)
 
 func removeCritChanceBuff(key):
-	var amount := 0;
-	if(_modifiers.has(key)):
-		amount = _modifiers.get(key, 0)
-		removeBuff(key, amount);
-	_critChanceBuff -= amount
+	if key:
+		buffs.remove(str(key))
+
+# Internal helper — REFRESH-on-key semantics (matches legacy behavior).
+# Inserts BuffInstance into `buffs`; if `key` already exists it's replaced.
+func _addBuffByStat(statType: int, value: float, key) -> void:
+	if not key:
+		return
+	var keyStr := str(key)
+	buffs.remove(keyStr)
+	var category: int = BuffInstance.Category.BUFF if value >= 0 else BuffInstance.Category.DEBUFF
+	buffs.add(BuffInstance.new(keyStr, statType, value, category))
 
 func levelUp():
 	print("level up, current level ", _level, " max level ", maxLevel);
@@ -166,11 +150,5 @@ func evolve():
 	_isEvolved = true;
 	print("evolve success");
 	return true;
-
-func applyBuff(key: String, value):
-	_modifiers[key] = value
-
-func removeBuff(key: String, value):
-	_modifiers.erase(key);
 
 signal onAttack(target);

--- a/scripts/skill/skillActions/skill_action_attack.gd
+++ b/scripts/skill/skillActions/skill_action_attack.gd
@@ -1,11 +1,78 @@
 extends SkillAction
 class_name SkillActionAttack
 
-@export var damage := 10
-@export var damageType := Damage.DamageType.PHYSIC
+# Phase 3 Block C — Skill Multiplier (per Master Formula §3.5)
+# baseDamage = Total Attack × Skill Multiplier × hit_ratio
+# Each hit goes through full pipeline (crit + armor + ΣAmp + ΣRed) independently.
+
+# Legacy fallback (kept for backward compat with old YAML using `damage: N`)
+@export var damage: int = 0
+
+# Skill Multiplier — scalar OR per-level array (array overrides scalar)
+@export var damageMultiplier: float = 1.0
+@export var damageMultiplierPerLevel: Array[float] = []
+
+# Multi-hit distribution — empty = single hit @ 1.0
+# Sum should = 1.0 (warns if not). Each ratio applies to baseDamage before pipeline.
+@export var hitDistribution: Array[float] = []
+
+# Crit toggle — false disables crit roll for this skill (e.g. Kiara fire blade)
+@export var canCrit: bool = true
+
+# Damage type — defaults to tower.data.attackType (set damageTypeOverride=true to use this)
+@export var damageType: Damage.DamageType = Damage.DamageType.PHYSIC
+@export var damageTypeOverride: bool = false
 
 func execute(context: SkillContext):
-	for target in context.target:
-		if is_instance_valid(target) && target.has_method("recvDamage"):
-			target.recvDamage(Damage.new(context.user, damage, damageType));
+	var tower: Tower = context.user as Tower
 
+	# Pure legacy: no tower available → flat damage as-is
+	if tower == null:
+		for target in context.target:
+			if is_instance_valid(target) && target.has_method("recvDamage"):
+				target.recvDamage(Damage.new(null, damage, damageType))
+		return
+
+	# Resolve multiplier: per-level array > scalar
+	var mult: float = damageMultiplier
+	if damageMultiplierPerLevel.size() > 0:
+		var idx: int = clampi(tower.data.level - 1, 0, damageMultiplierPerLevel.size() - 1)
+		mult = damageMultiplierPerLevel[idx]
+
+	# Resolve hits — empty distribution = single hit
+	var hits: Array[float] = hitDistribution if hitDistribution.size() > 0 else ([1.0] as Array[float])
+	if hitDistribution.size() > 0:
+		var hitSum: float = 0.0
+		for r in hits:
+			hitSum += r
+		if abs(hitSum - 1.0) > 0.001:
+			push_warning("hit_distribution sum %.4f != 1.0 — sum should equal 1.0 (skill=%s)" % [hitSum, context.skillName])
+
+	# Resolve damage type
+	var dmgType: Damage.DamageType = damageType if damageTypeOverride else tower.data.attackType
+
+	# Resolve base value: legacy flat (if no multiplier configured) OR Total Attack × multiplier
+	var useLegacyFlat: bool = damageMultiplierPerLevel.is_empty() and damageMultiplier == 1.0 and damage > 0
+	var baseValue: float
+	if useLegacyFlat:
+		baseValue = float(damage)
+	else:
+		baseValue = float(tower.data.getTotalAttack()) * mult
+
+	# Cache crit context (avoid recomputing per-target)
+	var stat = tower.data.getStat()
+	var critChance: float = tower.data.getCritChance() if canCrit else 0.0
+	var sigmaCD: float = stat.critMultiplier + tower.data.buffs.aggregate(BuffInstance.StatType.CRIT_DAMAGE_BONUS)
+
+	# Apply damage: per (hit, target) — each crit roll independent
+	for hitRatio in hits:
+		var hitBase: float = baseValue * hitRatio
+		for target in context.target:
+			if not is_instance_valid(target) or not target.has_method("recvDamage"):
+				continue
+			var isCrit: bool = canCrit and critChance > 0 and randi_range(0, 100) <= critChance
+			var hitDamage: float = hitBase
+			if isCrit:
+				# §5: Critical Damage = 1 + (1 × (ΣCD − 1)) = ΣCD
+				hitDamage *= sigmaCD
+			target.recvDamage(Damage.new(tower, int(hitDamage), dmgType, isCrit))

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -134,7 +134,26 @@ static func ParseAction(data: Dictionary) -> SkillAction:
 			skill = SkillActionAttack.new();
 			var skillData = data.get("data", {});
 			skill.damage = skillData.get("damage", 0);
-			skill.damageType = Utility.parse_string_to_enum(Damage.DamageType, skillData.get("damage_type", "physic"))
+			# Phase 3 Block C — Skill Multiplier
+			if skillData.has("damage_multiplier"):
+				var dm = skillData["damage_multiplier"]
+				if typeof(dm) == TYPE_ARRAY:
+					var dmArr: Array[float] = []
+					for v in dm:
+						dmArr.append(float(v))
+					skill.damageMultiplierPerLevel = dmArr
+				else:
+					skill.damageMultiplier = float(dm)
+			if skillData.has("hit_distribution"):
+				var hd = skillData["hit_distribution"]
+				var hdArr: Array[float] = []
+				for v in hd:
+					hdArr.append(float(v))
+				skill.hitDistribution = hdArr
+			skill.canCrit = skillData.get("can_crit", true)
+			if skillData.has("damage_type"):
+				skill.damageType = Utility.parse_string_to_enum(Damage.DamageType, skillData["damage_type"])
+				skill.damageTypeOverride = true
 		"clear_enemy":
 			skill = SkillActionClearEnemy.new();
 		"find_multi_enemy":

--- a/scripts/status_effect/dmg_reduction_buff.gd
+++ b/scripts/status_effect/dmg_reduction_buff.gd
@@ -14,9 +14,12 @@ func _process_effect(delta: float, target: Node) -> void:
 	if elapsedTime >= duration:
 		_on_expire(target)
 
+func _buffKey() -> String:
+	return "dmgReductionBuff_" + str(get_instance_id())
+
 func _on_apply(target: Node) -> void:
 	if target.stats != null && target.stats is EnemyStat:
-		target.stats.damageReduction += reductionAmount
+		target.stats.addDamageReduction(reductionAmount, _buffKey())
 
 	if(target is Enemy):
 		var enemy := target as Enemy
@@ -31,7 +34,7 @@ func _on_expire(target: Node) -> void:
 		return;
 
 	if target.stats != null && target.stats is EnemyStat:
-		target.stats.damageReduction = max(0.0, target.stats.damageReduction - reductionAmount)
+		target.stats.removeDamageReduction(_buffKey())
 
 	if(target is Enemy):
 		var enemy := target as Enemy

--- a/scripts/utility/yaml_parser.gd
+++ b/scripts/utility/yaml_parser.gd
@@ -216,9 +216,44 @@ static func _convert(v: String) -> Variant:
 		return int(s)
 	if s.is_valid_float():
 		return float(s)
+	# Inline (flow-style) array: [a, b, c]
+	if s.length() >= 2 and s.substr(0, 1) == "[" and s.substr(s.length() - 1, 1) == "]":
+		var inner := s.substr(1, s.length() - 2).strip_edges()
+		var arr: Array = []
+		if inner == "":
+			return arr
+		var parts := _split_top_level_commas(inner)
+		for p in parts:
+			arr.append(_convert(p))
+		return arr
 	if s.length() >= 2:
 		var a := s.substr(0, 1)
 		var b := s.substr(s.length() - 1, 1)
 		if (a == '"' and b == '"') or (a == "'" and b == "'"):
 			return s.substr(1, s.length() - 2)
 	return s
+
+
+# Splits a string by top-level commas, respecting quotes and nested brackets/braces.
+# Used for parsing inline (flow-style) arrays/objects in YAML values.
+static func _split_top_level_commas(s: String) -> PackedStringArray:
+	var parts: PackedStringArray = []
+	var depth := 0
+	var in_s := false
+	var in_d := false
+	var start := 0
+	for i in range(s.length()):
+		var ch := s.substr(i, 1)
+		if ch == "'" and not in_d:
+			in_s = not in_s
+		elif ch == '"' and not in_s:
+			in_d = not in_d
+		elif (ch == "[" or ch == "{") and not in_s and not in_d:
+			depth += 1
+		elif (ch == "]" or ch == "}") and not in_s and not in_d:
+			depth -= 1
+		elif ch == "," and depth == 0 and not in_s and not in_d:
+			parts.append(s.substr(start, i - start).strip_edges())
+			start = i + 1
+	parts.append(s.substr(start, s.length() - start).strip_edges())
+	return parts


### PR DESCRIPTION
**Problem:** Damage system ยังขาด final pipeline ตาม Master Formula  — ไม่มี ΣDamage Amplifier / Reduction, crit เป็น multiplicative ไม่ additive (stack ไม่ได้), skill ไม่มี Skill Multiplier DSL ตาม design §3.5 (skill ทุกตัวตี flat damage scale ตาม Total Attack ไม่ได้), buff range/mana_regen/crit_chance ยังเป็น legacy private field แยกจาก BuffInstance system

**Impact:** (1) ออกแบบ skill ที่ "ตี % ของ Total Attack" เช่น Kiara skill 140%/150%/170% ทำไม่ได้ (2) buff "+25% Crit Damage" stack หลายแหล่งไม่ได้ — มีแค่ critMultiplier ตัวเดียว (3) buff "+50% damage to boss" / shield "ลด damage 30%" ทำไม่ได้ (4) buff range/mana regen/crit chance debug ยากเพราะอยู่คนละระบบกับ ATTACK_FLAT/MULT — รวมถึง latent crash ใน synergy "mana_regen" ที่เรียก method ไม่มีจริง

**Fix:** 5 commits / 4 blocks
- **Block A** (`ac9af2d`): refactor crit เป็น additive `1 + (Crit Check × (ΣCD−1))` + split `BuffInstance.StatType.CRIT` → `CRIT_CHANCE` + `CRIT_DAMAGE_BONUS` (append-only enum)
- **Block B** (`6ea621b`): เพิ่ม `DAMAGE_AMPLIFIER` / `DAMAGE_REDUCTION` enum + apply `× (1+ΣAmp) × (1−ΣRed)` ใน `enemy.recvDamage` หลัง armor/MR factor + flat armor/MR layer (`extraArmorFlat` / `extraMArmorFlat`) + key-based `addDamageReduction` (King Salam Adaptation)
- **Block C** (`b3f64a3` + revert `9495e44`): Skill Multiplier DSL ใน `skill_action_attack.gd` — `damage_multiplier` (scalar/per-level array), `hit_distribution` (multi-hit), `can_crit`, `damage_type` override + Kiara base 140%/150%/170% physic + evolution skill 300% physic w3×h6 + เพิ่ม inline (flow-style) array support ใน `yaml_parser.gd` (`[a, b, c]` syntax)
- **Block D** (`dab6618`): migrate `_rangeBuff` / `_manaRegenBuff` / `_critChanceBuff` / `_modifiers` private fields → `BuffInstance` ผ่าน `buffs.aggregate(StatType)` — single source of truth ทุก stat + bonus fix typo `addManaRegen` → `addManaRegenBuff` ใน `tower.gd` (latent runtime crash ถ้า synergy "mana_regen" trigger)

Backward compat ทุก block — YAML/.tres เดิมไม่ต้องแก้