### PR TITLE
fix: reset tower animation to idle on wave end

### DIFF
--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -354,6 +354,8 @@ func resetForWave():
 		if child is CircleEffectArea:
 			child.queue_free()
 
+	play_animation_default()
+
 func addIntervalAction(key,interval: float, action: String, value: float):
 	var callable: Callable;
 	match action:


### PR DESCRIPTION
**Problem:** P2-J wave-end cleanup (PR #13) reset combat flags, mana, skill cancel, skill-buff filter, and `CircleEffectArea` — but did not touch `AnimationController` state. If a wave ended while a tower was mid-skill, the skill animation kept looping into the next wave and the tower never returned to its idle pose. The `animation_finished` callback at `tower.gd:225` has its `play_animation_default()` call commented out, so no auto-revert path existed either.

**Impact:** Visible across all towers that use skill animations (Watson Amelia is the most obvious in the current build). No gameplay/state damage, just a stuck visual that breaks the between-wave "tower at rest" read.

**Fix:** One-line addition inside `Tower.resetForWave()` ([tower.gd:339](scripts/entity/tower/tower.gd:339)) to call the existing `play_animation_default()` helper after the `CircleEffectArea` cleanup. `play_animation_default()` ([tower.gd:221](scripts/entity/tower/tower.gd:221)) delegates to `AnimationController.playDefault()` which plays the default "idle" animation set by `AnimationController._init` at `tower.gd:48`. No race with active attacks — `attacking = false` is cleared earlier in the same function, and the next attack tick triggers its own play call.