### PR TITLE
Migrate default tower template to skill slots; drop dead manaRegen field

### DIFF
--- a/resources/database/towers/axel_syrios.yaml
+++ b/resources/database/towers/axel_syrios.yaml
@@ -13,7 +13,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 30
-    manaRegen: 10
     intialMana: 0
     critChance: 0
     critMultiplier: 1.5
@@ -22,7 +21,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 30
-    manaRegen: 10
     intialMana: 0
     critChance: 0
     critMultiplier: 1.5
@@ -31,7 +29,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 30
-    manaRegen: 10
     intialMana: 0
     critChance: 0
     critMultiplier: 1.5
@@ -60,7 +57,6 @@ evolutionStat:
   attackRange: 1.0
   attackSpeed: 80
   mana: 30
-  manaRegen: 10
   intialMana: 0
   critChance: 50.0
   critMultiplier: 1.5
@@ -74,5 +70,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   manaRegen: 15
 #   intialMana: 20

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -13,7 +13,6 @@ stats:
     attackRange: 2.0
     attackSpeed: 120.0
     mana: 80
-    manaRegen: 10
     intialMana: 20
     critChance: 0
     critMultiplier: 1.5
@@ -22,7 +21,6 @@ stats:
     attackRange: 2.0
     attackSpeed: 120.0
     mana: 80
-    manaRegen: 10
     intialMana: 20
     critChance: 0
     critMultiplier: 1.5
@@ -31,7 +29,6 @@ stats:
     attackRange: 2.0
     attackSpeed: 120.0
     mana: 80
-    manaRegen: 10
     intialMana: 20
     critChance: 0
     critMultiplier: 1.5
@@ -60,7 +57,6 @@ evolutionStat:
   attackRange: 2.0
   attackSpeed: 120
   mana: 80
-  manaRegen: 10
   intialMana: 20
   critChance: 50.0
   critMultiplier: 1.5
@@ -74,5 +70,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   manaRegen: 15
 #   intialMana: 20

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -1,22 +1,21 @@
 maxLevel: 3 # tower max level
 towerClass: diva # tower class (Assassin, Diva, Hero, King, Marksman, Robotic, SpellCaster, Warrior)
 generation: tempus # tower generation (Myth, Tempus, Gen0, Gen1, Indo1)
-attackType: physic
+attackType: physic # physic | magic (1 tower 1 type ตาม design)
 evolutionCost: 1 # ค่า evolution
 
-# skill: "res://resources/database/skill/gawr_gura_skill.tres" #tower skill file path (เดี๋ยวอัปเดตเป็น yaml ให้อีกที)
-attack_sound: "hit" # ชื่อเสียงที่ใช้ตอนโจมตี\
-open_sound: "open" # ชื่อเสียงที่ใช้ตอนเปิดตัว (เป็น enum ใน sound_database.gd VOICE_NAME)
+attack_sound: "hit" # ชื่อเสียงที่ใช้ตอนโจมตี (enum ใน sound_database.gd VOICE_NAME)
+open_sound: "open" # ชื่อเสียงที่ใช้ตอนเปิดตัว
 evolve_sound: "" # optional evolve voice key (VOICE_NAME); empty = no evolve voice
+# attack_vfx: "blue" # optional — ชื่อ VFX ตอนโจมตี (enum ใน attack_vfx.gd AttackVFXName); ไม่ใส่ = "default"
 
 stats:
   - damage: 80 # ค่าพลังโจมตี
-    attackRange: 2.0 #ระยะการตี (cell)
-    attackSpeed: 80.0 #ความเร็วการโจมตี
+    attackRange: 2.0 # ระยะการตี (cell)
+    attackSpeed: 80.0 # ความเร็วการโจมตี
     critChance: 15.0
     critMultiplier: 1.5
     mana: 120 # ค่า mana สูงสุด
-    manaRegen: 10 # ค่า mana รีเจน ต่อการตี 1 ที
     intialMana: 60 # ค่า mana เริ่มต้น
 
   - damage: 120
@@ -25,7 +24,6 @@ stats:
     critChance: 15.0
     critMultiplier: 1.5
     mana: 120
-    manaRegen: 10
     intialMana: 60
 
   - damage: 180
@@ -34,60 +32,137 @@ stats:
     critChance: 15.0
     critMultiplier: 1.5
     mana: 120
-    manaRegen: 10
     intialMana: 60
 
