### PR TITLE
fix: pre-Kiara bug sweep (wave race, evolve mana UI, Elite type, signal dedup, count reset)

### DIFF
--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -15,6 +15,11 @@ var skillController: EnemySkillController;
 var enableMove: bool = true;
 
 var initialized: bool = false;
+# Mutex flag: ensures exactly ONE removal signal fires per enemy (onDead OR
+# onReachEndPoint, not both). Without this, lethal damage on the same frame
+# an enemy reaches the end double-decrements wave_controller.enemyAliveCount,
+# causing wave to end prematurely while monsters are still alive.
+var _removed: bool = false;
 
 enum EnemyType {Normal, Elite, Boss}
 const FACING_X_EPSILON: float = 0.01
@@ -43,6 +48,9 @@ func _process(_delta):
 		skillController.useSkill();
 
 	if(progress_ratio >= 1.0):
+		if _removed:
+			return
+		_removed = true
 		onReachEndPoint.emit();
 		queue_free()
 
@@ -146,6 +154,15 @@ func updateHealthBar(value: float):
 		healthBar.updateValue(value)
 
 func dead(cause: Damage):
+	# Mutex guard (see _removed comment near top). If the reach-end branch
+	# already fired, suppress onDead so the enemy doesn't double-decrement.
+	# Note: ordering inside _process matters — statusEffects.processEffects
+	# (line 39) runs BEFORE the reach-end check (line 45), so a DOT-lethal
+	# tick at progress_ratio >= 1.0 will set _removed here first, suppressing
+	# the reach-end emit later in the same frame.
+	if _removed:
+		return
+	_removed = true
 	var reward = calcurateReward();
 	onDead.emit(self, cause, reward);
 	queue_free();

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -152,6 +152,14 @@ func evolve():
 			var stat = data.getStat()
 			skillController = SkillController.new(self, stat.mana, stat.intialMana, data.evolutionSkill)
 			Utility.ConnectSignal(skillController, "on_mana_updated", Callable(self, "update_mana_bar"))
+			# Refresh manaBar visual to match the new evolved stat:
+			# - setup() re-applies the new max so the bar's full-bar fills at the
+			#   evolved cap (e.g., Kiara 50 -> 80) instead of the base cap.
+			# - updateValue() shows the new initial mana (e.g., Kiara 10 -> 40)
+			#   immediately; no on_mana_updated signal fires from the constructor.
+			if manaBar != null:
+				manaBar.setup(stat.mana, false)
+				manaBar.updateValue(stat.intialMana)
 	return success
 
 func _play_evolve_sound():

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -59,6 +59,11 @@ func startNextWave():
 	isSpawnAllEnemy = false;
 	endWaveCalled = false;
 	groupSpawnRemain.clear()
+	# Reset alive count as defense vs any stale count carryover from the
+	# previous wave's tracking. With Enemy._removed mutex preventing
+	# double-decrement at source, count should already be 0 here; this is
+	# unguarded cheap insurance, not the primary fix.
+	enemyAliveCount = 0
 
 	var wData: WaveData = data.waveDatas[currWave - 1] as WaveData
 	waveData = wData

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -137,7 +137,13 @@ func spawnEnemy(groupIndex: int):
 	# and call endWave() before the uncounted enemy is even on the map.
 	enemyAliveCount += 1;
 
-	var enemy: Enemy = await createEnemyObject(Enemy.EnemyType.Normal, health, def, mDef, moveSpeed, texture, skills);
+	# Resolve enemy tier from the texture key (registered by ResourceManager.
+	# preloadEnemy via enemy_list.yaml). Elite enemies deal Elite-tier damage
+	# (10) on reach-end and are correctly tagged for any downstream type-aware
+	# logic. Default to Normal if the texture wasn't registered.
+	var enemy_type := _tierToEnemyType(ResourceManager.getEnemyTier(waveGroup.texture))
+
+	var enemy: Enemy = await createEnemyObject(enemy_type, health, def, mDef, moveSpeed, texture, skills);
 
 	if enemy == null:
 		# Spawn failed — undo the reservation so the count stays accurate.
@@ -145,6 +151,15 @@ func spawnEnemy(groupIndex: int):
 		return;
 
 	connectSignalToEnemy(enemy);
