### PR TITLE
refactor(tower): migrate AS buff scale from percent to decimal

### DIFF
--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -8,13 +8,13 @@ attack_sound: "hit_amelia"
 open_sound: "debut_amelia"
 skill:
   name: "Time Traveler I"
-  desc: "Amelia increases her own attack speed by {attackSpeedPercent}% for 4 seconds."
+  desc: "Amelia increases her own attack speed by {attackSpeedBuff}% for 4 seconds."
   cast_time: 0.5
   parameters:
-    attackSpeedPercent:
-      - 10
-      - 15
-      - 20
+    attackSpeedBuff:
+      - 0.10
+      - 0.15
+      - 0.20
   actions:
     - type: "play_animation"
       data:
@@ -25,7 +25,7 @@ skill:
     - type: "atk_speed_buff"
       data:
         duration: 4.0
-        param_name: "attackSpeedPercent"
+        param_name: "attackSpeedBuff"
     - type: "play_animation"
       data:
         animation: "idle"
@@ -72,7 +72,7 @@ evolution_skill:
     - type: "atk_speed_buff_aoe"
       data:
         duration: 4.0
-        percent: 50.0
+        percent: 0.50
         range: 1
     - type: "crit_chance_buff"
       data:

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -386,10 +386,11 @@ func setTowerStar(tier: int):
 		towerStar.setStar(tier);
 
 func addDecreaseAtkSpeed(value: float, key: String = ""):
+	# ATTACK_SPEED is decimal scale (0.5 = +50%) — caller passes decimal directly.
 	var buff := BuffInstance.new(
 		key,
 		BuffInstance.StatType.ATTACK_SPEED,
-		-value * 100.0,
+		-value,
 		BuffInstance.Category.DEBUFF,
 	)
 	buff.sourceSkill = key

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -96,7 +96,8 @@ func removeAttackRangeBuff(key):
 		buffs.remove(str(key))
 
 func getAttackSpeed() -> float:
-	var sigma := 1.0 + (buffs.aggregate(BuffInstance.StatType.ATTACK_SPEED) / 100.0)
+	# ATTACK_SPEED is decimal scale (0.5 = +50%) — matches MOVE_SPEED post-PR #9.
+	var sigma := 1.0 + buffs.aggregate(BuffInstance.StatType.ATTACK_SPEED)
 	return clampf(getStat().attackSpeed * sigma, AS_MIN, AS_MAX)
 
 func getAttackDelay() -> float:

--- a/scripts/skill/skillActions/skill_action_atk_speed_buff.gd
+++ b/scripts/skill/skillActions/skill_action_atk_speed_buff.gd
@@ -2,7 +2,7 @@ class_name SkillActionAtkSpeedBuff
 extends SkillAction
 
 @export var duration: float = 4.0
-@export var paramName: String = "attackSpeedPercent"
+@export var paramName: String = "attackSpeedBuff"
 @export var displayName: String = "Attack Speed Up"
 @export var iconPath: String = ""
 

--- a/scripts/skill/skillActions/skill_action_atk_speed_buff_aoe.gd
+++ b/scripts/skill/skillActions/skill_action_atk_speed_buff_aoe.gd
@@ -2,7 +2,8 @@ class_name SkillActionAtkSpeedBuffAOE
 extends SkillAction
 
 @export var duration: float = 4.0
-@export var percent: float = 50.0
+# ATTACK_SPEED is decimal scale (0.5 = +50%) — see tower_data.getAttackSpeed.
+@export var percent: float = 0.5
 @export var range: int = 1
 @export var displayName: String = "Attack Speed Up"
 @export var iconPath: String = ""

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -106,7 +106,8 @@ static func ParseAction(data: Dictionary) -> SkillAction:
 			skill = SkillActionAtkSpeedBuffAOE.new()
 			var skillData = data.get("data", {})
 			skill.duration = skillData.get("duration", 4.0)
-			skill.percent = skillData.get("percent", 50.0)
+			# ATTACK_SPEED is decimal scale (0.5 = +50%) — see tower_data.getAttackSpeed.
+			skill.percent = skillData.get("percent", 0.5)
 			skill.range = skillData.get("range", 1)
 		"crit_chance_buff":
 			skill = SkillActionCritChanceBuff.new()
@@ -121,7 +122,7 @@ static func ParseAction(data: Dictionary) -> SkillAction:
 			skill = SkillActionAtkSpeedBuff.new()
 			var skillData = data.get("data", {})
 			skill.duration = skillData.get("duration", 4.0)
-			skill.paramName = skillData.get("param_name", "attackSpeedPercent")
+			skill.paramName = skillData.get("param_name", "attackSpeedBuff")
 		"block_damage":
 			skill = SkillActionBlockDamage.new();
 			var skillData = data.get("data", {});


### PR DESCRIPTION
แก้ของตัวเองเนี่ยแหละ

**Problem:** Attack Speed buffs used percent scale (50 = +50%) while PR #9 moved Move Speed to decimal (0.5 = +50%). Two conventions for the same concept invited YAML-authoring traps; the parameter name `attackSpeedPercent` cemented the wrong mental model — a future tower author might paste `50` thinking "percent" and unwittingly produce a +5000% AS buff.

**Impact:** None in-game today — the hidden `×100` (in `tower.gd:addDecreaseAtkSpeed`) and `/100` (in `tower_data.gd:getAttackSpeed`) cancel out so current behavior is correct. The cost is technical debt + a long-term trap for tower authoring. Closes Reminder #1 (marked 2026-05-05) + buff_debuff.md §6.2 #3 + damage_formula.md §4.2 #4.

**Fix:**
- `tower_data.gd:getAttackSpeed()` — drop `/100` from the sigma formula.
- `tower.gd:addDecreaseAtkSpeed()` — drop `*100` (caller already passes decimal).
- `SkillActionAtkSpeedBuffAOE.percent` default `50.0 → 0.5`.
- `skill_utility.gd:109` fallback `50.0 → 0.5`.
- Rename parameter key `attackSpeedPercent → attackSpeedBuff` in `watson_amelia.yaml` (parameters block + desc template + param_name field) + `SkillActionAtkSpeedBuff.paramName` default + `skill_utility.gd:124` fallback (5 places synced).
- `watson_amelia.yaml` AS values `[10, 15, 20] → [0.10, 0.15, 0.20]` and `50.0 → 0.50`.
- `forest01.yaml` already decimal — no change.

Math equivalence verified pre-edit; Game Director tested 7 cases in-engine (Amelia L1/L2/L3 basic, Amelia evo AOE, King Salam slow, stacked sigma 1.40, regression wave 1→5) — identical cadence, no console errors.