-skill:
-  name: "Skill"
-  names: ["Skill I", "Skill II", "Skill III"] # optional UI display names per tower level
-  desc: "Just a skill"
-  desc_template: "Just a skill with {damageBonus:percent} bonus" # UI display template; desc is legacy/fallback text
-  parameters:
-    damageBonus:
-      - 0.10
-      - 0.15
-      - 0.20
-  actions:
-    - type: find_multi_enemy
-      data:
-        width: 3
-        height: 1
-    - type: play_animation
-      data:
-        animation: "skill"
-    - type: attack
-      data:
-        damage: 100
-        damage_type: physic
-        # ─────────────────────────────────────────────────────────────────
-        # Phase 3 Block C — Skill Multiplier (สำหรับ skill tower เท่านั้น)
-        #
-        # damage_multiplier:
-        #   - scalar  → ใช้ค่าเดียว ทุก level     เช่น 2.0 (200% Total Attack)
-        #   - array   → ค่าแต่ละ level [L1, L2, L3]  เช่น [1.4, 1.5, 1.7]
-        #
-        # damage_type ถ้าไม่ใส่ → ใช้ tower.attackType (default ตาม design 1 tower 1 type)
-        #
-        # can_crit:
-        #   - true (default) → skill roll crit ตามเลขของ tower
-        #   - false           → skill ไม่ crit (เช่น skill Kiara ตามดีไซน์)
-        #
-        # hit_distribution: [r1, r2, ...]  ← multi-hit, แบ่ง 100% ของ final damage
-        #   ⚠️ caution: ผลรวม ratio ต้อง = 1.0 ไม่งั้น push_warning
-        #   ⚠️ ใช้ได้กับ skill ของ tower เท่านั้น (normal attack ไม่มี multi-hit)
-        #
-        # ตัวอย่าง 4-hit skill ความเสียหาย 200% รวม:
-        #   - type: attack
-        #     data:
-        #       damage_multiplier: 2.0
-        #       hit_distribution: [0.2, 0.2, 0.1, 0.5]   # รวม = 1.0 ✓
-        #
-        # ตัวอย่าง skill non-crit ที่ scale ตาม level:
-        #   - type: attack
-        #     data:
-        #       damage_multiplier: [1.4, 1.5, 1.7]
-        #       can_crit: false
-        # ─────────────────────────────────────────────────────────────────
-    - type: play_animation
-      data:
-        animation: "idle"
+# ── Skill slots (ทรงใหม่) ────────────────────────────────────────────
+# skills.active = Active Skill (auto-cast ตอน Energy เต็ม)
+# skills.passive = Passive Skill (ยังไม่มี runtime — ใส่ null ไว้ก่อน)
+skills:
+  active:
+    name: "Skill"
+    names: ["Skill I", "Skill II", "Skill III"] # optional UI display names per tower level
+    desc: "Just a skill" # legacy/fallback text
+    desc_template: "Just a skill with {damageBonus:percent} bonus" # UI display template
+    icon: "" # optional — ว่างได้ ถ้ายังไม่มี icon
+    # tags = ป้ายสรุปสกิลแบบผู้เล่นอ่าน (controlled registry ดู tower_skill.md §Tags)
+    tags:
+      - damage
+      - attack
+      - aoe
+      - enemy
+    # target_summary = สรุป target ระดับสกิลไว้โชว์ UI (ความแม่นจริงอยู่ที่ effect/action)
+    # ใช้ block map เท่านั้น อย่าใช้ inline {...} (custom YAML parser support flow จำกัด)
+    target_summary:
+      target_team: enemy # self | enemy | ally | both
+      target_type: enemy # tower | enemy | any
+      target_shape: area # single | area | global
+    effects:
+      - name: "Area Damage"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    cast_time: 0.0
+    parameters:
+      damageBonus:
+        - 0.10
+        - 0.15
+        - 0.20
+    actions:
+      - type: find_multi_enemy
+        data:
+          width: 3
+          height: 1
+      - type: play_animation
+        data:
+          animation: "skill"
+      - type: attack
+        data:
+          damage: 100
+          damage_type: physic
+          # ─────────────────────────────────────────────────────────────────
+          # Phase 3 Block C — Skill Multiplier (สำหรับ skill tower เท่านั้น)
+          #
+          # damage_multiplier:
+          #   - scalar  → ใช้ค่าเดียว ทุก level     เช่น 2.0 (200% Total Attack)
+          #   - array   → ค่าแต่ละ level [L1, L2, L3]  เช่น [1.4, 1.5, 1.7]
+          #
+          # damage_type ถ้าไม่ใส่ → ใช้ tower.attackType (default ตาม design 1 tower 1 type)
+          #
+          # can_crit:
+          #   - true (default) → skill roll crit ตามเลขของ tower
+          #   - false           → skill ไม่ crit (เช่น skill Kiara ตามดีไซน์)
+          #
+          # hit_distribution: [r1, r2, ...]  ← multi-hit, แบ่ง 100% ของ final damage
+          #   ⚠️ caution: ผลรวม ratio ต้อง = 1.0 ไม่งั้น push_warning
+          #   ⚠️ ใช้ได้กับ skill ของ tower เท่านั้น (normal attack ไม่มี multi-hit)
+          #
+          # ตัวอย่าง 4-hit skill ความเสียหาย 200% รวม:
+          #   - type: attack
+          #     data:
+          #       damage_multiplier: 2.0
+          #       hit_distribution: [0.2, 0.2, 0.1, 0.5]   # รวม = 1.0 ✓
+          #
+          # ตัวอย่าง skill non-crit ที่ scale ตาม level:
+          #   - type: attack
+          #     data:
+          #       damage_multiplier: [1.4, 1.5, 1.7]
+          #       can_crit: false
+          # ─────────────────────────────────────────────────────────────────
+      - type: play_animation
+        data:
+          animation: "idle"
+  passive: null
+
+# evolutionStat = stat ตอน evolve (block เดียว ไม่ใช่ array)
+evolutionStat:
+  damage: 240
+  attackRange: 2.0
+  attackSpeed: 100.0
+  critChance: 50.0
+  critMultiplier: 1.5
+  mana: 120
+  intialMana: 80
+
+# evolution_skills = สกิลร่างวิวัฒน์ (ทรงเดียวกับ skills) — optional
+evolution_skills:
+  active:
+    name: "Evolved Skill"
+    desc: "Just a stronger skill"
+    desc_template: "Just a stronger skill with {damageBonus:percent} bonus"
+    icon: ""
+    tags:
+      - damage
+      - attack
+      - aoe
+      - enemy
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Area Damage"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    cast_time: 0.0
+    parameters:
+      damageBonus:
+        - 0.30
+    actions:
+      - type: find_multi_enemy
+        data:
+          width: 3
+          height: 3
+      - type: play_animation
+        data:
+          animation: "skill"
+      - type: attack
+        data:
+          damage_multiplier: 2.0
+          damage_type: physic
+      - type: play_animation
+        data:
+          animation: "idle"
+  passive: null

