### PR TITLE
feat(tower): add skill slot compatibility

### DIFF
--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -6,31 +6,48 @@ evolutionCost: 1
 
 attack_sound: "hit_amelia"
 open_sound: "debut_amelia"
-skill:
-  name: "Time Traveler"
-  names: ["Time Traveler I", "Time Traveler II", "Time Traveler III"]
-  desc: "Amelia increases her own attack speed for 4 seconds."
-  desc_template: "Amelia increases her own attack speed by {attackSpeedBuff:percent} for 4 seconds."
-  cast_time: 0.5
-  parameters:
-    attackSpeedBuff:
-      - 0.10
-      - 0.15
-      - 0.20
-  actions:
-    - type: "play_animation"
-      data:
-        animation: "skill"
-    - type: "play_effect"
-      data:
-        effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gd"
-    - type: "atk_speed_buff"
-      data:
-        duration: 4.0
-        param_name: "attackSpeedBuff"
-    - type: "play_animation"
-      data:
-        animation: "idle"
+skills:
+  active:
+    name: "Time Traveler"
+    names: ["Time Traveler I", "Time Traveler II", "Time Traveler III"]
+    desc: "Amelia increases her own attack speed for 4 seconds."
+    desc_template: "Amelia increases her own attack speed by {attackSpeedBuff:percent} for 4 seconds."
+    icon: ""
+    tags:
+      - buff
+      - attack_speed
+      - self
+    target_summary:
+      target_team: self
+      target_type: tower
+      target_shape: single
+    effects:
+      - name: "Attack Speed Buff"
+        target:
+          target_team: self
+          target_type: tower
+          target_shape: single
+    cast_time: 0.5
+    parameters:
+      attackSpeedBuff:
+        - 0.10
+        - 0.15
+        - 0.20
+    actions:
+      - type: "play_animation"
+        data:
+          animation: "skill"
+      - type: "play_effect"
+        data:
+          effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gd"
+      - type: "atk_speed_buff"
+        data:
+          duration: 4.0
+          param_name: "attackSpeedBuff"
+      - type: "play_animation"
+        data:
+          animation: "idle"
+  passive: null
 
 stats:
   - damage: 60
@@ -60,29 +77,55 @@ stats:
     critChance: 0
     critMultiplier: 1.5
 
-evolution_skill:
-  name: "Elementary my dear"
-  desc: "Amelia increases attack speed by 50% for herself and nearby towers, and gains 100% critical chance for 4 seconds."
-  cast_time: 0.5
-  actions:
-    - type: "play_animation"
-      data:
-        animation: "skill"
-    - type: "play_effect"
-      data:
-        effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gd"
-    - type: "atk_speed_buff_aoe"
-      data:
-        duration: 4.0
-        percent: 0.50
-        range: 1
-    - type: "crit_chance_buff"
-      data:
-        duration: 4.0
-        percent: 100.0
-    - type: "play_animation"
-      data:
-        animation: "idle"
+evolution_skills:
+  active:
+    name: "Elementary my dear"
+    desc: "Amelia increases attack speed by 50% for herself and nearby towers, and gains 100% critical chance for 4 seconds."
+    icon: ""
+    tags:
+      - buff
+      - attack_speed
+      - crit_rate
+      - aoe
+      - self
+      - ally
+    target_summary:
+      target_team: ally
+      target_type: tower
+      target_shape: area
+    effects:
+      - name: "Area Attack Speed Buff"
+        target:
+          target_team: ally
+          target_type: tower
+          target_shape: area
+        include_self: true
+      - name: "Self Critical Rate Buff"
+        target:
+          target_team: self
+          target_type: tower
+          target_shape: single
+    cast_time: 0.5
+    actions:
+      - type: "play_animation"
+        data:
+          animation: "skill"
+      - type: "play_effect"
+        data:
+          effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gd"
+      - type: "atk_speed_buff_aoe"
+        data:
+          duration: 4.0
+          percent: 0.50
+          range: 1
+      - type: "crit_chance_buff"
+        data:
+          duration: 4.0
+          percent: 100.0
+      - type: "play_animation"
+        data:
+          animation: "idle"
+  passive: null
 
 evolutionStat:
   damage: 350

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -70,34 +70,77 @@ static func load_data(prefix: String, name: String) -> TowerData:
 	tower.open_sound = data.get("open_sound", "default");
 	tower.evolve_sound = data.get("evolve_sound", "");
 
-	var skillData = data.get("skill", {"actions": []});
-	var skill = Skill.new();
-	var skillActions: Array[SkillAction] = [];
-	for act in skillData.get("actions", []):
-		var action = SkillUtility.ParseAction(act);
-		if action != null:
-			skillActions.append(action);
-		else:
-			print("Warning: Failed to parse action in skill for tower", name);
+	_warn_if_passive_slot_present(data, "skills", name)
+	_warn_if_passive_slot_present(data, "evolution_skills", name)
 
-	skill.actions = skillActions;
-	_apply_skill_data(skill, skillData, "Unnamed Skill");
+	var skillData := _resolve_skill_block(data, "skills", "skill", name, {"actions": []})
+	tower.skill = _parse_skill_data(skillData, "Unnamed Skill", name, "active skill")
 
-	tower.skill = skill
-
-	if data.has("evolution_skill"):
-		var evoSkillData = data["evolution_skill"]
-		var evoSkill := Skill.new()
-		var evoActions: Array[SkillAction] = []
-		for act in evoSkillData.get("actions", []):
-			var action = SkillUtility.ParseAction(act)
-			if action != null:
-				evoActions.append(action)
-		evoSkill.actions = evoActions
-		_apply_skill_data(evoSkill, evoSkillData, "Evolved Skill")
-		tower.evolutionSkill = evoSkill
+	var evoSkillData := _resolve_skill_block(data, "evolution_skills", "evolution_skill", name, {})
+	if not evoSkillData.is_empty():
+		tower.evolutionSkill = _parse_skill_data(evoSkillData, "Evolved Skill", name, "evolved active skill")
 
 	return tower
