### PR TITLE
fix: crit roll off-by-one — randi_range(0, 100) → (1, 100)

### DIFF
--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -77,7 +77,8 @@ func calculateFinalDamage(baseDamage: float, enemy: Enemy) -> Damage:
 		finalDamage = modifier.call(finalDamage, enemy)
 
 	var critChance: float = getCritChance()
-	var isCrit: bool = critChance > 0 and randi_range(0, 100) <= critChance
+	# randi_range(1, 100) → 100 values for exact critChance/100 probability (§6.2 #1 fix)
+	var isCrit: bool = critChance > 0 and randi_range(1, 100) <= critChance
 	var sigmaCD: float = getStat().critMultiplier + buffs.aggregate(BuffInstance.StatType.CRIT_DAMAGE_BONUS)
 	var critCheck: float = 1.0 if isCrit else 0.0
 	finalDamage *= 1.0 + (critCheck * (sigmaCD - 1.0))

--- a/scripts/skill/skillActions/skill_action_attack.gd
+++ b/scripts/skill/skillActions/skill_action_attack.gd
@@ -70,7 +70,8 @@ func execute(context: SkillContext):
 		for target in context.target:
 			if not is_instance_valid(target) or not target.has_method("recvDamage"):
 				continue
-			var isCrit: bool = canCrit and critChance > 0 and randi_range(0, 100) <= critChance
+			# randi_range(1, 100) → 100 values for exact critChance/100 probability (§6.2 #1 fix)
+			var isCrit: bool = canCrit and critChance > 0 and randi_range(1, 100) <= critChance
 			var hitDamage: float = hitBase
 			if isCrit:
 				# §5: Critical Damage = 1 + (1 × (ΣCD − 1)) = ΣCD


### PR DESCRIPTION
**Problem:**
Crit roll uses `randi_range(0, 100)` which returns 101 values (0..100 inclusive). Comparison `<= critChance` then yields effective probability `(critChance+1)/101` instead of `critChance/100` — every crit roll is biased ~1% higher than the design value (e.g., critChance=10 actually triggers ~10.89%, critChance=50 actually triggers ~50.50%).

**Impact:**
All balance numbers for crit chance in YAML/.tres are off by +1% from the intended rate. Towers with critChance=0 are protected by the existing short-circuit `critChance > 0` so the bias only affects tuned values.

**Fix:**
Switch both crit roll sites to `randi_range(1, 100)` (100 values) so the comparison gives exact `critChance/100` probability. No other logic changes — short-circuit `critChance > 0` retained, sigmaCD pipeline untouched.

Affects two crit roll sites:
- `tower_data.gd::calculateFinalDamage()` (normal attack path)
- `skill_action_attack.gd::execute()` (skill attack path, per-hit roll)

Inline comment added at both sites referencing `holove_damage_formula.md` §6.2 #1 to prevent accidental revert.