### PR TITLE
fix wave-end cleanup on towers

### DIFF
--- a/scripts/buff/tower_buff_container.gd
+++ b/scripts/buff/tower_buff_container.gd
@@ -51,3 +51,10 @@ func clear() -> void:
 	_buffs.clear()
 	for buff: BuffInstance in buffs:
 		buff_removed.emit(buff)
+
+func clear_skill_buffs() -> void:
+	for id in _buffs.keys().duplicate():
+		var buff: BuffInstance = _buffs[id]
+		if buff.sourceSkill != "":
+			_buffs.erase(id)
+			buff_removed.emit(buff)

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -335,6 +335,24 @@ func clearSynergyBuffs(synergy_id: int):
 
 	synergyBuffs.erase(synergy_id)
 
+func resetForWave():
+	attacking = false
+	usingSkill = false
+	lastAttackTime = 0.0
+	clearEnemy(null, null, null)
+
+	if skillController != null:
+		skillController.cancel()
+		var initMana: float = data.getStat().intialMana
+		skillController.currentMana = initMana
+		skillController.on_mana_updated.emit(initMana)
+
+	data.buffs.clear_skill_buffs()
+
+	for child in get_children():
+		if child is CircleEffectArea:
+			child.queue_free()
+
 func addIntervalAction(key,interval: float, action: String, value: float):
 	var callable: Callable;
 	match action:
@@ -373,6 +391,7 @@ func addDecreaseAtkSpeed(value: float, key: String = ""):
 		-value * 100.0,
 		BuffInstance.Category.DEBUFF,
 	)
+	buff.sourceSkill = key
 	data.buffs.add(buff)
 
 func removeDecreaseAtkSpeed(key: String):
@@ -386,6 +405,7 @@ func addDecreaseDmgAllPercent(value: float, key: String = ""):
 		-value * 100.0,
 		BuffInstance.Category.DEBUFF,
 	)
+	buff.sourceSkill = key
 	data.buffs.add(buff)
 
 func removeDecreaseDmgAllPercent(key: String):

--- a/scripts/entity/tower/tower_factory.gd
+++ b/scripts/entity/tower/tower_factory.gd
@@ -239,6 +239,11 @@ func onMissionCompleted(id: int, buff: Dictionary):
 func onWaveStart():
 	processGen0Buff()
 
+func onWaveEnd():
+	for tower: Tower in towersByName.values():
+		if is_instance_valid(tower):
+			tower.resetForWave()
+
 func processGen0Buff():
 	if (!activeSynergies.has(TowerGeneration.Gen0)):
 		return;

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -56,7 +56,7 @@ func _ready():
 		var waveControllerData: WaveControllerData = WaveControllerData.new();
 		waveControllerData.waveDatas = waves;
 		waveControllerData.onEnemyReachEndpoint = Callable(self, "reducePlayerHp");
-		waveControllerData.onWaveEnd = Callable(self, "show_popup_panel");
+		waveControllerData.onWaveEnd = Callable(self, "on_wave_ended");
 
 		waveController.setup(waveControllerData);
 
@@ -77,6 +77,11 @@ func checkValidCell(cell: Vector2):
 	return !map.grids.has(cell);
 func reducePlayerHp(amount: int):
 	player.updateHp(-amount);
+
+func on_wave_ended():
+	if towerFactory != null:
+		towerFactory.onWaveEnd()
+	show_popup_panel()
 
 func show_popup_panel():
 	# Prevent opening multiple popups if this function is called repeatedly


### PR DESCRIPTION
**Problem:** At wave end, `TowerFactory.onWaveStart()` only ran `processGen0Buff()` — no wave-end hook existed for towers. Tower `currentMana`, active skill awaits, temporary skill buffs in `data.buffs`, persistent `CircleEffectArea` nodes, and combat flags (`attacking` / `usingSkill` / `lastAttackTime` / `enemy`) all carried over into the next wave.

**Impact:** Towers in the next wave inherited stale combat state — mana stayed full so skills fired immediately, AOE buff timers from the previous wave kept ticking, defensive area circles lingered on the floor, and a skill mid-`await` when the last enemy died could fire one frame into the new wave. Violates the autochess/TFT reset model the design targets.

**Fix:** New `Tower.resetForWave()` invoked by new `TowerFactory.onWaveEnd()`, wired through `GameScene.on_wave_ended()` wrapping the existing `WaveControllerData.onWaveEnd` Callable. Resets combat flags, cancels `skillController` and resets mana to `intialMana`, calls new `TowerBuffContainer.clear_skill_buffs()` (filters by `sourceSkill != ""` so synergy buffs survive), and `queue_free()`s `CircleEffectArea` children. Also sets `buff.sourceSkill = key` in two `tower.add*` helpers so area-applied buffs match the filter. Tower level, evolution state, `synergyBuffs`, and `activeSynergies` intentionally preserved.