### PR TITLE
Fix/tower review gaps

### DIFF
--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -7,6 +7,9 @@ const TowerGeneration = preload("res://scripts/entity/tower/tower_trait.gd").Tow
 const AS_MIN := 1.0
 const AS_MAX := 500.0
 
+# Energy gained per normal attack. Design intent: a fixed base, buff/debuff adjustable.
+const BASE_MANA_REGEN := 10
+
 var _level: int = 1;
 var _evolutionCost: int = 1;
 var _isEvolved: bool = false;
@@ -104,7 +107,7 @@ func getAttackDelay() -> float:
 	return 100.0 / getAttackSpeed()
 
 func getManaRegen():
-	return getStat().manaRegen + buffs.aggregate(BuffInstance.StatType.MANA_REGEN)
+	return BASE_MANA_REGEN + buffs.aggregate(BuffInstance.StatType.MANA_REGEN)
 
 func getAttackAnimationSpeed(anim: AnimatedSprite2D, name: String) -> float:
 	return getStat().getAttackAnimationSpeed(anim, name, getAttackDelay())

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -45,7 +45,6 @@ static func load_data(prefix: String, name: String) -> TowerData:
 		stat.critChance = stat_dict.get("critChance", 0.0)
 		stat.critMultiplier = stat_dict.get("critMultiplier", 1.0)
 		stat.mana = stat_dict.get("mana", 0)
-		stat.manaRegen = stat_dict.get("manaRegen", 0.0)
 		stat.intialMana = stat_dict.get("intialMana", 0)
 
 		stat_list.append(stat)
@@ -62,7 +61,6 @@ static func load_data(prefix: String, name: String) -> TowerData:
 		evo.critChance = evo_dict.get("critChance", 0.0)
 		evo.critMultiplier = evo_dict.get("critMultiplier", 1.0)
 		evo.mana = evo_dict.get("mana", 0)
-		evo.manaRegen = evo_dict.get("manaRegen", 0.0)
 		evo.intialMana = evo_dict.get("intialMana", 0)
 
 		tower.evolutionStat = evo

--- a/scripts/entity/tower/tower_factory.gd
+++ b/scripts/entity/tower/tower_factory.gd
@@ -26,7 +26,6 @@ func setup(onPlace: Callable, onRemove: Callable):
 	self.onRemove = onRemove
 
 	Utility.ConnectSignal(towerTrait, "synergy_activated", Callable(self, "onActivateSynergy"));
-	Utility.ConnectSignal(towerTrait, "synergy_deactivated", Callable(self, "onDeactivateSynergy"));
 	Utility.ConnectSignal(towerTrait, "mission_completed", Callable(self, "onMissionCompleted"));
 
 func getTower(name: String, evoToken: int = 0) -> GetTowerResult:
@@ -191,28 +190,6 @@ func onActivateSynergy(synergy_id: int, tier: int, buff: Dictionary):
 
 		if isStarGen1:
 			towerTrait.setStarGen1Damage(starGen1Damage);
-
-# Dont have to deactive synergy
-# func onDeactivateSynergy(synergy_id: int, tier: int):
-# 	if not activeSynergies.has(synergy_id):
-# 		return
-
-# 	var buffList = activeSynergies[synergy_id]
-# 	if tier >= 0 and tier < buffList.size():
-# 		var buff = buffList[tier]
-# 		# Remove this tier's buff
-# 		buffList.remove_at(tier)
-
-# 		# Optional: Clear and re-apply all current buffs for this synergy to all affected towers
-# 		if towers.has(synergy_id):
-# 			for tower in towers[synergy_id]:
-# 				tower.clearSynergyBuffs(synergy_id)  # You will define this
-# 				for remaining_buff in buffList:
-# 					tower.processActiveBuff(remaining_buff)
-
-# 	# If no more buffs, clean up
-# 	if buffList.is_empty():
-# 		activeSynergies.erase(synergy_id)
 
 func onMissionCompleted(id: int, buff: Dictionary):
 	var synergyId = buff.get("synergy_id", -1);

--- a/scripts/entity/tower/tower_stat.gd
+++ b/scripts/entity/tower/tower_stat.gd
@@ -7,7 +7,6 @@ extends Resource
 @export var critChance: float = 15.0
 @export var critMultiplier: float = 1.5
 @export var mana: int = 100
-@export var manaRegen: int = 10
 @export var intialMana: int = 10
 
 func getAttackAnimationSpeed(anim: AnimatedSprite2D, name: String, attack_delay: float) -> float:

--- a/scripts/entity/tower/tower_trait.gd
+++ b/scripts/entity/tower/tower_trait.gd
@@ -150,10 +150,6 @@ func _check_synergy_tiers(synergy_id: int) -> void:
 				buff["synergy_id"] = synergy_id  # Mark the buff
 				synergy_activated.emit(synergy_id, tier, buff)
 				print("Synergy activated:", getSynergyName(synergy_id), "Tier", tier + 1)
-		elif new_tier < prev_tier:
-			for tier in range(prev_tier, new_tier, -1):
-				synergy_deactivated.emit(synergy_id, tier)
-				print("Synergy deactivated:", getSynergyName(synergy_id), "Tier", tier + 1)
 
 		active_synergy_tiers[synergy_id] = new_tier
 
@@ -234,5 +230,4 @@ func getMinRequirement(synergy_id: int) -> int:
 	return synergyRequirements[0]
 
 signal synergy_activated(synergy_id: int, tier: int, buff: Dictionary)