+
+static func _resolve_skill_block(data: Dictionary, slot_root_key: String, legacy_key: String, tower_name: String, default_block: Dictionary) -> Dictionary:
+	var has_new_slot := false
+	var new_skill_data: Dictionary = {}
+	if data.has(slot_root_key):
+		var slot_root = data[slot_root_key]
+		if slot_root is Dictionary:
+			if slot_root.has("active") and slot_root["active"] != null:
+				if slot_root["active"] is Dictionary:
+					new_skill_data = slot_root["active"]
+					has_new_slot = true
+				else:
+					push_warning("Tower YAML '" + tower_name + "': '" + slot_root_key + ".active' must be a dictionary.")
+		elif slot_root != null:
+			push_warning("Tower YAML '" + tower_name + "': '" + slot_root_key + "' must be a dictionary.")
+
+	var has_legacy := false
+	var legacy_skill_data: Dictionary = {}
+	if data.has(legacy_key) and data[legacy_key] != null:
+		if data[legacy_key] is Dictionary:
+			legacy_skill_data = data[legacy_key]
+			has_legacy = true
+		else:
+			push_warning("Tower YAML '" + tower_name + "': '" + legacy_key + "' must be a dictionary.")
+
+	if has_new_slot:
+		if has_legacy:
+			push_warning("Tower YAML '" + tower_name + "': both '" + legacy_key + "' and '" + slot_root_key + ".active' exist; using the new slot.")
+		return new_skill_data
+	if has_legacy:
+		return legacy_skill_data
+	return default_block
+
+static func _warn_if_passive_slot_present(data: Dictionary, slot_root_key: String, tower_name: String) -> void:
+	if not data.has(slot_root_key):
+		return
+
+	var slot_root = data[slot_root_key]
+	if not (slot_root is Dictionary):
+		return
+	if slot_root.has("passive") and slot_root["passive"] != null:
+		push_warning("Tower YAML '" + tower_name + "': '" + slot_root_key + ".passive' is currently ignored until passive skill runtime exists.")
+
+static func _parse_skill_data(skill_data: Dictionary, default_name: String, tower_name: String, source_name: String) -> Skill:
+	var skill := Skill.new()
+	var skillActions: Array[SkillAction] = []
+	var action_data_list = skill_data.get("actions", [])
+	if action_data_list is Array:
+		for act in action_data_list:
+			var action = SkillUtility.ParseAction(act)
+			if action != null:
+				skillActions.append(action)
+			else:
+				push_warning("Tower YAML '" + tower_name + "': failed to parse action in " + source_name + ".")
+	else:
+		push_warning("Tower YAML '" + tower_name + "': actions in " + source_name + " must be an array.")
+
+	skill.actions = skillActions
+	_apply_skill_data(skill, skill_data, default_name)
+	return skill
 
 static func _apply_skill_data(skill: Skill, skill_data: Dictionary, default_name: String) -> void:
 	skill.names = _parse_skill_names(skill_data)
@@ -108,9 +151,31 @@ static func _apply_skill_data(skill: Skill, skill_data: Dictionary, default_name
 	skill.desc_template = skill_data.get("desc_template", "")
 	skill.parameters = skill_data.get("parameters", {})
 	skill.castTime = skill_data.get("cast_time", 0.0)
+	skill.tags = _parse_string_array(skill_data.get("tags", []))
+	skill.target_summary = _parse_dictionary(skill_data.get("target_summary", {}))
+	skill.icon = str(skill_data.get("icon", ""))
+	skill.effects = _parse_array(skill_data.get("effects", []))
 
 static func _parse_skill_names(skill_data: Dictionary) -> Array[String]:
 	var parsed_names: Array[String] = []
 	for display_name in skill_data.get("names", []):
 		parsed_names.append(str(display_name))
 	return parsed_names
+
+static func _parse_string_array(value) -> Array[String]:
+	var parsed_values: Array[String] = []
+	if not (value is Array):
+		return parsed_values
+	for item in value:
+		parsed_values.append(str(item))
+	return parsed_values
+
+static func _parse_dictionary(value) -> Dictionary:
+	if value is Dictionary:
+		return value
+	return {}
+
+static func _parse_array(value) -> Array:
+	if value is Array:
+		return value
+	return []

--- a/scripts/skill/skill.gd
+++ b/scripts/skill/skill.gd
@@ -11,6 +11,10 @@ enum TARGET_TYPE {ENEMY, FRIENDLY}
 @export var castTime: float = 0.0
 @export var actions: Array[SkillAction] = []
 @export var parameters: Dictionary = {}
+@export var tags: Array[String] = []
+@export var target_summary: Dictionary = {}
+@export var icon: String = ""
+@export var effects: Array = []
 
 var using = false;
 var disable = false;


### PR DESCRIPTION
**Summary:** Adds compatibility loading for the new tower skill slot schema and migrates Watson Amelia as the reference tower while preserving existing gameplay.

**How it works:** `TowerDataLoader` now reads `skills.active` / `evolution_skills.active` first, falls back to legacy `skill` / `evolution_skill`, and stores skill display metadata such as tags, target summary, icon, and effects. Runtime execution still uses the top-level `actions` list.

**Implementation Notes:** Passive slots remain inert until future Passive Skill work. `effects` is descriptive metadata only and is not flattened into runtime actions. Watson Amelia is the only YAML migrated in this PR; other towers remain legacy-compatible.