### PR TITLE
Fix cleanup little bug

### DIFF
--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -91,9 +91,10 @@ func _process(delta):
 		attackEnemy();
 
 func setup(id: String, onPlace: Callable, onRemove: Callable):
+	self.id = id;
+	self.name = id;
+	towerName = id;
 	self.onPlace = onPlace;
-	self.name = name;
-	towerName = name;
 	self.onRemove = onRemove;
 
 	var towerData = TowerCenter._towers_data.get(id.to_lower(), null);

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -178,6 +178,10 @@ func testSpawnBoss(index: int = -1):
 	if(index < 0):
 		index = randi_range(0, bossList.size() - 1);
 
+	if(index >= bossList.size()):
+		print("No boss at index ", index, " (bossList size: ", bossList.size(), ")");
+		return;
+
 	var boss = bossList[index]; # For testing, spawn the first boss in the list.
 
 	var texture = boss.texture;

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -45,9 +45,9 @@ func updateHp(updateAmount: int):
 		currentHp = 0;
 		ui.updateBar(currentHp);
 
-		var ui = UIEndDemo.create();
-		if(ui):
-			get_tree().current_scene.add_child(ui);
+		var endScreen = UIEndDemo.create();
+		if(endScreen):
+			get_tree().current_scene.add_child(endScreen);
 
 func getItem(item: InventoryItem):
 	inventory.addItem(item);


### PR DESCRIPTION
**Problem:** Three minor issues batched in one PR, split per commit for review:
- **P3-E:** `Tower.setup(id)` did `self.name = name` and `towerName = name` — both self-assignments of the implicit Node.name property. `@export var id` was never populated, `Node.name` stayed at the instantiate default, and `towerName` held the default Node name instead of the tower's `data_name`.
- **P3-G:** `Player.updateHp()` declared `var ui = UIEndDemo.create()` inside the lose branch, shadowing the class field `var ui: PlayerUI`.
- **N-7:** Pressing the debug key KEY_3 (index 2) in `WaveController.testSpawnBoss()` crashed with `Out of bounds get index '2' (on base: 'Array[BossDBData]')` when the current map's `bossList` had fewer than 3 bosses.

**Impact:**
- **P3-E:** silent correctness bug — debug logs and any future code reading `tower.towerName` / `tower.id` / scene-tree `Node.name` saw the default Godot name instead of the tower's identifier. No gameplay break but blocks correctness for future features.
- **P3-G:** code-smell only — `updateHp` reads worse than necessary.
- **N-7:** hard crash during debug-boss-spawn use, halting playtest.

**Fix:**
- **P3-E** (`fe7c50e`): `Tower.setup(id)` now assigns `self.id = id`, `self.name = id`, `towerName = id` — all three identifier fields populated from the parameter.
- **P3-G** (`e57342e`): renamed the local var `ui` → `endScreen` in the lose branch. No behavioral change.
- **N-7** (`158bad6`): added an explicit bounds check `if(index >= bossList.size())` after the random-index path and before `bossList[index]`. Prints a warning and returns early — keeps the debug feature usable. The broader P3-H concern (debug keys still in build) stays Intentional Hold per Game Director (post-demo dev-tool refactor).