-signal synergy_deactivated(synergy_id: int, tier: int)
 signal mission_completed(mission_id: int, buff: Dictionary);

--- a/scripts/random_cards_dealer.gd
+++ b/scripts/random_cards_dealer.gd
@@ -16,6 +16,6 @@ func get_random_cards(deck, count: int, evoToken: int) -> Array:
 	var result: Array[TowerSelectData] = []
 	for card in selected_cards:
 		var selectData = TowerCenter.getTowerSelectDataByName(card);
-		result.append(TowerSelectData.new(card, selectData.level if selectData.level is String else selectData.level + 1, selectData.evoCost))
+		result.append(TowerSelectData.new(card, selectData.level + 1, selectData.evoCost))
 
 	return result  # Get the first 3 random cards

--- a/scripts/tower_center.gd
+++ b/scripts/tower_center.gd
@@ -12,9 +12,6 @@ var _own_towers: Dictionary = {}
 var _canEvoList = [];
 var _evolvedList = [];
 
-var MAX_LEVEL = "Max";
-var EVOLVED = "Evolved";
-
 #var selected_deck: String = ""
 var selected_deck: String = "Myth" #temporary
 var selected_data_file: String = "myth.yaml" #temporary
@@ -120,7 +117,8 @@ func getTowerSelectDataByName(name: String):
 
 	var data = _own_towers.get(name.to_lower(), null);
 	if(data != null):
-		return {"level": data.level, "evoCost": data.evoCost if data.level is String and data.level == MAX_LEVEL else 0}
+		var maxed: bool = data.level >= data.maxLevel and not data.isEvolved
+		return {"level": data.level, "evoCost": data.evoCost if maxed else 0}
 
 	return {"level":0, "evoCost":0}
 
@@ -133,7 +131,8 @@ func validateSelectTower(name: String, evoToken: int):
 
 	var data = _own_towers.get(name.to_lower(), null);
 	if(data != null):
-		if(data.level is String and (data.level == EVOLVED or (data.level == MAX_LEVEL and data.evoCost > evoToken))):
+		var maxed: bool = data.level >= data.maxLevel and not data.isEvolved
+		if(data.isEvolved or (maxed and data.evoCost > evoToken)):
 			return false
 
 		return true
@@ -159,16 +158,14 @@ func upgradeTowerLevelByName(name: String):
 
 	var data = _own_towers.get(name.to_lower(), null);
 	if(data != null):
-		if(data.level is String):
-			if(data.level == EVOLVED):
-				return
-			if(data.level == MAX_LEVEL):
-				data.level = EVOLVED;
-				_canEvoList.erase(name);
+		if(data.isEvolved):
+			return
+		if(data.level >= data.maxLevel):
+			data.isEvolved = true;
+			_canEvoList.erase(name);
 		else:
 			data.level += 1
 			if(data.level >= data.maxLevel):
-				data.level = MAX_LEVEL;
 				_canEvoList.append(name);
 	else:
 		var tData = getTowerDataByName(name);
@@ -177,7 +174,7 @@ func upgradeTowerLevelByName(name: String):
 		var d = tData.data;
 		var evoCost = d.evolutionCost;
 		var maxLevel = d.maxLevel;
-		_own_towers[name.to_lower()] = {"level": 1, "maxLevel": maxLevel, "evoCost": evoCost};
+		_own_towers[name.to_lower()] = {"level": 1, "maxLevel": maxLevel, "evoCost": evoCost, "isEvolved": false};
 
 func getTowerPortraitByName(name: String):
 	if _tower_portrait_by_name == null:

--- a/scripts/ui/tower_select/tower_select_data.gd
+++ b/scripts/ui/tower_select/tower_select_data.gd
@@ -6,7 +6,7 @@ var icon: Texture2D;
 var level: int;
 var evolutionCost: int;
 
-func _init(name: String, level, evolutionCost: int):
+func _init(name: String, level: int, evolutionCost: int):
 	self.name = name;
 	self.level = level;
 	self.evolutionCost = evolutionCost;


### PR DESCRIPTION
**Problem:** Three gaps found in the tower-system review:
- G4 — a `synergy_deactivated` signal wired to a commented-out handler;
  dead and unreachable code.
- G2 — `manaRegen` was a per-tower stat field, diverging from the design's
  fixed base of 10 Energy per attack.
- G6 — owned-tower `level` stored a mixed int / `"Max"` / `"Evolved"` type,
  forcing type checks everywhere and risking a String/int comparison crash
  when a maxed card reached the tower-select button.

**Impact:** No current player-facing breakage — G4 is unreachable, G2 ships
at 10 on every tower, and G6's crash needs a maxed/evolved card on screen.
All three are latent risks or design drift rather than active bugs.

**Fix:**
- G4 — remove the dead signal, its emit branch, and the connection
  (`tower_factory.gd`, `tower_trait.gd`).
- G2 — replace the field with a `BASE_MANA_REGEN` constant; buff/debuff still
  applies (`tower_data.gd`, `tower_stat.gd`, `tower_data_loader.gd`).
- G6 — `level` is now always int plus an `isEvolved` bool
  (`tower_center.gd`, `random_cards_dealer.gd`, `tower_select_data.gd`).

Out of scope, flagged in `.claude/docs/tower.md`: `returnTower()` /
`removeTowerFromDict()` dead code; the `tower_factory.gd` evolve-trigger
condition reads opposite to `validateSelectTower`. Verified in Godot:
leveling, evolve + maxed-card display, energy/skill pass.