--- a/resources/database/towers/gavis_bettel.yaml
+++ b/resources/database/towers/gavis_bettel.yaml
@@ -13,7 +13,6 @@ stats:
     attackRange: 3.0
     attackSpeed: 95
     mana: 140
-    manaRegen: 10
     intialMana: 100
     critChance: 0
     critMultiplier: 1.5
@@ -22,7 +21,6 @@ stats:
     attackRange: 3.0
     attackSpeed: 95
     mana: 140
-    manaRegen: 10
     intialMana: 100
     critChance: 0
     critMultiplier: 1.5
@@ -31,7 +29,6 @@ stats:
     attackRange: 3.0
     attackSpeed: 95
     mana: 140
-    manaRegen: 10
     intialMana: 100
     critChance: 0
     critMultiplier: 1.5
@@ -60,7 +57,6 @@ evolutionStat:
   attackRange: 3.0
   attackSpeed: 95
   mana: 140
-  manaRegen: 10
   intialMana: 100
   critChance: 50.0
   critMultiplier: 1.5
@@ -74,5 +70,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   manaRegen: 15
 #   intialMana: 20

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -13,7 +13,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 120
-    manaRegen: 10
     intialMana: 60
     critChance: 0
     critMultiplier: 1.5
@@ -22,7 +21,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 120
-    manaRegen: 10
     intialMana: 60
     critChance: 0
     critMultiplier: 1.5
@@ -31,7 +29,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 120
-    manaRegen: 10
     intialMana: 60
     critChance: 0
     critMultiplier: 1.5
@@ -93,7 +90,6 @@ evolutionStat:
   attackRange: 1.0
   attackSpeed: 100
   mana: 120
-  manaRegen: 10
   intialMana: 80
   critChance: 50.0
   critMultiplier: 1.5

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -13,7 +13,6 @@ stats:
     attackRange: 4.0
     attackSpeed: 140.0
     mana: 100
