### PR TITLE
feat(tower): add skill display metadata

### DIFF
--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -39,7 +39,14 @@ stats:
 
 skill:
   name: "Skill"
+  names: ["Skill I", "Skill II", "Skill III"] # optional UI display names per tower level
   desc: "Just a skill"
+  desc_template: "Just a skill with {damageBonus:percent} bonus" # UI display template; desc is legacy/fallback text
+  parameters:
+    damageBonus:
+      - 0.10
+      - 0.15
+      - 0.20
   actions:
     - type: find_multi_enemy
       data:

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -7,8 +7,10 @@ evolutionCost: 1
 attack_sound: "hit_amelia"
 open_sound: "debut_amelia"
 skill:
-  name: "Time Traveler I"
-  desc: "Amelia increases her own attack speed by {attackSpeedBuff}% for 4 seconds."
+  name: "Time Traveler"
+  names: ["Time Traveler I", "Time Traveler II", "Time Traveler III"]
+  desc: "Amelia increases her own attack speed for 4 seconds."
+  desc_template: "Amelia increases her own attack speed by {attackSpeedBuff:percent} for 4 seconds."
   cast_time: 0.5
   parameters:
     attackSpeedBuff:

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -73,7 +73,7 @@ static func load_data(prefix: String, name: String) -> TowerData:
 	var skillData = data.get("skill", {"actions": []});
 	var skill = Skill.new();
 	var skillActions: Array[SkillAction] = [];
-	for act in skillData.actions:
+	for act in skillData.get("actions", []):
 		var action = SkillUtility.ParseAction(act);
 		if action != null:
 			skillActions.append(action);
@@ -81,10 +81,7 @@ static func load_data(prefix: String, name: String) -> TowerData:
 			print("Warning: Failed to parse action in skill for tower", name);
 
 	skill.actions = skillActions;
-	skill.name = skillData.get("name", "Unnamed Skill");
-	skill.desc = skillData.get("desc", "");
-	skill.parameters = skillData.get("parameters", {});
-	skill.castTime = skillData.get("cast_time", 0.0);
+	_apply_skill_data(skill, skillData, "Unnamed Skill");
 
 	tower.skill = skill
 
@@ -97,10 +94,23 @@ static func load_data(prefix: String, name: String) -> TowerData:
 			if action != null:
 				evoActions.append(action)
 		evoSkill.actions = evoActions
-		evoSkill.name = evoSkillData.get("name", "Evolved Skill")
-		evoSkill.desc = evoSkillData.get("desc", "")
-		evoSkill.parameters = evoSkillData.get("parameters", {})
-		evoSkill.castTime = evoSkillData.get("cast_time", 0.0)
+		_apply_skill_data(evoSkill, evoSkillData, "Evolved Skill")
 		tower.evolutionSkill = evoSkill
 
 	return tower
+
+static func _apply_skill_data(skill: Skill, skill_data: Dictionary, default_name: String) -> void:
+	skill.names = _parse_skill_names(skill_data)
+	skill.name = skill_data.get("name", default_name)
+	if not skill_data.has("name") and skill.names.size() > 0:
+		skill.name = skill.names[0]
+	skill.desc = skill_data.get("desc", "")
+	skill.desc_template = skill_data.get("desc_template", "")
+	skill.parameters = skill_data.get("parameters", {})
+	skill.castTime = skill_data.get("cast_time", 0.0)
+
+static func _parse_skill_names(skill_data: Dictionary) -> Array[String]:
+	var parsed_names: Array[String] = []
+	for display_name in skill_data.get("names", []):
+		parsed_names.append(str(display_name))
+	return parsed_names

--- a/scripts/skill/skill.gd
+++ b/scripts/skill/skill.gd
@@ -5,6 +5,8 @@ enum TARGET_TYPE {ENEMY, FRIENDLY}
 
 @export var name:String = "Skill"
 @export var desc:String = "Just a skill"
+@export var names: Array[String] = []
+@export var desc_template: String = ""
 @export var oneTimeUse: bool = false
 @export var castTime: float = 0.0
 @export var actions: Array[SkillAction] = []
@@ -20,6 +22,68 @@ func _init(name:String="Skill", desc:String="Just a skill", actions:Array[SkillA
 	self.parameters = parameters;
 	self.oneTimeUse = oneTimeUse;
 	self.castTime = castTime;
+
+func get_display_name(level: int) -> String:
+	if names.size() > 0:
+		var index: int = clampi(level - 1, 0, names.size() - 1)
+		return names[index]
+	return name
+
+func get_display_desc(level: int) -> String:
+	if desc_template == "":
+		return desc
+
+	var result := desc_template
+	var regex := RegEx.new()
+	regex.compile("\\{([^}:]+)(?::([^}]+))?\\}")
+	var matches := regex.search_all(desc_template)
+	for i in range(matches.size() - 1, -1, -1):
+		var match_result := matches[i]
+		var param_name := match_result.get_string(1)
+		var format := match_result.get_string(2)
+		var value = _get_display_parameter(param_name, level)
+		result = result.substr(0, match_result.get_start()) + _format_display_parameter(value, format) + result.substr(match_result.get_end())
+	return result
+
+func _get_display_parameter(param_name: String, level: int):
+	if not parameters.has(param_name):
+		push_warning("Missing skill display parameter: " + param_name)
+		return null
+
+	var value = parameters.get(param_name, "")
+	if value is Array:
+		if value.is_empty():
+			return ""
+		var index: int = clampi(level - 1, 0, value.size() - 1)
+		return value[index]
+	return value
+
+func _format_display_parameter(value, format: String) -> String:
+	if value == null:
+		return ""
+
+	match format:
+		"percent":
+			return _format_display_number(float(value) * 100.0) + "%"
+		"":
+			return _format_display_number(value)
+		_:
+			push_warning("Unknown skill display placeholder format: " + format)
+			return _format_display_number(value)
+
+func _format_display_number(value) -> String:
+	if value is int:
+		return str(value)
+	if value is float:
+		if is_equal_approx(value, round(value)):
+			return str(int(round(value)))
+		var text := "%.4f" % value
+		while text.ends_with("0"):
+			text = text.substr(0, text.length() - 1)
+		if text.ends_with("."):
+			text = text.substr(0, text.length() - 1)
+		return text
+	return str(value)
 
 func use():
 	if oneTimeUse:


### PR DESCRIPTION
**Summary:** Adds optional per-level skill display metadata for tower YAML so production UI can show level-specific skill names and parameterized descriptions later. This is data/API only and does not wire any UI in this PR.

**How it works:** Tower skill YAML can now provide `names` and `desc_template` alongside the existing `name`, `desc`, `parameters`, and `actions`. `Skill.get_display_name(level)` clamps the level and returns `names[level - 1]` when present, while `Skill.get_display_desc(level)` formats placeholders from `parameters`, including explicit percent formatting such as `{attackSpeedBuff:percent}`.

**Implementation Notes:** `name` and `desc` remain canonical runtime/legacy fallback fields. Watson Amelia is migrated as the reference tower, and `default_tower.yaml` now shows the designer-facing schema sample. Existing towers without `names` or `desc_template` continue to fall back to `name` and `desc`.