### PR TITLE
Kiara VFX: pre-launch flash, aim snapshot, first-cast shader warm

### DIFF
--- a/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gd
@@ -32,7 +32,7 @@ const MOUTH_AHEAD  := 0.6      # corridor mouth (slash) this many cells ahead of
 const DURATION := 1.15        # progress 0→1 seconds
 const POP_FRAC := 0.16        # scale_p elastic pop length (fraction of DURATION)
 
-func setup(tower) -> void:
+func setup(tower, context = null) -> void:
 	var cell := float(GridHelper.CELL_SIZE)
 	var total_x := AREA_LEN_CELLS + PAD_L + PAD_R
 	var total_y := AREA_W_CELLS + 2.0 * PAD_TB
@@ -44,13 +44,17 @@ func setup(tower) -> void:
 	var hy := (AREA_W_CELLS * cell * 0.5) / eff.y
 	var cx := (corridor_cx_tiles * cell) / eff.y
 
-	# Orient toward the locked target — same lane as find_multi_enemy.
+	# Orient toward the locked target — same lane as find_multi_enemy. Falls back
+	# to the snapshotted aim_dir if the enemy died during the cast animation.
 	var forward := Vector2.RIGHT
+	var aim := Vector2.ZERO
 	if tower != null and tower.enemy != null and is_instance_valid(tower.enemy):
-		var to_enemy: Vector2 = tower.enemy.global_position - tower.global_position
-		if to_enemy.length() > 0.001:
-			forward = to_enemy.normalized()
-			rotation = forward.angle() + ROT_OFFSET
+		aim = tower.enemy.global_position - tower.global_position
+	elif context != null and context.extra.has("aim_dir"):
+		aim = context.extra["aim_dir"]
+	if aim.length() > 0.001:
+		forward = aim.normalized()
+		rotation = forward.angle() + ROT_OFFSET
 
 	# Push the rect forward so the corridor mouth (slash) sits ~MOUTH_AHEAD cells
 	# ahead of the caster. The rect centre is (hx - cx) author-units ahead of the

--- a/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gdshader
@@ -124,7 +124,7 @@ void fragment() {
 		float charge = smoothstep(0.0, WIN, progress) * (1.0 - smoothstep(WIN, WIN + 0.06, progress));
 		vec2 cp = uv - vec2(LEFT - pull, 0.0);
 		float g = exp(-dot(cp, cp) * 18.0) * (0.82 + 0.18 * sin(progress * 40.0));
-		col += ramp(0.92) * g * charge * 2.2;
+		col += ramp(0.92) * g * charge * 1.4;
 		a = max(a, g * charge);
 	}
 
