### PR TITLE
feat: Watson Amelia normal-attack homing projectile + Soft Glow bullet

### DIFF
--- a/resources/combat/bullets/watson_amelia_bullet.tscn
+++ b/resources/combat/bullets/watson_amelia_bullet.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=7 format=3 uid="uid://camelbullet0amly"]
+
+[ext_resource type="Script" path="res://scripts/combat/projectile.gd" id="1_proj"]
+[ext_resource type="Shader" path="res://resources/tower/hololive/en_branch/myth_gen/amelia/normal_effect/amelia_bullet.gdshader" id="2_shdr"]
+
+[sub_resource type="Gradient" id="Gradient_w"]
+offsets = PackedFloat32Array(0, 1)
+colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradTex_w"]
+gradient = SubResource("Gradient_w")
+width = 64
+height = 64
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_b"]
+shader = ExtResource("2_shdr")
+
+[sub_resource type="CircleShape2D" id="Circle_b"]
+radius = 42.0
+
+[node name="WatsonAmeliaBullet" type="Area2D"]
+script = ExtResource("1_proj")
+speed = 4608.0
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+material = SubResource("ShaderMaterial_b")
+texture = SubResource("GradTex_w")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("Circle_b")

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -8,6 +8,17 @@ attack_sound: "hit_amelia"
 open_sound: "debut_amelia"
 evolve_sound: "evo_amelia"
 
+# Normal attack = homing pistol-bullet burst (Soft Glow). Damage lands ONCE per
+# attack (the burst is visual); speed/size/burst/glow_softness are artist-tunable.
+attack:
+  mode: projectile
+  projectile: "res://resources/combat/bullets/watson_amelia_bullet.tscn"
+  vfx_shader: "res://resources/tower/hololive/en_branch/myth_gen/amelia/normal_effect/amelia_bullet.gdshader"
+  speed: 9.0          # tiles/sec
+  size: 84            # bullet diameter px (scales sprite + hitbox)
+  burst: 3            # rounds per shot (visual only)
+  glow_softness: 0.3  # 0 = crisp edge, higher = fuzzier halo
+
 stats:
   - damage: 60
     attackRange: 5.0

--- a/resources/tower/hololive/en_branch/myth_gen/amelia/normal_effect/amelia_bullet.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/amelia/normal_effect/amelia_bullet.gdshader
@@ -1,0 +1,30 @@
+shader_type canvas_item;
+render_mode blend_mix;
+// Watson Amelia — normal-attack bullet (Soft Glow). Clean round shape drawn entirely
+// in-shader (no sprite texture sampled, so no black rim). Warm-gold pistol round.
+// Static look — the bullet's animation is its transform, not the shader (no internal
+// TIME; matches shader.md). Do NOT use MODULATE: a custom-COLOR canvas_item fragment
+// won't auto-apply it and an unknown built-in fails compile silently (square fallback).
+// First production bullet in the game to use a custom shader (others use sprite+tint).
+
+uniform vec4 core_color : source_color = vec4(1.0, 0.98, 0.86, 1.0);
+uniform vec4 mid_color  : source_color = vec4(1.0, 0.84, 0.45, 1.0);
+uniform vec4 edge_color : source_color = vec4(0.86, 0.52, 0.18, 1.0);
+uniform float glow_softness : hint_range(0.0, 0.6) = 0.3;   // halo width (artist-tunable)
+uniform float intensity : hint_range(0.0, 2.0) = 1.0;
+uniform float alpha_mul : hint_range(0.0, 1.0) = 1.0;       // spawn-in / fade hook
+
+void fragment() {
+	vec2 uv = (UV - 0.5) * 2.0;          // -1..1, centre at 0
+	float d = length(uv);                // 0 centre .. 1 circle edge
+
+	// SOFT GLOW: white-hot core -> gold -> warm falloff; halo width = glow_softness
+	// so a bigger bullet won't read as a smudge.
+	vec3 col = mix(core_color.rgb, mid_color.rgb, smoothstep(0.0, 0.7, d));
+	col = mix(col, edge_color.rgb, smoothstep(0.7, 1.0, d));
+	col += core_color.rgb * (1.0 - smoothstep(0.0, 0.5, d)) * 0.6;
+
+	float alpha = (1.0 - smoothstep(1.0 - glow_softness, 1.0, d)) * alpha_mul;
+	col *= intensity;
+	COLOR = vec4(col, alpha);
+}

