### PR TITLE
Tower desc copy cleanup (Gura + Amelia)

### DIFF
--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -37,8 +37,8 @@ skills:
   active:
     name: "Atlantis Trident"
     names: ["Atlantis Trident I", "Atlantis Trident II", "Atlantis Trident III"]
-    desc: "Gawr Gura wields the Trident of Atlantis to summon four storm waves within one tile around her for 10 seconds. Each wave deals damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
-    desc_template: "Gawr Gura wields the Trident of Atlantis to summon four storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
+    desc: "Gawr Gura wields the Trident of Atlantis to summon 4 storm waves within one tile around her for 10 seconds. Each wave deals damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
+    desc_template: "Gawr Gura wields the Trident of Atlantis to summon 4 storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
     icon: ""
     tags:
       - damage
@@ -97,8 +97,8 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Sink to the Void at the Bottom of the Sea!!"
-    desc: "Gawr Gura wields the Trident of Atlantis to summon eight storm waves within one tile around her for 10 seconds. Each wave deals damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
-    desc_template: "Gawr Gura wields the Trident of Atlantis to summon eight storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
+    desc: "Gawr Gura wields the Trident of Atlantis to summon 8 storm waves within one tile around her for 10 seconds. Each wave deals damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
+    desc_template: "Gawr Gura wields the Trident of Atlantis to summon 8 storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
     icon: ""
     tags:
       - damage

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -37,7 +37,7 @@ skills:
   active:
     name: "Atlantis Trident"
     names: ["Atlantis Trident I", "Atlantis Trident II", "Atlantis Trident III"]
-    desc: "Gawr Gura summons crashing waves of the Atlantis Trident around herself.\nNote: Gawr Gura does not gain Energy while this skill is active."
+    desc: "Gawr Gura wields the Trident of Atlantis to summon four storm waves within one tile around her for 10 seconds. Each wave deals damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
     desc_template: "Gawr Gura wields the Trident of Atlantis to summon four storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
     icon: ""
     tags:
@@ -97,7 +97,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Sink to the Void at the Bottom of the Sea!!"
-    desc: "Gawr Gura unleashes the full fury of the Atlantis Trident.\nNote: Gawr Gura does not gain Energy while this skill is active."
+    desc: "Gawr Gura wields the Trident of Atlantis to summon eight storm waves within one tile around her for 10 seconds. Each wave deals damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
     desc_template: "Gawr Gura wields the Trident of Atlantis to summon eight storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
     icon: ""
     tags:

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -87,7 +87,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Elementary my dear"
-    desc: "Watson Amelia invokes the Clock of Time, granting an attack speed buff to nearby towers and a large critical chance buff to herself for 4 seconds."
+    desc: "Watson Amelia invokes the Clock of Time, increasing attack speed for herself and nearby towers within 1 tile, and granting herself bonus critical chance for 4 seconds."
     desc_template: "Watson Amelia invokes the Clock of Time, increasing attack speed by {attackSpeedBuff:percent} for herself and nearby towers within 1 tile, and granting herself {critChanceBuff}% critical chance for 4 seconds."
     icon: ""
     tags:


### PR DESCRIPTION
**Summary:** Bring tower skill `desc` copy into line with the `desc` ⇔ `desc_template` parity + skill-copy format rules (display text only).

**How it works:**
- **Gawr Gura**: `desc` (both forms) rewritten to mirror `desc_template`; fixed wave counts written as digits (`4` / `8`) to match the `10s` / `0.1s` style.
- **Watson Amelia**: evolved `desc` rewritten to mirror `desc_template` (it was missing the `within 1 tile` geometry and read as a vague summary).
- Per-level/scaling values become neutral words in `desc` (the template renders the exact %); fixed mechanic values (durations, counts) stay concrete because the player needs them in the fallback — e.g. Kiara keeps `5 seconds`, so Kiara needed no change.

**Implementation Notes:**
- `desc` is the static fallback shown until the production Skill UI renders `desc_template`; keeping them in sync prevents the fallback from reading differently than the live copy.
- Altare is intentionally excluded — its skill is still on the legacy `skill:` block (not migrated).
- Display text only — `desc`/`desc_template` are not consumed by runtime yet, so no in-engine behavior changes (no Godot test needed).
