### PR TITLE
perf: skip Wallet + Currency update when amount is zero

### DIFF
--- a/scripts/wallet/currency.gd
+++ b/scripts/wallet/currency.gd
@@ -16,6 +16,8 @@ func _init(id: int, name: String, desc: String, icon: Texture2D, value: int) -> 
 	self.value = value
 
 func update(updateAmount: int):
+	if updateAmount == 0:
+		return
 	self.value += updateAmount;
 	for key in onUpdate:
 		onUpdate[key].call(self.value);

--- a/scripts/wallet/wallet.gd
+++ b/scripts/wallet/wallet.gd
@@ -8,6 +8,8 @@ func _init(onGoldUpdate: Callable, onEvoTokenUpdate: Callable):
 	evoToken.subscribeOnUpdate("ui", onEvoTokenUpdate);
 
 func updateGold(value: int):
+	if value == 0:
+		return
 	print("update gold", value);
 	gold.update(value);
 
@@ -15,6 +17,8 @@ func getGold() -> int:
 	return gold.value;
 
 func updateEvoToken(amount: int):
+	if amount == 0:
+		return
 	print("update evo token", amount);
 	evoToken.update(amount);
 


### PR DESCRIPTION
**Problem:** Every monster death (boss or not) called `Wallet.updateGold(0)` and `Wallet.updateEvoToken(0)` because `Player.processReward` forwards reward fields unconditionally. Wallet's debug prints fired on every call — visible console spam (`update gold 0` / `update evo token 0`) on every non-boss kill. `Currency.update` then iterated `onUpdate` subscribers and fired UI callbacks even though the value was unchanged. After PR #18 token-UI-hide-zero, each fire ran a useless visibility toggle + label rewrite — 50+ wasted UI fires per wave on a busy wave.

**Impact:** Console spam reported by Game Director. UI did unnecessary work on every kill emission. No gameplay break but pure waste.

**Fix:** Two early-return guards. (1) `Wallet.updateGold` / `updateEvoToken` return when amount == 0 — catches the dominant path (`Player.processReward` forwarding zero rewards) BEFORE the debug print and BEFORE `Currency.update`. (2) `Currency.update` also returns when `updateAmount == 0` as defense-in-depth — protects any future non-Wallet caller from accidentally firing subscriber callbacks on a no-op.