-    manaRegen: 10
     intialMana: 10
     critChance: 0
     critMultiplier: 1.5
@@ -22,7 +21,6 @@ stats:
     attackRange: 4.0
     attackSpeed: 140.0
     mana: 100
-    manaRegen: 10
     intialMana: 10
     critChance: 0
     critMultiplier: 1.5
@@ -31,7 +29,6 @@ stats:
     attackRange: 4.0
     attackSpeed: 140.0
     mana: 100
-    manaRegen: 10
     intialMana: 10
     critChance: 0
     critMultiplier: 1.5
@@ -60,7 +57,6 @@ evolutionStat:
   attackRange: 4.0
   attackSpeed: 140
   mana: 100
-  manaRegen: 10
   intialMana: 10
   critChance: 50.0
   critMultiplier: 1.5
@@ -74,5 +70,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   manaRegen: 15
 #   intialMana: 20

--- a/resources/database/towers/machina_x_flayon.yaml
+++ b/resources/database/towers/machina_x_flayon.yaml
@@ -13,7 +13,6 @@ stats:
     attackRange: 2.0
     attackSpeed: 100
     mana: 100
-    manaRegen: 10
     intialMana: 60
     critChance: 0
     critMultiplier: 1.5
@@ -22,7 +21,6 @@ stats:
     attackRange: 2.0
     attackSpeed: 100
     mana: 100
-    manaRegen: 10
     intialMana: 60
     critChance: 0
     critMultiplier: 1.5
@@ -31,7 +29,6 @@ stats:
     attackRange: 2.0
     attackSpeed: 100
     mana: 100
-    manaRegen: 10
     intialMana: 60
     critChance: 0
     critMultiplier: 1.5
@@ -60,7 +57,6 @@ evolutionStat:
   attackRange: 4.0
   attackSpeed: 20
   mana: 100
-  manaRegen: 10
   intialMana: 80
   critChance: 50.0
   critMultiplier: 1.5
@@ -74,5 +70,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   manaRegen: 15
 #   intialMana: 20

--- a/resources/database/towers/mori_calliope.yaml
+++ b/resources/database/towers/mori_calliope.yaml
@@ -14,7 +14,6 @@ stats:
     attackSpeed: 100
     mana: 40
     intialMana: 10
-    manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -23,7 +22,6 @@ stats:
     attackSpeed: 100
     mana: 40
     intialMana: 10
-    manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -32,7 +30,6 @@ stats:
     attackSpeed: 100
     mana: 40
     intialMana: 10
-    manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -60,7 +57,6 @@ evolutionStat:
   attackRange: 2.0
   attackSpeed: 120
   mana: 80
-  manaRegen: 10
   intialMana: 40
   critChance: 50.0
   critMultiplier: 1.5

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -14,7 +14,6 @@ stats:
     attackSpeed: 60
     mana: 100
     intialMana: 60
-    manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -23,7 +22,6 @@ stats:
     attackSpeed: 60
     mana: 100
     intialMana: 60
-    manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -32,7 +30,6 @@ stats:
     attackSpeed: 60
     mana: 100
     intialMana: 60
-    manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -57,7 +54,6 @@ evolutionStat:
   attackRange: 4.0
   attackSpeed: 80
   mana: 100
-  manaRegen: 10
   intialMana: 60
   critChance: 50.0
   critMultiplier: 1.5

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -13,7 +13,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 110
     mana: 120
-    manaRegen: 10
     intialMana: 40
     critChance: 0
     critMultiplier: 1.5
@@ -22,7 +21,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 110.0
     mana: 120
-    manaRegen: 10
     intialMana: 40
     critChance: 0
     critMultiplier: 1.5
@@ -31,7 +29,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 110.0
     mana: 120
-    manaRegen: 10
     intialMana: 40
     critChance: 0
     critMultiplier: 1.5
@@ -77,7 +74,6 @@ evolutionStat:
   attackRange: 1.0
   attackSpeed: 110
   mana: 120
-  manaRegen: 10
   intialMana: 40
   critChance: 50.0
   critMultiplier: 1.5
@@ -91,5 +87,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   manaRegen: 15
 #   intialMana: 20

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -13,7 +13,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 90.0
     mana: 50
-    manaRegen: 10
     intialMana: 10
     critChance: 0
     critMultiplier: 1.5
@@ -22,7 +21,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 90.0
     mana: 50
-    manaRegen: 10
     intialMana: 10
     critChance: 0
     critMultiplier: 1.5