@@ -235,7 +235,7 @@ void fragment() {
 	// ── Launch flash (brief, no fbm) ────────────────────────────
 	float flash = 1.0 - smoothstep(0.0, 0.12, abs(progress - 0.30));
 	vec2 fp = vec2(uv.x - (LEFT + 0.05), uv.y);
-	col += mix(P_CORE, rim_color.rgb, 0.2) * exp(-dot(fp, fp) * 9.0) * flash * 1.3;
+	col += mix(P_CORE, rim_color.rgb, 0.2) * exp(-dot(fp, fp) * 16.0) * flash * 0.8;
 
 	// ── Terminal impact burst (baked off: burst_mode=1) ─────────
 	if (burst_mode != 1) {

--- a/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_skill_effect.gd
@@ -25,13 +25,19 @@ const POP_FRAC := 0.26         # scale_p elastic pop length (fraction of DURATIO
 
 # Called by SkillActionPlayEffect after the node is in the tree.
 # tower is the caster (Tower); tower.enemy is the locked target, if any.
-func setup(tower) -> void:
+func setup(tower, context = null) -> void:
+	# Aim from the live target, else the snapshotted aim_dir (set in
+	# find_multi_enemy while the enemy was valid) — so a target dying during the
+	# skill animation no longer leaves the slash centred on the tower.
+	var forward := Vector2.ZERO
 	if tower != null and tower.enemy != null and is_instance_valid(tower.enemy):
-		var to_enemy: Vector2 = tower.enemy.global_position - tower.global_position
-		if to_enemy.length() > 0.001:
-			var forward := to_enemy.normalized()
-			global_position += forward * (GridHelper.CELL_SIZE * FORWARD_CELLS)
-			rotation = to_enemy.angle() + ROT_OFFSET
+		forward = tower.enemy.global_position - tower.global_position
+	elif context != null and context.extra.has("aim_dir"):
+		forward = context.extra["aim_dir"]
+	if forward.length() > 0.001:
+		forward = forward.normalized()
+		global_position += forward * (GridHelper.CELL_SIZE * FORWARD_CELLS)
+		rotation = forward.angle() + ROT_OFFSET
 	_spawn_effect()
 
 func _spawn_effect() -> void:

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -121,7 +121,9 @@ static func warmSkillEffectShaders(host: Node) -> void:
 
 	var shaderPaths: Dictionary = {}
 	for k in TowerCenter._towers_data.keys():
-		var data = TowerCenter._towers_data.get(k, null)
+		var entry = TowerCenter._towers_data.get(k, null)
+		# _towers_data values are YAML wrapper dicts; the TowerData is under "data".
+		var data = entry.get("data", null) if entry is Dictionary else entry
 		if data == null:
 			continue
 		for skill in [data.skill, data.evolutionSkill]:

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -103,3 +103,72 @@ static func getSprite(group: String, key: String):
 	if !_sprites.has(group):
 		return null
 	return _sprites[group].get(key, null)
+
+# -----------------------------
+# SKILL-EFFECT SHADER WARM-UP
+# -----------------------------
+
+# A skill-effect shader compiles its GPU pipeline the first time it is drawn,
+# which lands on the visible cast frame → a one-time hitch (worst on heavy
+# shaders like Kiara's evolved Hinotori). Warm every deck skill-effect shader
+# once here at load (behind the deck / loading screen) so the first in-run cast
+# is smooth. Data-driven: reads each tower's normal + evolved play_effect
+# actions and resolves the effect script's `SHADER_PATH` const — no per-tower
+# hardcoding. Fire-and-forget coroutine; needs a host Node for the scene tree.
+static func warmSkillEffectShaders(host: Node) -> void:
+	if host == null or not is_instance_valid(host):
+		return
+
+	var shaderPaths: Dictionary = {}
+	for k in TowerCenter._towers_data.keys():
+		var data = TowerCenter._towers_data.get(k, null)
+		if data == null:
+			continue
+		for skill in [data.skill, data.evolutionSkill]:
+			if skill == null:
+				continue
+			for action in skill.actions:
+				if action is SkillActionPlayEffect and action.effectScriptPath != "":
+					var sp := _shaderPathFromEffectScript(action.effectScriptPath)
+					if sp != "":
+						shaderPaths[sp] = true
+
+	if shaderPaths.is_empty():
+		return
+
+	# Draw each pipeline for two frames on a throwaway CanvasLayer, then free.
+	# Must actually rasterize (not visible=false, and on-screen so it isn't
+	# culled) so the RenderingServer compiles the pipeline; the real shader +
+	# render_mode is used so the key matches the in-run cast. At the shaders'
+	# default `progress`=0 the output is ~invisible, and a 2px alpha-low rect
+	# for two frames is imperceptible.
+	var layer := CanvasLayer.new()
+	host.add_child(layer)
+	for sp in shaderPaths.keys():
+		var shader = load(sp)
+		if shader == null:
+			continue
+		var mat := ShaderMaterial.new()
+		mat.shader = shader
+		var rect := ColorRect.new()
+		rect.size = Vector2(2, 2)
+		rect.position = Vector2.ZERO
+		rect.modulate = Color(1, 1, 1, 0.01)
+		rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		rect.material = mat
+		layer.add_child(rect)
+
+	await host.get_tree().process_frame
+	await host.get_tree().process_frame
+
+	if is_instance_valid(layer):
+		layer.queue_free()
+
+# Reads the `SHADER_PATH` const off an effect controller script without
+# instantiating it. Returns "" if the script has no such const (warm skipped).
+static func _shaderPathFromEffectScript(scriptPath: String) -> String:
+	var script = load(scriptPath)
+	if script == null:
+		return ""
+	var consts: Dictionary = script.get_script_constant_map()
+	return consts.get("SHADER_PATH", "")

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -66,6 +66,9 @@ func _ready():
 	var default = TowerDataLoader.load_data("res://resources/database/towers/", "default_tower")
 	TowerCenter.setDefaultTowerData(default)
 	ResourceManager.loadResources();
+	# Compile skill-effect shader pipelines now (behind the deck/loading screen)
+	# so the first in-run cast doesn't hitch. Fire-and-forget coroutine.
+	ResourceManager.warmSkillEffectShaders(self)
 
 	# Staff system: load data → instantiate entity → wire widget → spawn endpoint sprite.
 	setup_staff()

--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -46,6 +46,11 @@ func find_targets_in_rotated_range(context: SkillContext):
 		if tower.enemy == null:
 			return
 		user_rotation = get_user_rotation(tower, tower.enemy)
+		# Snapshot aim direction while tower.enemy is valid — survives the skill's
+		# animation await even if the enemy dies before play_effect/projectile run.
+		var aim := tower.enemy.global_position - tower.global_position
+		if aim.length() > 0.001:
+			context.extra["aim_dir"] = aim.normalized()
 
 	# Calculate actual dimensions from cell counts
 	var cellSize = GridHelper.CELL_SIZE

--- a/scripts/skill/skillActions/skill_action_play_effect.gd
+++ b/scripts/skill/skillActions/skill_action_play_effect.gd
@@ -22,4 +22,4 @@ func execute(context: SkillContext) -> void:
 	# setup(tower) to rotate/offset themselves toward tower.enemy. Self-centered
 	# effects (e.g. Amelia) omit it and stay put — backward compatible.
 	if effect.has_method("setup"):
-		effect.setup(tower)
+		effect.setup(tower, context)

--- a/scripts/skill/skillActions/skill_create_directional_projectile.gd
+++ b/scripts/skill/skillActions/skill_create_directional_projectile.gd
@@ -29,6 +29,9 @@ func setupProjectile(projectile: Projectile, i: int, context: SkillContext):
 		direction = (context.target[0].global_position - tower.global_position).normalized()
 	elif is_instance_valid(tower.enemy):
 		direction = (tower.enemy.global_position - tower.global_position).normalized()
+	elif context.extra.has("aim_dir"):
+		# Snapshotted at find_multi_enemy time — survives the enemy dying mid-cast.
+		direction = context.extra["aim_dir"]
 
 	# Cap travel by range if specified. Pierce projectiles can have a long
 	# configured lifetime but should stop at the AOE corridor edge.


### PR DESCRIPTION
**Summary:** Three Kiara VFX issues found in in-engine review — the evolved Hinotori pre-launch flash bloomed past the rect, the Flame Slash / Hinotori effect could render on the tower when the target died mid-cast, and the first evolved cast stuttered from shader pipeline compilation.

**How it works:**
- Tone down the two pre-launch left-edge layers (charge orb, launch flash) and tighten the launch-flash gaussian falloff in `kiara_evo_skill_effect.gdshader` so it stays inside the effect rect.
- `find_multi_enemy` snapshots the aim direction (a Vector2) into `context.extra["aim_dir"]` while `tower.enemy` is still valid; the two Kiara effect controllers and the directional projectile consume it as live-enemy → snapshot → existing fallback, so a target dying during the cast animation no longer drops the aim.
- `ResourceManager.warmSkillEffectShaders` draws each deck skill-effect shader for two frames on a throwaway CanvasLayer at load (behind the deck screen) to compile the GPU pipeline off the cast path; called from `game_scene._ready` after `loadResources`.

**Implementation Notes:** `aim_dir` is an additive `context.extra` entry; effect `setup()` gains an optional `context` arg (only the two Kiara controllers define `setup`, so backward-compatible). The warm is data-driven off each effect script's `SHADER_PATH` const (no per-tower hardcode); the TowerData lives under the `_towers_data` wrapper dict's `data` key. Disjoint files from open PRs #36/#37 — no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