+
+func _tierToEnemyType(tier: String) -> Enemy.EnemyType:
+	match tier:
+		"boss":
+			return Enemy.EnemyType.Boss
+		"elite":
+			return Enemy.EnemyType.Elite
+		_:
+			return Enemy.EnemyType.Normal
 
 func spawnBoss():
 	var result = bossList.filter(func(b):

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -129,8 +129,20 @@ func spawnEnemy(groupIndex: int):
 	for skill in waveGroup.skill:
 		skills.append(Utility.deep_duplicate_resource(skill))
 
-	var enemy: Enemy = await createEnemyObject(Enemy.EnemyType.Normal, health, def, mDef, moveSpeed, texture, skills);
+	# Reserve count BEFORE the async spawn so the in-flight createEnemyObject
+	# await window can't cause a premature wave-end. Otherwise, the while loop
+	# in spawnEnemyTask flips isSpawnAllEnemy = true while the final enemy is
+	# still being instantiated; if previously-spawned enemies have already
+	# died / reached the end, checkEndWave would see alive=0 + spawnedAll=true
+	# and call endWave() before the uncounted enemy is even on the map.
 	enemyAliveCount += 1;
+
+	var enemy: Enemy = await createEnemyObject(Enemy.EnemyType.Normal, health, def, mDef, moveSpeed, texture, skills);
+
+	if enemy == null:
+		# Spawn failed — undo the reservation so the count stays accurate.
+		enemyAliveCount -= 1;
+		return;
 
 	connectSignalToEnemy(enemy);
 
@@ -160,9 +172,16 @@ func spawnBoss():
 	var moveSpeed = bossData.stats.moveSpeed
 	var skills = bossData.skills;
 
+	# Reserve count BEFORE the async spawn (same race-condition guard as
+	# spawnEnemy — checkEndWave can fire while boss creation is still in flight).
 	isSpawnAllEnemy = true;
-	var boss: Enemy = await createEnemyObject(Enemy.EnemyType.Boss, health, def, mDef, moveSpeed, texture, skills);
 	enemyAliveCount += 1;
+
+	var boss: Enemy = await createEnemyObject(Enemy.EnemyType.Boss, health, def, mDef, moveSpeed, texture, skills);
+
+	if boss == null:
+		enemyAliveCount -= 1;
+		return;
 
 	connectSignalToEnemy(boss);
 
@@ -190,8 +209,12 @@ func testSpawnBoss(index: int = -1):
 	var mDef = boss.stats.mDef
 	var moveSpeed = boss.stats.moveSpeed
 
-	var enemy: Enemy = await createEnemyObject(Enemy.EnemyType.Boss, health, def, mDef, moveSpeed, texture);
+	# Same race-condition guard as spawnEnemy / spawnBoss (debug-only path).
 	enemyAliveCount += 1;
+	var enemy: Enemy = await createEnemyObject(Enemy.EnemyType.Boss, health, def, mDef, moveSpeed, texture);
+	if enemy == null:
+		enemyAliveCount -= 1;
+		return;
 	connectSignalToEnemy(enemy);
 
 func connectSignalToEnemy(enemy: Enemy):

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -52,6 +52,8 @@ static func preloadSynergy():
 			var path = "ui_asset/synergies/" + key + ".png"
 			loadImage("synergy", key, path)
 
+static var _enemy_tier: Dictionary = {}  # texture key -> tier string ("boss"/"elite"/"normal")
+
 static func preloadEnemy(mapName: String, types: Array[String]) -> void:
 	var enemyPrefix := "res://resources/enemy"
 	var loaded: Dictionary = {}
@@ -61,6 +63,13 @@ static func preloadEnemy(mapName: String, types: Array[String]) -> void:
 	for type in types:
 		var enemyNames: Array = enemies.get(type, [])
 		for enemy in enemyNames:
+			# Record the tier this texture belongs to so spawn-time code can
+			# resolve the correct Enemy.EnemyType (Elite vs Normal vs Boss).
+			# Without this, wave_controller defaults every non-boss spawn to
+			# Normal, causing elites to deal Normal-tier damage (1 instead of
+			# 10 per PlayerHealth.DAMAGE_BY_MONSTER_TYPE).
+			_enemy_tier[enemy] = type
+
 			var full_path := "%s/%s/%s/%s/%s.png" % [
 				enemyPrefix,
 				mapName,
@@ -84,6 +93,11 @@ static func getSpriteGroup(group: String):
 	if !_sprites.has(group):
 		return null
 	return _sprites[group]
+
+# Returns the tier string ("boss"/"elite"/"normal") for an enemy texture key,
+# defaulting to "normal" when the texture wasn't registered in enemy_list.yaml.
+static func getEnemyTier(texture_key: String) -> String:
+	return _enemy_tier.get(texture_key, "normal")
 
 static func getSprite(group: String, key: String):
 	if !_sprites.has(group):


### PR DESCRIPTION
**Problem:**
- `wave_controller.spawnEnemy` reserved `enemyAliveCount` AFTER `await createEnemyObject`, leaving a race window
- All non-boss spawns hardcoded `Enemy.EnemyType.Normal` — Elite never used its tier
- `Enemy` could emit BOTH `onDead` and `onReachEndPoint` on lethal-at-reach, double-decrementing alive count
- `Tower.evolve()` swapped SkillController with new evolved stats but didn't refresh `manaBar` UI
- `startNextWave` never reset `enemyAliveCount`, allowing stale carryover

**Impact:**
- Tower-select popup appeared mid-wave with monsters still on the map
- Elite enemies dealt 1 damage to player instead of 10 (per `PlayerHealth.DAMAGE_BY_MONSTER_TYPE`)
- Evolved tower mana bar showed stale base-tier max + value
- Wave occasionally ended before all spawn slots resolved

**Fix:**
- `wave_controller.gd`: reserve `enemyAliveCount` before async spawn (all 3 paths); resolve EnemyType via new `ResourceManager.getEnemyTier()` lookup; reset count on `startNextWave`
- `enemy.gd`: `_removed` mutex so each enemy emits exactly ONE removal signal
- `resource_manager.gd`: store tier mapping when preloading `enemy_list.yaml`
- `tower.gd`: `manaBar.setup()` + `updateValue()` after evolve swaps the controller