### PR TITLE
fix(ui): guard tower-select popup against deck-card lookup miss

### DIFF
--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -141,9 +141,15 @@ func _apply_cards_to_buttons(cards: Array) -> void:
 	for index in range(buttons.size()):
 		if index < cards.size():
 			var cardSelectData: TowerSelectData = cards[index] as TowerSelectData;
-			var data: TowerData = TowerCenter.getTowerDataByName(cardSelectData.name).data;
-			var tClass = data.towerClass;
-			var tGen = data.generation;
+			# Deck popup callsite passes deck keys (e.g. "myth") as card name, which
+			# are not registered tower names — fall through with default trait icons
+			# so the synergy chips render the "default" sprite instead of crashing.
+			var entry = TowerCenter.getTowerDataByName(cardSelectData.name);
+			var tClass: int = 0;
+			var tGen: int = 0;
+			if entry != null and entry.data != null:
+				tClass = entry.data.towerClass;
+				tGen = entry.data.generation;
 
 			buttons[index].Setup(cardSelectData.name, cardSelectData.icon, tClass, tGen, cardSelectData.level, cardSelectData.evolutionCost)
 			var bound: Callable = select_callable.bind(cardSelectData.name)


### PR DESCRIPTION
**Problem:** `show_deck_popup()` (game_scene.gd:251-257) creates cards keyed by deck name ("myth", "tempus") to drive the post-boss "Select Additional Deck" panel. The synergy-icon refactor (commit `2a903ae`) made `_apply_cards_to_buttons` assume every card maps to a registered TowerData via `TowerCenter.getTowerDataByName`, which returns null for deck keys — accessing `.data` then crashes.

**Impact:** Killing a wave-milestone boss while at least one undiscovered deck remained produced `Invalid access to property or key 'data' on a base object of type 'Nil'.` and froze the post-wave flow.

**Fix:** Fall through with default trait enum values (0) when the lookup misses, so synergy chips render the "default" sprite instead of crashing. Existing tower-select callsite is unaffected because tower cards still resolve via the same lookup.