--- a/scripts/entity/attack_controller.gd
+++ b/scripts/entity/attack_controller.gd
@@ -67,3 +67,78 @@ func dealDamage(enemy: Enemy = null, damage: Damage = null):
 	if (enemy && enemy.has_method("recvDamage")):
 		enemy.recvDamage(damage);
 		executeModifier();
+
+# Normal-attack PROJECTILE path (design A: fire `burst` homing bullets, but only
+# the first carries damage so DPS == one hitscan hit). Fire-and-forget: the attack
+# commits (cooldown/energy) in Tower.attackEnemy at fire time; damage lands on hit.
+func attackProjectile(target: Enemy, dmg: Damage, cfg: TowerAttackConfig) -> void:
+	if target == null or cfg == null or cfg.projectile_scene == null:
+		return
+	if not is_instance_valid(tower):
+		return
+
+	# Captured at fire; if a wave reset bumps it, in-flight callbacks/spawns abort
+	# so a stale bullet can't damage a recycled enemy next wave (see resetForWave).
+	var saved_gen: int = tower.skill_lock_generation
+
+	_spawnBullet(target, cfg, dmg, saved_gen, true)   # damage carrier
+	if cfg.burst > 1:
+		_spawnBurstRemainder(target, cfg, saved_gen)   # cosmetic, staggered
+
+func _spawnBullet(target: Enemy, cfg: TowerAttackConfig, dmg: Damage, saved_gen: int, carries_damage: bool) -> void:
+	if not is_instance_valid(tower) or not is_instance_valid(target):
+		return
+	var proj := cfg.projectile_scene.instantiate() as Projectile
+	if proj == null:
+		return
+	tower.get_tree().root.add_child(proj)
+	proj.global_position = tower.global_position
+	proj.speed = cfg.speed * GridHelper.CELL_SIZE
+	_applyBulletVisual(proj, cfg)
+
+	var cb: ProjectileCallback
+	if carries_damage:
+		# bound saved_gen arrives as the 3rd arg of _onProjectileHit(proj, target, gen)
+		cb = ProjectileCallback.new(Callable(self, "_onProjectileHit").bind(saved_gen), Callable(), Callable())
+	else:
+		cb = ProjectileCallback.new()   # empty -> no damage; fizzles on hit / target death
+	proj.setupTarget(tower, target, dmg, 5.0, cb)
+
+func _spawnBurstRemainder(target: Enemy, cfg: TowerAttackConfig, saved_gen: int) -> void:
+	for i in range(1, cfg.burst):
+		await tower.get_tree().create_timer(0.07).timeout
+		if not is_instance_valid(tower) or tower.skill_lock_generation != saved_gen:
+			return   # wave reset mid-burst (tower survives waves; only gen bumps)
+		if not is_instance_valid(target):
+			return
+		_spawnBullet(target, cfg, null, saved_gen, false)
+
+func _onProjectileHit(proj: Projectile, target, saved_gen: int) -> void:
+	if not is_instance_valid(tower) or tower.skill_lock_generation != saved_gen:
+		return   # stale: a wave reset happened since fire — don't hit a recycled enemy
+	if target is Enemy and is_instance_valid(target):
+		(target as Enemy).recvDamage(proj.damage)
+		executeModifier()
+
+# Scales sprite + collision to cfg.size and pushes the Soft Glow uniforms. Duplicates
+# the shared ShaderMaterial / CircleShape2D so per-bullet (and per-tower) tuning never
+# mutates the scene's shared resources.
+func _applyBulletVisual(proj: Projectile, cfg: TowerAttackConfig) -> void:
+	for child in proj.get_children():
+		if child is Sprite2D:
+			var spr := child as Sprite2D
+			var tex_h: float = float(spr.texture.get_height()) if spr.texture else 64.0
+			spr.scale = Vector2.ONE * (cfg.size / max(tex_h, 1.0))
+			if spr.material is ShaderMaterial:
+				var mat := (spr.material as ShaderMaterial).duplicate() as ShaderMaterial
+				spr.material = mat
+				mat.set_shader_parameter("core_color", cfg.core_color)
+				mat.set_shader_parameter("mid_color", cfg.mid_color)
+				mat.set_shader_parameter("edge_color", cfg.edge_color)
+				mat.set_shader_parameter("glow_softness", cfg.glow_softness)
+		elif child is CollisionShape2D:
+			var cs := child as CollisionShape2D
+			if cs.shape is CircleShape2D:
+				var shape := (cs.shape as CircleShape2D).duplicate() as CircleShape2D
+				shape.radius = cfg.size * 0.5
+				cs.shape = shape

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -196,7 +196,16 @@ func attackEnemy():
 		# this call (bumping skill_lock_generation). If so, skip the post-attack
 		# state writes so mana/cooldown/attacking don't leak into the next wave.
 		var gen := skill_lock_generation
