### PR TITLE
Tower targets enemy closest to path end + Hitbox return-type fix

### DIFF
--- a/scripts/combat/hitbox.gd
+++ b/scripts/combat/hitbox.gd
@@ -57,45 +57,46 @@ func _draw():
 	draw_rect(rect, _visual_color, true)
 	draw_rect(rect, Color(_visual_color.r, _visual_color.g, _visual_color.b, 1.0), false, 2)
 
+# Normalize an overlap / group-scan result to its owning Enemy (PathFollow2D).
+# enemy_base.tscn places the "enemy" group on BOTH the PathFollow2D Enemy and its child Area2D (EnemyArea),
+# so overlap queries / group scans may return either node. Resolve once here so callbacks always receive Enemy.
+# Returns null if the node is not an enemy-shaped node.
+static func _resolve_enemy(node: Node) -> Enemy:
+	if node is Enemy:
+		return node
+	if node is Area2D and node.get_parent() is Enemy:
+		return node.get_parent()
+	return null
+
 func _detect():
 	var enemies: Array = []
-	var discovered = {}
+	var discovered := {}
 
 	# Check areas and bodies so we cover both area-based and body-based enemies
 	for node in get_overlapping_areas() + get_overlapping_bodies():
 		print("overlapping node:", node)
-		if not node or not node is Node:
-			continue
-
-		# enemy_base.tscn: PathFollow2D has group enemy, and sub-node Enemy Area2D also has group enemy.
-		# Prefer returning the top-level Enemy instance when possible.
-		var enemy_node: Node = node
-		if node is PathFollow2D and node.is_in_group("enemy"):
-			enemy_node = node
-		elif node.has_node("..") and node.get_parent() and node.get_parent().is_in_group("enemy"):
-			enemy_node = node.get_parent()
-		elif node.is_in_group("enemy"):
-			enemy_node = node
-
-		if not enemy_node or not enemy_node.is_in_group("enemy"):
+		var enemy_node := _resolve_enemy(node)
+		if enemy_node == null:
 			continue
 		if enemy_node in discovered:
 			continue
-
 		discovered[enemy_node] = true
 		enemies.append(enemy_node)
 
 	# If physics overlap gave nothing, fallback to group check via enemy nodes + local rectangle test
 	if enemies.is_empty():
-		for enemy_candidate in get_tree().get_nodes_in_group("enemy"):
-			if not enemy_candidate or not enemy_candidate is Node2D:
+		for candidate in get_tree().get_nodes_in_group("enemy"):
+			var enemy_node := _resolve_enemy(candidate)
+			if enemy_node == null:
+				continue
+			if enemy_node in discovered:
 				continue
 
-			var point = to_local(enemy_candidate.global_position) - _local_offset
+			# Rect test uses the canonical Enemy position (EnemyArea may have local offset).
+			var point = to_local(enemy_node.global_position) - _local_offset
 			if abs(point.x) <= _size.x * 0.5 and abs(point.y) <= _size.y * 0.5:
-				if enemy_candidate not in discovered:
-					discovered[enemy_candidate] = true
-					enemies.append(enemy_candidate)
+				discovered[enemy_node] = true
+				enemies.append(enemy_node)
 
 	# Call callback
 	if _callback:

--- a/scripts/enemy_detector.gd
+++ b/scripts/enemy_detector.gd
@@ -70,19 +70,20 @@ func updateTarget(_enemy, _cause, _reward):
 		onEnemyDetected.emit(null)
 		return
 
+	# Priority: enemy closest to its path end point (highest progress_ratio).
+	# Sticky: current target stays locked until it leaves range / dies.
 	var best: Enemy = null
-	var currentDistance: float = -1
+	var bestProgress: float = -1.0
 
 	for enemy in enemyInRange:
 		if enemy:
 			if (enemy == target):
 				best = enemy
-				currentDistance = 0
 				break;
 
-			var distance = position.distance_to(enemy.position)
-			if distance < currentDistance || currentDistance == -1:
-				currentDistance = distance
+			var p: float = enemy.progress_ratio
+			if p > bestProgress:
+				bestProgress = p
 				best = enemy
 
 	setTarget(best)

--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -61,14 +61,25 @@ func _on_hitbox_detected(enemies: Array, context: SkillContext, user_position: V
 		if not enemy or not enemy is Node2D:
 			continue
 
+		# Normalize to the Enemy (PathFollow2D) for progress lookup.
+		# Hitbox._detect() may return either Enemy or EnemyArea (Area2D child of Enemy), since both share the "enemy" group.
+		var enemy_node: Enemy = null
+		if enemy is Enemy:
+			enemy_node = enemy
+		elif enemy is Area2D and enemy.get_parent() is Enemy:
+			enemy_node = enemy.get_parent()
+		if enemy_node == null:
+			continue
+
 		var distance = user_position.distance_to(enemy.global_position)
 		valid_targets.append({
 			"target": enemy,
+			"enemy_node": enemy_node,
 			"distance": distance
 		})
 
-	# Sort by distance (closest first)
-	valid_targets.sort_custom(func(a, b): return a.distance < b.distance)
+	# Sort by path progress (closest to end first) — match normal-attack priority.
+	valid_targets.sort_custom(func(a, b): return a.enemy_node.progress_ratio > b.enemy_node.progress_ratio)
 
 	for target_data in valid_targets:
 		context.target.append(target_data.target)


### PR DESCRIPTION
**Problem:** Towers normal-attack the closest enemy to the tower, letting high-progress threats slip through to the base. Investigation surfaced a latent Hitbox bug: `_detect()` returned mixed `Enemy` / `EnemyArea` nodes (both share the `"enemy"` group in `enemy_base.tscn`), and downstream skill actions (`skill_action_attack`, `skill_action_add_buff`) duck-type via `has_method("recvDamage")` / `has_method("addStatusEffect")` — methods that exist on `Enemy` but not `EnemyArea` — silently skipping any `EnemyArea` entry.

**Impact:**
- Towers waste shots on close-but-trailing enemies while high-progress threats walk to the base.
- AOE skills (Kiara fire blade, etc.) damage fewer enemies than their visible AOE covers, random per cast depending on hitbox node ordering.
- Crashed when the fix's new sort lambda accessed `progress_ratio` on the wrong node type — same root ambiguity.

**Fix:** 3 files, layered.
- `scripts/enemy_detector.gd` — normal-attack comparator switches from `position.distance_to(...)` (smallest) to `enemy.progress_ratio` (largest). Sticky behavior preserved per Game Director: current target stays locked until it dies / leaves range; first pick uses new priority. Generalizes for free to future multi-path / multi-endpoint maps — each `Enemy` is a `PathFollow2D` measuring progress on its own parent `Path2D`.
- `scripts/combat/hitbox.gd` — extract `static _resolve_enemy(node)` helper applied in BOTH the overlap-physics path AND the fallback group-scan path. Dedup uses the normalized `Enemy` in both paths. `_detect()` callback contract is now: array contains `Enemy` only — no more `EnemyArea` leaking through.
- `scripts/skill/skillActions/skill_action_find_multiple_in_range.gd` — sort by `progress_ratio` descending to match the new normal-attack priority (Game Director design: skills aim where normal attack aims) + defensive consumer-side normalize step as belt + suspenders for any future `Hitbox` regression.

In-engine test by Game Director: crash repro (Kiara + Amelia + monster kill timing) clean; normal-attack priority works; sticky preserved; AOE applies to all enemies in range; 1 wave end-to-end with no error console. QA gate (per AGENTS.md §4.2(b)) audited the commit: CLEAN.