### PR TITLE
Fix skill-mana bounce across waves on killing blow

### DIFF
--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -183,7 +183,14 @@ func attackEnemy():
 		if(spr):
 			spr.flip_h = attackDir == Global.DIRECTION.RIGHT
 
+		# attack() deals damage synchronously. If this is the killing blow on the
+		# wave's last enemy, the onDead cascade runs endWave -> resetForWave INSIDE
+		# this call (bumping skill_lock_generation). If so, skip the post-attack
+		# state writes so mana/cooldown/attacking don't leak into the next wave.
+		var gen := skill_lock_generation
 		attackController.attack(enemy, attackDir, data.getDamage(enemy, self), data.attack_sound, data.attack_vfx);
+		if skill_lock_generation != gen:
+			return
 		attacking = true;
 		regenMana(data.getManaRegen());
 		attackCooldownRemaining = data.getAttackDelay()


### PR DESCRIPTION
**Problem:** In `Tower.attackEnemy()`, the attack deals damage synchronously. When a tower lands the killing blow on a wave's last enemy, the `onDead` cascade runs `endWave -> resetForWave` *inside* the `attack()` call, then control returns to the post-attack writes (mana/attacking/cooldown), re-applying them after the reset.
**Impact:** The tower that landed the final kill carried extra skill-mana (and stale attacking/cooldown state) into the next wave instead of resetting to its initial mana.
**Fix:** Capture `skill_lock_generation` before the attack and skip the post-attack state writes if it changed mid-call, reusing the existing stale-callback guard pattern from `skill_action_projectile.gd`. Single-file change in `scripts/entity/tower/tower.gd`.