-		attackController.attack(enemy, attackDir, data.getDamage(enemy, self), data.attack_sound, data.attack_vfx);
+		var dmg: Damage = data.getDamage(enemy, self)
+		if data.attack_config != null and data.attack_config.is_projectile():
+			# Projectile mode: spawn homing bullet(s). Damage lands on hit (async),
+			# so the killing-blow guard below won't trip here — attack commits at fire.
+			# Play attack sound at fire; no generic AttackVfx (the bullet IS the vfx).
+			attackController.attackProjectile(enemy, dmg, data.attack_config)
+			if data.attack_sound != "":
+				AudioManager.playSfx(Utility.parse_string_to_enum(SoundDatabase.SFX_NAME, data.attack_sound))
+		else:
+			attackController.attack(enemy, attackDir, dmg, data.attack_sound, data.attack_vfx);
 		if skill_lock_generation != gen:
 			return
 		attacking = true;

--- a/scripts/entity/tower/tower_attack_config.gd
+++ b/scripts/entity/tower/tower_attack_config.gd
@@ -1,0 +1,64 @@
+class_name TowerAttackConfig
+extends RefCounted
+
+## Optional per-tower normal-attack config, parsed from the YAML `attack:` block.
+## Absent block => the tower stays HITSCAN (back-compat); see TowerDataLoader.
+##
+## mode "projectile": the tower fires `burst` homing bullets at its target. Only
+## ONE bullet carries damage (design A: the burst is visual; damage lands once),
+## so balance is unchanged vs a single hitscan hit. Visual tunables (size, colours,
+## glow_softness) drive the bullet's ShaderMaterial; speed is tiles/sec.
+
+const MODE_HITSCAN := "hitscan"
+const MODE_PROJECTILE := "projectile"
+
+var mode: String = MODE_HITSCAN
+var projectile_scene: PackedScene = null
+var vfx_shader: String = ""          # shader path, for ResourceManager warm (avoids first-fire hitch)
+var speed: float = 9.0               # tiles/sec (converted to px at spawn via GridHelper.CELL_SIZE)
+var size: float = 84.0               # bullet diameter px (drives sprite scale AND collision radius)
+var burst: int = 3                   # rounds fired per attack (visual; damage still lands once)
+var glow_softness: float = 0.3       # Soft Glow halo width
+
+# Warm-gold defaults mirror amelia_bullet.gdshader's uniform defaults.
+var core_color: Color = Color(1.0, 0.98, 0.86)
+var mid_color: Color = Color(1.0, 0.84, 0.45)
+var edge_color: Color = Color(0.86, 0.52, 0.18)
+
+func is_projectile() -> bool:
+	return mode == MODE_PROJECTILE
+
+static func from_dict(d: Dictionary) -> TowerAttackConfig:
+	var cfg := TowerAttackConfig.new()
+	cfg.mode = str(d.get("mode", MODE_HITSCAN))
+	cfg.vfx_shader = str(d.get("vfx_shader", ""))
+	cfg.speed = float(d.get("speed", cfg.speed))
+	cfg.size = float(d.get("size", cfg.size))
+	cfg.burst = max(1, int(d.get("burst", cfg.burst)))   # never 0 bullets
+	cfg.glow_softness = float(d.get("glow_softness", cfg.glow_softness))
+	cfg.core_color = _parse_color(d.get("core_color", null), cfg.core_color)
+	cfg.mid_color = _parse_color(d.get("mid_color", null), cfg.mid_color)
+	cfg.edge_color = _parse_color(d.get("edge_color", null), cfg.edge_color)
+
+	var scene_path := str(d.get("projectile", ""))
+	if scene_path != "":
+		var res = load(scene_path)
+		if res is PackedScene:
+			cfg.projectile_scene = res
+		else:
+			push_warning("TowerAttackConfig: projectile scene not found or invalid: " + scene_path)
+
+	if cfg.is_projectile() and cfg.projectile_scene == null:
+		push_warning("TowerAttackConfig: mode=projectile but no valid projectile scene; falling back to hitscan.")
+		cfg.mode = MODE_HITSCAN
+
+	return cfg
+
+# Accepts a "#rrggbb"/"#rrggbbaa" hex string OR an [r,g,b(,a)] float array; else default.
+static func _parse_color(value, default_color: Color) -> Color:
+	if value is String and value != "":
+		return Color(value)
+	if value is Array and value.size() >= 3:
+		var a: float = float(value[3]) if value.size() >= 4 else 1.0
+		return Color(float(value[0]), float(value[1]), float(value[2]), a)
+	return default_color

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -32,6 +32,8 @@ var attack_sound: String = "hit";
 var attack_vfx: String = "atk";
 var open_sound: String = "open";
 var evolve_sound: String = "";
