### PR TITLE
Fix — dead code cleanup + float equality

### DIFF
--- a/scripts/entity/attack_controller.gd
+++ b/scripts/entity/attack_controller.gd
@@ -36,8 +36,7 @@ func attack(target: Enemy, direction: Global.DIRECTION, damage: Damage = Damage.
 	if(sound != ""):
 		AudioManager.playSfx(Utility.parse_string_to_enum(SoundDatabase.SFX_NAME, sound));
 
-	if true:
-		AttackVfx.play_vfx(Utility.parse_string_to_enum(AttackVfx.AttackVFXName, vfx), self.tower.global_position, direction, get_tree().current_scene);
+	AttackVfx.play_vfx(Utility.parse_string_to_enum(AttackVfx.AttackVFXName, vfx), self.tower.global_position, direction, get_tree().current_scene);
 
 # func shootProjectile(onHit: Callable = Callable()):
 # 	if(target == null):

--- a/scripts/entity/attack_controller.gd
+++ b/scripts/entity/attack_controller.gd
@@ -18,9 +18,6 @@ func addModifier(key: int, mod: Callable):
 	modifier[key] = mod
 
 func removeModifier(key: int):
-	if(!modifier.has(key)):
-		pass
-
 	modifier.erase(key);
 
 func executeModifier():

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -40,7 +40,7 @@ func _process(_delta):
 	if skillController:
 		skillController.useSkill();
 
-	if(progress_ratio == 1):
+	if(progress_ratio >= 1.0):
 		onReachEndPoint.emit();
 		queue_free()
 


### PR DESCRIPTION
**Problem:** Three small issues found during code audit:
- `AttackController.removeModifier` has a no-op `pass` that hides the original early-return intent.
- `AttackController.attack` wraps `AttackVfx.play_vfx` in a vacuous `if true:`.
- `Enemy._process` checks `progress_ratio == 1` (float equality) which can miss the end-point trigger if `moveRatio` overshoots in a single tick.

**Impact:** N-3 and N-4 are code smells with no runtime impact. N-5 is a latent risk for future high-MS scenarios — currently not triggered because Godot's `PathFollow2D` clamps to 1.0 in the common path.

**Fix:** N-3 deletes the no-op block (`Dictionary.erase` is safe on missing keys). N-4 unwraps the dead conditional. N-5 switches to `>= 1.0` to be robust against float arithmetic and any future change in `PathFollow2D` behavior. Three separate commits, one per bug, for per-block review.

**Note:** N-2 (deck filter underfill) was reconsidered and dropped from this PR — the original adaptive behavior matches design intent (pool shrinks as towers max out). The real edge case is "all towers maxed → skip select phase entirely", which needs caller investigation; tracked separately in the log.