@@ -31,7 +29,6 @@ stats:
     attackRange: 1.0
     attackSpeed: 90.0
     mana: 50
-    manaRegen: 10
     intialMana: 10
     critChance: 0
     critMultiplier: 1.5
@@ -110,7 +107,6 @@ evolutionStat:
   attackRange: 1.0
   attackSpeed: 110
   mana: 80
-  manaRegen: 10
   intialMana: 40
   critChance: 50.0
   critMultiplier: 1.5

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -13,7 +13,6 @@ stats:
     attackSpeed: 120
     mana: 100
     intialMana: 80
-    manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -22,7 +21,6 @@ stats:
     attackSpeed: 120
     mana: 100
     intialMana: 80
-    manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -31,7 +29,6 @@ stats:
     attackSpeed: 120
     mana: 100
     intialMana: 80
-    manaRegen: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -83,7 +80,6 @@ evolutionStat:
   attackRange: 5.0
   attackSpeed: 140
   mana: 120
-  manaRegen: 10
   intialMana: 80
   critChance: 50.0
   critMultiplier: 1.5

--- a/resources/tower/data/gawr_gura_data.tres
+++ b/resources/tower/data/gawr_gura_data.tres
@@ -12,7 +12,6 @@ attackSpeed = 80.0
 critChance = 15.0
 critMultiplier = 1.5
 mana = 120
-manaRegen = 10
 intialMana = 60
 
 [sub_resource type="Resource" id="Resource_6820u"]
@@ -23,7 +22,6 @@ attackSpeed = 80.0
 critChance = 15.0
 critMultiplier = 1.5
 mana = 120
-manaRegen = 10
 intialMana = 60
 
 [sub_resource type="Resource" id="Resource_bjofy"]
@@ -34,7 +32,6 @@ attackSpeed = 80.0
 critChance = 15.0
 critMultiplier = 1.5
 mana = 120
-manaRegen = 10
 intialMana = 60
 
 [resource]

--- a/resources/tower/data/takanashi_kiara_data.tres
+++ b/resources/tower/data/takanashi_kiara_data.tres
@@ -12,7 +12,6 @@ attackSpeed = 90.0
 critChance = 15.0
 critMultiplier = 1.5
 mana = 50
-manaRegen = 10
 intialMana = 10
 
 [sub_resource type="Resource" id="Resource_6820u"]
@@ -23,7 +22,6 @@ attackSpeed = 90.0
 critChance = 15.0
 critMultiplier = 1.5
 mana = 50
-manaRegen = 10
 intialMana = 10
 
 [sub_resource type="Resource" id="Resource_bjofy"]
@@ -34,7 +32,6 @@ attackSpeed = 90.0
 critChance = 15.0
 critMultiplier = 1.5
 mana = 50
-manaRegen = 10
 intialMana = 10
 
 [resource]


### PR DESCRIPTION
**Summary:** Bring the designer-facing tower template up to the current skill-slot schema and remove a dead stat field that was carried in every tower's data by mistake.

**How it works:**
- `default_tower.yaml` migrates from the legacy top-level `skill:` block to the new `skills.active` / `passive: null` slot shape, matching the migrated reference towers (Gura/Amelia) and the canonical shape in `tower_skill.md`. It is now a full reference template: skill display metadata (`tags`, `target_summary`, `effects`, `icon`, `cast_time`), an `evolutionStat` block, and an `evolution_skills` slot. The obsolete `.tres` skill-path comment is removed. The loader already supports this shape (`tower_data_loader.gd._resolve_skill_block`), so no code change is needed.
- The `manaRegen` field is dropped from every tower YAML and the two tower data `.tres` files. Mana regen per attack is the hardcoded constant `BASE_MANA_REGEN` (=10) in `tower_data.gd`; `TowerStat` has no `manaRegen` property and the loader never read it, so the key was inert leftover.

**Implementation Notes:**
- Template uses semantically-correct `target_type: enemy` (the model in `tower_skill.md`) rather than copying Gura's `target_type: tower`; these fields are inert UI metadata today, so behavior is unaffected either way.
- Template demonstrates both damage styles on purpose: flat `damage:` on the normal skill, `damage_multiplier:` on the evolved skill, with the Phase 3 Block C authoring comment preserved.
- `default_tower.yaml` doubles as the loader fallback (used when a tower YAML fails to open); verified in-engine by forcing the fallback. No `.tscn` files touched.
