### PR TITLE
fix(P2-M): guard tower-select popup against game-over + popup titles

### DIFF
--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -27,6 +27,9 @@ var mission: Mission = null;
 var t: Tower = null
 var state: String = ""
 var _popup_open: bool = false
+# Ref to the popup currently on screen (tower-select or deck-select). Used so _on_staff_died()
+# can dismiss it; cleared via _on_popup_closed() when the popup frees itself normally.
+var _active_popup: UITowerSelect = null
 
 # Staff skill casting state — indicator follows mouse; LeftClick commits, RightClick / ESC cancels.
 var _skill_cast_indicator: SkillCastIndicator = null
@@ -167,6 +170,13 @@ func setup_staff():
 
 func _on_staff_died():
 	# Game-over flow — previously inside Player.updateHp; now lives here so Staff owns HP lifecycle.
+	# Mark game over BEFORE any UI work so popup factories early-return if they fire
+	# concurrently from a wave-end timer or deferred callback.
+	state = "game_over"
+	# Dismiss any tower-select / deck popup currently open so it can't sit on top of
+	# the end screen or accept clicks after the game is over.
+	if _active_popup != null and is_instance_valid(_active_popup):
+		_active_popup.queue_free()
 	var endScreen = UIEndDemo.create()
 	if endScreen:
 		get_tree().current_scene.add_child(endScreen)
@@ -210,8 +220,11 @@ func on_wave_ended():
 	# visual at the boss death position is readable before the popup covers it.
 	if waveController != null and waveController.isBossWave:
 		await get_tree().create_timer(BOSS_WAVE_END_POPUP_DELAY).timeout
-		# Re-entry guard: scene may have been freed mid-wait (e.g. game-over).
+		# Re-entry guard: scene may have been freed mid-wait (e.g. game-over) OR the staff
+		# may have died during the await window leaving the scene alive but the game over.
 		if !is_instance_valid(self):
+			return
+		if state == "game_over":
 			return
 
 	# At configured wave milestones, offer one of the remaining decks BEFORE
@@ -223,12 +236,16 @@ func on_wave_ended():
 		show_popup_panel()
 
 func show_deck_popup():
+	# End-game guard: if the staff has died, never open a new popup over the end screen.
+	if state == "game_over":
+		return
 	if _popup_open:
 		print("show_deck_popup: popup already open, ignoring duplicate call")
 		return
 
 	var popup: UITowerSelect = PopupPanelScene.instantiate() as UITowerSelect
 	_popup_open = true
+	_active_popup = popup
 	get_tree().root.add_child(popup)
 
 	var cards: Array = []
@@ -247,7 +264,7 @@ func show_deck_popup():
 	# Flag handoff is explicit in _on_deck_selected / _on_deck_skipped below; the
 	# tower popup wires its own tree_exited via show_popup_panel().
 
-	popup.setup_with_cards(cards, 0)
+	popup.setup_with_cards(cards, 0, "Select Additional Deck")
 
 func _on_deck_selected(deck_key: String):
 	TowerCenter.addDeck(deck_key)
@@ -262,6 +279,9 @@ func _on_deck_skipped():
 	show_popup_panel()
 
 func show_popup_panel():
+	# End-game guard: if the staff has died, never open a new popup over the end screen.
+	if state == "game_over":
+		return
 	# Prevent opening multiple popups if this function is called repeatedly
 	if _popup_open:
 		print("show_popup_panel: popup already open, ignoring duplicate call")
@@ -269,6 +289,7 @@ func show_popup_panel():
 
 	var popup: UITowerSelect = PopupPanelScene.instantiate() as UITowerSelect;
 	_popup_open = true
+	_active_popup = popup
 	# Ensure it's added to the UI layer, not just as a child of the 2D scene
 	get_tree().root.add_child(popup)
 
@@ -280,12 +301,13 @@ func show_popup_panel():
 	Utility.ConnectSignal(popup, "tree_exited", Callable(self, "_on_popup_closed"));
 
 	var evoToken = player.wallet.getEvoToken();
-	popup.setup(evoToken, 1000);
+	popup.setup(evoToken, 1000, "Select Tower");
 
 	return
 
 func _on_popup_closed():
 	_popup_open = false
+	_active_popup = null
 
 func _on_tower_select_skipped():
 	print("Tower select skipped — no valid towers available")

--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -12,21 +12,25 @@ var test_deck = ['1','2','3','4','5']
 @onready var refreshText: Label = $CanvasLayer/PopupPanel/Panel/RefreshButton/RefreshText
 var refreshLeft = 0;
 var maxRefresh = 0;
+# Programmatic title header — lazy-created on first _apply_setup() call when a title is provided.
+# Lives as a child of Panel; anchored top-center above the HBoxContainer card row. Avoids editing
+# tower_select.tscn (RULES.md §5: Engineer cannot modify the node tree in the Scene editor).
+var _title_label: Label = null
 
 
 func _ready() -> void:
 	setupRefreshText(refreshLeft, maxRefresh);
 
