### PR TITLE
Fix tower-select popup hang when no valid towers

### DIFF
--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -88,19 +88,25 @@ func show_popup_panel():
 	_popup_open = true
 	# Ensure it's added to the UI layer, not just as a child of the 2D scene
 	get_tree().root.add_child(popup)
-	var evoToken = player.wallet.getEvoToken();
-	popup.setup(evoToken, 1000);
 
-	# Connect function "_on_option_selected" to the signal "tower_select"
+	# Connect signals BEFORE setup() — popup may emit tower_select_skipped during
+	# setup() when no valid towers exist (all maxed/evolved with insufficient evoToken).
 	popup.tower_select.connect(Callable(self, "_on_option_selected"))
-
+	Utility.ConnectSignal(popup, "tower_select_skipped", Callable(self, "_on_tower_select_skipped"));
 	# When the popup is closed/freed, allow it to be opened again
 	Utility.ConnectSignal(popup, "tree_exited", Callable(self, "_on_popup_closed"));
+
+	var evoToken = player.wallet.getEvoToken();
+	popup.setup(evoToken, 1000);
 
 	return
 
 func _on_popup_closed():
 	_popup_open = false
+
+func _on_tower_select_skipped():
+	print("Tower select skipped — no valid towers available")
+	startWave()
 
 # Handle the selection from the popup
 func _on_option_selected(selection):

--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -3,6 +3,9 @@ class_name UITowerSelect
 
 # Signal to send selection back to the stage
 signal tower_select(num_select)
+# Emitted when no valid tower cards can be built (e.g. all towers maxed/evolved
+# and evoToken insufficient). Caller should resume wave flow without selection.
+signal tower_select_skipped
 
 var _dealer: RandomCardsDealer;
 var test_deck = ['1','2','3','4','5']
@@ -17,7 +20,14 @@ func _ready() -> void:
 func setup(evoToken: int = 0, maxRefresh: int = 0):
 	self.refreshLeft = maxRefresh;
 	self.maxRefresh = maxRefresh;
-	_setup_buttons(evoToken);
+
+	var cards = _build_card_list(evoToken)
+	if cards.is_empty():
+		emit_signal("tower_select_skipped")
+		queue_free()
+		return
+
+	_apply_cards_to_buttons(cards)
 	var refresh_button = get_node("CanvasLayer/PopupPanel/Panel/RefreshButton")
 	refresh_button.pressed.connect(Callable(self, "refreshList").bind(evoToken))
 
@@ -31,17 +41,22 @@ func refreshList(evoToken: int = 0):
 	if(refreshLeft <= 0):
 		return
 	refreshLeft -= 1;
-	_setup_buttons(evoToken);
+
+	var cards = _build_card_list(evoToken)
+	if cards.is_empty():
+		emit_signal("tower_select_skipped")
+		queue_free()
+		return
+
+	_apply_cards_to_buttons(cards)
 	setupRefreshText(refreshLeft, maxRefresh)
 
-func _setup_buttons(evoToken: int = 0):
-	var cards: Array = []
-
-	# Show valid evolution towers first
-	var remain: int = 3;
+func _build_card_list(evoToken: int) -> Array:
 	if (!_dealer):
 		_dealer = $RandomCardsDealer
-	var finalList = []
+
+	var remain: int = 3
+	var finalList: Array = []
 
 	var evoList = TowerCenter.getEvolutionList(3);
 	for tName in evoList:
@@ -60,17 +75,32 @@ func _setup_buttons(evoToken: int = 0):
 			available_towers.append(t)
 
 	print("available towers: ", available_towers);
-	finalList.append_array(_dealer.get_random_cards(available_towers, remain, evoToken))
-	cards = finalList
+	if remain > 0:
+		finalList.append_array(_dealer.get_random_cards(available_towers, remain, evoToken))
 
+	return finalList
+
+func _apply_cards_to_buttons(cards: Array) -> void:
 	var buttons = get_tree().get_nodes_in_group("tower_buttons")
+	var select_callable = Callable(self, "_on_select_tower_button")
 	for button: TowerSelectButton in buttons:
-		button.pressed.disconnect(Callable(self, "_on_select_tower_button"))  # ✅ Prevent duplicate connections
+		# Guard: pressed has no fixed binding so disconnecting an unbound callable errors
+		# on the first setup pass. Only disconnect prior bindings recorded on the button.
+		var prior: Callable = button.get_meta("_select_binding", Callable())
+		if prior.is_valid() and button.pressed.is_connected(prior):
+			button.pressed.disconnect(prior)
+			button.remove_meta("_select_binding")
 
-	for index in range(min(buttons.size(), cards.size())):
-		var cardSelectData: TowerSelectData = cards[index] as TowerSelectData;
-		buttons[index].setup(cardSelectData.name, cardSelectData.icon, cardSelectData.level, cardSelectData.evolutionCost)
-		buttons[index].pressed.connect(Callable(self, "_on_select_tower_button").bind(cardSelectData.name))
+	for index in range(buttons.size()):
+		if index < cards.size():
+			var cardSelectData: TowerSelectData = cards[index] as TowerSelectData;
+			buttons[index].setup(cardSelectData.name, cardSelectData.icon, cardSelectData.level, cardSelectData.evolutionCost)
+			var bound: Callable = select_callable.bind(cardSelectData.name)
+			buttons[index].pressed.connect(bound)
+			buttons[index].set_meta("_select_binding", bound)
+			buttons[index].visible = true
+		else:
+			buttons[index].visible = false
 
 func _on_select_tower_button(name):
 	print("signal: tower_select,"+str(name))


### PR DESCRIPTION
**Problem:** When all towers in the player's deck are at `Evolved` (or `Max` with insufficient `evoToken`), `RandomCardsDealer.get_random_cards()` returns an empty list after the `validateSelectTower` filter. The popup is still instantiated and `UI_tower_select._setup_buttons()` skips its setup loop (`min(buttons.size(), cards.size()) == 0`), leaving three buttons either dead or wired to stale state from the previous round. The 1-2 valid tower cases also leave unused buttons visible with leftover data.

**Impact:** Late-game / narrow-deck builds can stall between waves — the tower-select popup appears with no actionable cards and the wave never starts. In partial-pool cases the player sees 3 buttons but only 1-2 carry real data.

**Fix:**
- `UITowerSelect` builds the card list (`_build_card_list`) before touching buttons; an empty result emits a new `tower_select_skipped` signal and `queue_free()`s the popup.
- `GameScene._on_tower_select_skipped()` resumes the wave loop via `startWave()`.
- Signal connections in `GameScene.show_popup_panel()` were reordered to fire **before** `popup.setup()` so the skip emission isn't dropped (it's synchronous).
- Button setup toggles `visible` per card count — `HBoxContainer.alignment = 1` re-centers 1 or 2 cards naturally.
- Bound `Callable` is tracked per-button via `set_meta("_select_binding", ...)` so `disconnect()` only runs against an actual prior binding (avoids Godot 4.3's unbound-disconnect error).

**Test status:** Game Director verified Case 5 (3-card regression) in-engine — game flow runs end-to-end. Cases 1-4 (empty-pool skip, 1/2-card center, refresh edge) not yet reachable in current playable scope — to be re-verified later or via debug state injection.

Files: `scripts/ui/tower_select/UI_tower_select.gd`, `scripts/scene/game_scene.gd`.