### PR TITLE
Fix tower clearEnemy signal arg/connect errors

### DIFF
--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -240,10 +240,17 @@ func _onEnemyDetected(enemy: Enemy):
 		Utility.ConnectSignal(self.enemy, "onReachEndPoint", Callable(self, "clearEnemy"));
 
 func clearEnemy(_enemy = null, _cause = null, _reward = null):
-	# Default args so this can serve both the 3-arg enemy signals (onDead /
-	# onReachEndPoint) and the 0-arg EnemyDetector.onRemoveTarget — the latter
-	# previously errored ("expected 3 arguments, called with 0") and silently
-	# no-op'd. Net targeting is unchanged: _onEnemyDetected re-sets enemy.
+	# Default args so this serves both the 3-arg enemy signals (onDead /
+	# onReachEndPoint) and the 0-arg EnemyDetector.onRemoveTarget.
+	# Symmetric teardown: drop this enemy's hooks before clearing, so switching
+	# or re-detecting a target never double-connects clearEnemy ("already
+	# connected") nor leaks a stale onDead hook that would clear a later target.
+	if enemy != null and is_instance_valid(enemy):
+		var cb := Callable(self, "clearEnemy")
+		if enemy.is_connected("onDead", cb):
+			enemy.disconnect("onDead", cb)
+		if enemy.is_connected("onReachEndPoint", cb):
+			enemy.disconnect("onReachEndPoint", cb)
 	enemy = null;
 	attacking = false;
 

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -239,7 +239,11 @@ func _onEnemyDetected(enemy: Enemy):
 		Utility.ConnectSignal(self.enemy, "onDead", Callable(self, "clearEnemy"));
 		Utility.ConnectSignal(self.enemy, "onReachEndPoint", Callable(self, "clearEnemy"));
 
-func clearEnemy(_enemy, _cause, _reward):
+func clearEnemy(_enemy = null, _cause = null, _reward = null):
+	# Default args so this can serve both the 3-arg enemy signals (onDead /
+	# onReachEndPoint) and the 0-arg EnemyDetector.onRemoveTarget — the latter
+	# previously errored ("expected 3 arguments, called with 0") and silently
+	# no-op'd. Net targeting is unchanged: _onEnemyDetected re-sets enemy.
 	enemy = null;
 	attacking = false;
 


### PR DESCRIPTION
**Problem:** `EnemyDetector.onRemoveTarget()` (0 args) was wired to `Tower.clearEnemy(_enemy, _cause, _reward)` (3 args), and `_onEnemyDetected` connected the target's `onDead` / `onReachEndPoint` to `clearEnemy` without ever disconnecting them.

**Impact:** Every target change spammed the error log ("Method expected 3 arguments, but called with 0"; "Signal 'onDead'/'onReachEndPoint' is already connected"). The `onRemoveTarget` clear silently no-op'd, and a stale `onDead` hook left on a swapped-away enemy could clear a later, valid target when that old enemy died.

**Fix:** Default `clearEnemy`'s unused args so it serves both the 0-arg detector signal and the 3-arg enemy signals, and have `clearEnemy` disconnect the current enemy's `onDead` / `onReachEndPoint` hooks (is_connected-guarded) before nulling — making connect/disconnect symmetric across every clear path. Net targeting behaviour is unchanged: `_onEnemyDetected` re-sets the enemy right after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