-func setup(evoToken: int = 0, maxRefresh: int = 0):
+func setup(evoToken: int = 0, maxRefresh: int = 0, title: String = ""):
 	var cards = _build_card_list(evoToken)
-	_apply_setup(cards, maxRefresh, evoToken)
+	_apply_setup(cards, maxRefresh, evoToken, title)
 
 # Entry point for callers that already have a card list (e.g. deck-add popup at wave-5 end).
 # Bypasses _build_card_list so the popup is not tied to TowerCenter tower pool.
-func setup_with_cards(cards: Array, maxRefresh: int = 0):
-	_apply_setup(cards, maxRefresh, 0)
+func setup_with_cards(cards: Array, maxRefresh: int = 0, title: String = ""):
+	_apply_setup(cards, maxRefresh, 0, title)
 
-func _apply_setup(cards: Array, max_refresh: int, evoTokenForRefresh: int):
+func _apply_setup(cards: Array, max_refresh: int, evoTokenForRefresh: int, title: String = ""):
 	self.refreshLeft = max_refresh;
 	self.maxRefresh = max_refresh;
 
@@ -34,6 +38,9 @@ func _apply_setup(cards: Array, max_refresh: int, evoTokenForRefresh: int):
 		emit_signal("tower_select_skipped")
 		queue_free()
 		return
+
+	if title != "":
+		_ensure_title_label(title)
 
 	_apply_cards_to_buttons(cards)
 
@@ -43,6 +50,28 @@ func _apply_setup(cards: Array, max_refresh: int, evoTokenForRefresh: int):
 		refresh_button.pressed.connect(Callable(self, "refreshList").bind(evoTokenForRefresh))
 
 	setupRefreshText(refreshLeft, maxRefresh)
+
+func _ensure_title_label(title: String) -> void:
+	# Lazy-create a single header Label inside Panel. Anchored top-stretch so it remains centered
+	# regardless of Panel width; offset_top/bottom defines a fixed-height header band above the
+	# HBoxContainer card row.
+	if _title_label == null:
+		_title_label = Label.new()
+		_title_label.name = "TitleLabel"
+		_title_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		_title_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+		_title_label.anchor_left = 0.0
+		_title_label.anchor_right = 1.0
+		_title_label.anchor_top = 0.0
+		_title_label.anchor_bottom = 0.0
+		_title_label.offset_top = 12
+		_title_label.offset_bottom = 56
+		var ls := LabelSettings.new()
+		ls.font_size = 28
+		_title_label.label_settings = ls
+		var panel: Panel = $CanvasLayer/PopupPanel/Panel
+		panel.add_child(_title_label)
+	_title_label.text = title
 
 func setupRefreshText(refreshCount: int, maxRefresh: int):
 	if(refreshText):


### PR DESCRIPTION
**Problem:**
After staff death (`_on_staff_died()` from PR #22 Staff system), the `UIEndDemo` Game-Over screen appears but the tower-select / deck-select popup can still open (or remain visible if already on screen). Clicking a card on the lingering popup runs `_on_option_selected()` → places a tower + calls `startWave()` on a finished game → UI desync, input on a dead game. The boss-wave 2.2s `await` window in `on_wave_ended()` widens the race.

Separately, the tower popup and the deck-add popup look identical → player can't tell which one they're picking from.

**Impact:**
- UI desync after game-over; click-to-place tower on dead scene; reproducible especially during boss waves where the 2.2s `await` lets staff die mid-wait
- UX confusion at wave-5 deck unlock — same panel, no title

**Fix:**
- Added `"game_over"` sentinel state set by `_on_staff_died()` *before* any UI work
- `show_popup_panel()` + `show_deck_popup()` early-return when `state == "game_over"`
- `on_wave_ended()` re-checks state after the boss-wave timer (existing `is_instance_valid(self)` guard only caught scene-freed)
- New `_active_popup` ref so `_on_staff_died()` can `queue_free()` a popup already on screen; cleared in `_on_popup_closed()`
- `UI_tower_select.gd`: `setup()` / `setup_with_cards()` accept optional `title`; lazy-create `TitleLabel` (no `.tscn` edit per RULES.md §5)
- Call sites pass `"Select Tower"` and `"Select Additional Deck"`

**Test plan:**
- [x] Smoke + tower popup title (Test 1 — pass)
- [x] Deck popup title at wave 5 (Test 2 — pass)
- [x] Popup-stuck-before-death dismissal (Test 3 — pass)
- [ ] Boss-wave timer race (Test 4 — skipped; defensive guard for future DoT/time-bomb scenarios)
- [x] Regression: normal flow wave 1→2 (Test 5 — pass)