+# Optional normal-attack config (YAML `attack:` block). null = hitscan (back-compat).
+var attack_config: TowerAttackConfig = null;
 
 func getStat():
 	if(!_isEvolved):

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -70,6 +70,10 @@ static func load_data(prefix: String, name: String) -> TowerData:
 	tower.open_sound = data.get("open_sound", "default");
 	tower.evolve_sound = data.get("evolve_sound", "");
 
+	# Optional normal-attack block (absent = hitscan, back-compat).
+	if data.has("attack") and data["attack"] is Dictionary:
+		tower.attack_config = TowerAttackConfig.from_dict(data["attack"])
+
 	_warn_if_passive_slot_present(data, "skills", name)
 	_warn_if_passive_slot_present(data, "evolution_skills", name)
 

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -135,6 +135,13 @@ static func warmSkillEffectShaders(host: Node) -> void:
 					if sp != "":
 						shaderPaths[sp] = true
 
+		# Normal-attack projectile bullet shader (not a skill effect) — warm it too
+		# so the first shot doesn't hitch on pipeline compile. Its shader lives in a
+		# ShaderMaterial inside the bullet .tscn, invisible to the SHADER_PATH scan, so
+		# the path is declared explicitly in the tower's attack_config.vfx_shader.
+		if data.attack_config != null and data.attack_config.vfx_shader != "":
+			shaderPaths[data.attack_config.vfx_shader] = true
+
 	if shaderPaths.is_empty():
 		return
 


### PR DESCRIPTION
**Summary:** Adds an opt-in per-tower `attack:` block (absent = hitscan, fully back-compat). Watson Amelia's normal attack becomes a 3-round homing pistol burst drawn with a custom "Soft Glow" shader bullet. Damage still lands once per attack, so her balance is unchanged.

**How it works:** YAML `attack:` → `TowerAttackConfig` (typed) → `TowerData.attack_config`. `Tower.attackEnemy()` branches to `AttackController.attackProjectile()` for projectile mode: it spawns `burst` homing bullets via the existing `Projectile.setupTarget()`. Only the first bullet carries damage; the rest are cosmetic (empty callback) and fizzle on hit/target-death. Bullet visual is `amelia_bullet.gdshader` on a white `GradientTexture2D` quad; speed/size/colours/glow_softness are pushed onto a per-bullet duplicated `ShaderMaterial`. `ResourceManager.warmSkillEffectShaders` also warms the bullet shader via `attack_config.vfx_shader` to avoid a first-fire hitch.

**Implementation Notes:**
- Damage model "A" (visual burst, single damage event) — 3 bullets, one hit's worth of damage; DPS identical to a hitscan hit.
- Wave-end safe: every bullet sets `shooter = tower` so `Tower.resetForWave()` frees it, and the damage `onHit` aborts if `skill_lock_generation` changed since fire (no cross-wave phantom damage on a recycled enemy).
- First production bullet in the game to use a custom shader (others use sprite + tint) — noted for future bullets.
- Collision radius is driven from `size` at spawn so the hitbox tracks the visual when the artist retunes size.
- Artist-tunable in `watson_amelia.yaml`: `speed`, `size`, `burst`, `glow_softness`, and optional `core/mid/edge` colours.
