### PR TITLE
feat: re-land Shinri passive + G3 Passive runtime (fixes #36 wrong-base merge)

### DIFF
--- a/resources/combat/bullets/shinri_skill_projectile.tscn
+++ b/resources/combat/bullets/shinri_skill_projectile.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/combat/projectile.gd" id="1_proj"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_shinri"]
+size = Vector2(640, 512)
+
+[node name="ShinriSkillProjectile" type="Area2D"]
+script = ExtResource("1_proj")
+
+[node name="Placeholder" type="Polygon2D" parent="."]
+color = Color(1, 0.85, 0.2, 0.55)
+polygon = PackedVector2Array(0, -64, 640, -64, 640, 64, 0, 64)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(320, 0)
+shape = SubResource("RectangleShape2D_shinri")

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -4,71 +4,111 @@ generation: tempus
 attackType: physic
 evolutionCost: 1
 
-# skill: "res://resources/database/skill/takanashi_kiara_skill.tres"
 attack_sound: "hit_shinri"
 open_sound: "debut_shinri"
 evolve_sound: "evo_shinri"
 
+# Josuiji Shinri has no Active skill and no Energy — her kit is a pure Passive.
+# Stats omit mana/intialMana on purpose: with no active skill the tower builds
+# no Energy bar (see Tower._hasActiveSkill / _setupPassive).
 stats:
   - damage: 80
     attackRange: 4.0
     attackSpeed: 140.0
-    mana: 100
-    intialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
   - damage: 160
     attackRange: 4.0
     attackSpeed: 140.0
-    mana: 100
-    intialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
   - damage: 240
     attackRange: 4.0
     attackSpeed: 140.0
-    mana: 100
-    intialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
-skill:
-  name: "Skill"
-  desc: "Just a skill"
-  actions:
-    - type: find_multi_enemy
-      data:
-        width: 3
-        height: 1
-    - type: play_animation
-      data:
-        animation: "skill"
-    - type: attack
-      data:
-        damage: 100
-        damage_type: physic
-    - type: play_animation
-      data:
-        animation: "idle"
+skills:
+  passive:
+    name: "Bull Eyes"
+    names: ["Bull Eyes I", "Bull Eyes II", "Bull Eyes III"]
+    desc: "Josuiji Shinri steadies his aim with every shot. Each normal attack adds a Bull Eyes stack, raising his critical chance; on a critical hit he looses a piercing arrow that tears through every enemy in a line for bonus critical damage, then his aim resets."
+    desc_template: "Each normal attack grants 1 Bull Eyes stack (+{critChancePerStack}% critical chance, no cap). On a critical hit, Josuiji Shinri fires a piercing arrow through all enemies in a 1×4 line dealing critical damage +{bonusCritDamage:percent}, then loses every Bull Eyes stack."
+    icon: ""
+    tags:
+      - crit_rate
+      - projectile
+      - aoe
+      - damage
+      - self
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Bull Eyes Crit Stacking"
+        target:
+          target_team: self
+          target_type: tower
+          target_shape: single
+      - name: "Heartpierce Arrow"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    # Designer-tunable numbers (read by desc_template tokens + the passive runtime).
+    parameters:
+      critChancePerStack: 5
+      # Additive bonus crit damage (x) per level — arrow = ATK × (critDamage + x).
+      bonusCritDamage: [0.2, 0.25, 0.4]
+    # Behavior selector + structural runtime params (not display tokens).
+    behavior: "crit_pierce"
+    reset_on_crit: true
+    projectile: "res://resources/combat/bullets/shinri_skill_projectile.tscn"
+    arrow_speed: 12.0   # tiles/sec
+    arrow_range: 4.0    # tiles (pierce line length)
 
 evolutionStat:
   damage: 400
   attackRange: 4.0
-  attackSpeed: 140
-  mana: 100
-  intialMana: 10
+  attackSpeed: 140.0
   critChance: 50.0
   critMultiplier: 1.5
 
-
-# Optional (only if tower has evolution stats)
-# evolutionStat:
-#   damage: 250
-#   attackRange: 1.2
-#   attackSpeed: 110.0
-#   critChance: 25.0
-#   critMultiplier: 2.0
-#   mana: 80
-#   intialMana: 20
+evolution_skills:
+  passive:
+    name: "Heartpierce Shot"
+    desc: "Josuiji Shinri's aim turns lethal — he starts with a high critical chance and his Bull Eyes stacks no longer fade on a critical hit, so his piercing arrows quickly land with nearly every shot."
+    desc_template: "Each normal attack grants 1 Bull Eyes stack (+{critChancePerStack}% critical chance, no cap). On a critical hit, Josuiji Shinri fires a piercing arrow through all enemies in a 1×4 line dealing critical damage +{bonusCritDamage:percent}. Critical hits no longer consume Bull Eyes stacks."
+    icon: ""
+    tags:
+      - crit_rate
+      - projectile
+      - aoe
+      - damage
+      - self
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Bull Eyes Crit Stacking"
+        target:
+          target_team: self
+          target_type: tower
+          target_shape: single
+      - name: "Heartpierce Arrow"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    parameters:
+      critChancePerStack: 5
+      bonusCritDamage: [1.0]
+    behavior: "crit_pierce"
+    reset_on_crit: false
+    projectile: "res://resources/combat/bullets/shinri_skill_projectile.tscn"
+    arrow_speed: 12.0
+    arrow_range: 4.0

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -34,8 +34,8 @@ skills:
   passive:
     name: "Bull Eyes"
     names: ["Bull Eyes I", "Bull Eyes II", "Bull Eyes III"]
-    desc: "Josuiji Shinri steadies his aim with every shot. Each normal attack adds a Bull Eyes stack, raising his critical chance; on a critical hit he looses a piercing arrow that tears through every enemy in a line for bonus critical damage, then his aim resets."
-    desc_template: "Each normal attack grants 1 Bull Eyes stack (+{critChancePerStack}% critical chance, no cap). On a critical hit, Josuiji Shinri fires a piercing arrow through all enemies in a 1×4 line dealing critical damage +{bonusCritDamage:percent}, then loses every Bull Eyes stack."
+    desc: "Josuiji Shinri steadies his aim with every shot: each non-critical hit adds a Bull Eyes stack, each granting bonus critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for extra critical damage, then loses all Bull Eyes stacks."
+    desc_template: "Josuiji Shinri steadies his aim with every shot: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent}, then loses all Bull Eyes stacks."
     icon: ""
     tags:
       - crit_rate
@@ -80,8 +80,8 @@ evolutionStat:
 evolution_skills:
   passive:
     name: "Heartpierce Shot"
-    desc: "Josuiji Shinri's aim turns lethal — he starts with a high critical chance and his Bull Eyes stacks no longer fade on a critical hit, so his piercing arrows quickly land with nearly every shot."
-    desc_template: "Each normal attack grants 1 Bull Eyes stack (+{critChancePerStack}% critical chance, no cap). On a critical hit, Josuiji Shinri fires a piercing arrow through all enemies in a 1×4 line dealing critical damage +{bonusCritDamage:percent}. Critical hits no longer consume Bull Eyes stacks."
+    desc: "Josuiji Shinri's aim turns lethal: each non-critical hit adds a Bull Eyes stack, each granting bonus critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for extra critical damage — and critical hits no longer consume his Bull Eyes stacks."
+    desc_template: "Josuiji Shinri's aim turns lethal: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent} — and critical hits no longer consume his Bull Eyes stacks."
     icon: ""
     tags:
       - crit_rate

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -31,6 +31,9 @@ var skill_lock_generation: int = 0;
 var skillController: SkillController
 @onready var manaBar = $ManaBar
 
+# Passive runtime (e.g. PassiveCritPierce). null = tower has no passive.
+var passive = null
+
 var onPlace: Callable;
 var onRemove: Callable;
 
@@ -56,14 +59,18 @@ func _ready():
 	var maxMana = stat.mana;
 	var initMana = stat.intialMana;
 
-	if(manaBar != null):
-		manaBar.setup(maxMana, false);
-		manaBar.updateValue(initMana);
+	if _hasActiveSkill():
+		if(manaBar != null):
+			manaBar.setup(maxMana, false);
+			manaBar.updateValue(initMana);
 
-	skillController = SkillController.new(self,maxMana, initMana, data.skill);
-
-	if(skillController != null):
+		skillController = SkillController.new(self,maxMana, initMana, data.skill);
 		Utility.ConnectSignal(skillController, "on_mana_updated", Callable(self, "update_mana_bar"));
+	elif manaBar != null:
+		# No active skill (e.g. passive-only tower) -> no Energy bar.
+		manaBar.visible = false;
+
+	_setupPassive();
 
 	if(attackController != null):
 		attackController.setup(self, Callable(stat, "getAttackDelay"));
@@ -78,6 +85,26 @@ func _ready():
 		towerStar.setStar(data.level);
 
 	isReady = true;
+
+func _hasActiveSkill() -> bool:
+	return data.skill != null and not data.skill.actions.is_empty();
+
+# (Re)create the passive runtime from the current form's passive params.
+# Called on _ready and after evolve (evolutionPassive overrides passive).
+func _setupPassive() -> void:
+	if passive != null:
+		passive.reset();
+		passive = null;
+
+	var params: Dictionary = data.evolutionPassive if data.isEvolved and not data.evolutionPassive.is_empty() else data.passive;
+	if params == null or params.is_empty():
+		return;
+
+	match str(params.get("behavior", "")):
+		"crit_pierce":
+			passive = PassiveCritPierce.new(self, params);
+		_:
+			push_warning("Tower '" + towerName + "': unknown passive behavior '" + str(params.get("behavior", "")) + "'");
 
 func _process(delta):
 	if attackCooldownRemaining > 0.0:
@@ -160,6 +187,8 @@ func evolve():
 			if manaBar != null:
 				manaBar.setup(stat.mana, false)
 				manaBar.updateValue(stat.intialMana)
+
+		_setupPassive()
 	return success
 
 func _play_evolve_sound():
@@ -191,23 +220,33 @@ func attackEnemy():
 		if(spr):
 			spr.flip_h = attackDir == Global.DIRECTION.RIGHT
 
+		# Roll the attack once. Crit is decided here (TowerData.getDamage), and the
+		# crit chance already includes any passive Bull Eyes stacks.
+		var dmg: Damage = data.getDamage(enemy, self)
+
 		# attack() deals damage synchronously. If this is the killing blow on the
 		# wave's last enemy, the onDead cascade runs endWave -> resetForWave INSIDE
 		# this call (bumping skill_lock_generation). If so, skip the post-attack
 		# state writes so mana/cooldown/attacking don't leak into the next wave.
 		var gen := skill_lock_generation
-		var dmg: Damage = data.getDamage(enemy, self)
-		if data.attack_config != null and data.attack_config.is_projectile():
-			# Projectile mode: spawn homing bullet(s). Damage lands on hit (async),
-			# so the killing-blow guard below won't trip here — attack commits at fire.
-			# Play attack sound at fire; no generic AttackVfx (the bullet IS the vfx).
-			attackController.attackProjectile(enemy, dmg, data.attack_config)
+		if passive != null and dmg.isCritical and passive.replaces_attack_on_crit():
+			# Crit -> the passive fires its pierce arrow INSTEAD of the normal hit.
+			passive.on_crit_attack(enemy)
 			if data.attack_sound != "":
 				AudioManager.playSfx(Utility.parse_string_to_enum(SoundDatabase.SFX_NAME, data.attack_sound))
 		else:
-			attackController.attack(enemy, attackDir, dmg, data.attack_sound, data.attack_vfx);
-		if skill_lock_generation != gen:
-			return
+			if data.attack_config != null and data.attack_config.is_projectile():
+				# Projectile mode: spawn homing bullet(s); damage lands on hit (async).
+				# Sound at fire; no generic AttackVfx (the bullet IS the vfx).
+				attackController.attackProjectile(enemy, dmg, data.attack_config)
+				if data.attack_sound != "":
+					AudioManager.playSfx(Utility.parse_string_to_enum(SoundDatabase.SFX_NAME, data.attack_sound))
+			else:
+				attackController.attack(enemy, attackDir, dmg, data.attack_sound, data.attack_vfx);
+			if skill_lock_generation != gen:
+				return
+			if passive != null:
+				passive.on_normal_attack()
 		attacking = true;
 		regenMana(data.getManaRegen());
 		attackCooldownRemaining = data.getAttackDelay()
@@ -395,6 +434,9 @@ func resetForWave():
 	skill_lock_generation += 1
 	enableRegenMana = true
 	clearEnemy(null, null, null)
+
+	if passive != null:
+		passive.reset()
 
 	if skillController != null:
 		skillController.cancel()

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -28,6 +28,10 @@ var buffs: TowerBuffContainer = TowerBuffContainer.new()
 
 @export var skill: Skill;
 var evolutionSkill: Skill = null;
+# Passive slot params (designer-tunable values; behavior lives in code keyed by
+# `behavior`). Empty = no passive. evolutionPassive overrides when evolved.
+var passive: Dictionary = {};
+var evolutionPassive: Dictionary = {};
 var attack_sound: String = "hit";
 var attack_vfx: String = "atk";
 var open_sound: String = "open";
@@ -124,6 +128,12 @@ func removeManaRegenBuff(key):
 
 func getCritChance():
 	return getStat().critChance + buffs.aggregate(BuffInstance.StatType.CRIT_CHANCE)
+
+# Current critical-damage multiplier (base + additive CRIT_DAMAGE_BONUS).
+# Mirrors the `sigmaCD` term in calculateFinalDamage so callers (e.g. the
+# crit_pierce passive arrow) reuse the same additive crit-damage rule.
+func getCritDamage() -> float:
+	return getStat().critMultiplier + buffs.aggregate(BuffInstance.StatType.CRIT_DAMAGE_BONUS)
 
 func addCritChanceBuff(amount: float, key):
 	_addBuffByStat(BuffInstance.StatType.CRIT_CHANCE, amount, key)

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -74,8 +74,8 @@ static func load_data(prefix: String, name: String) -> TowerData:
 	if data.has("attack") and data["attack"] is Dictionary:
 		tower.attack_config = TowerAttackConfig.from_dict(data["attack"])
 
-	_warn_if_passive_slot_present(data, "skills", name)
-	_warn_if_passive_slot_present(data, "evolution_skills", name)
+	tower.passive = _resolve_passive_block(data, "skills")
+	tower.evolutionPassive = _resolve_passive_block(data, "evolution_skills")
 
 	var skillData := _resolve_skill_block(data, "skills", "skill", name, {"actions": []})
 	tower.skill = _parse_skill_data(skillData, "Unnamed Skill", name, "active skill")
@@ -118,15 +118,16 @@ static func _resolve_skill_block(data: Dictionary, slot_root_key: String, legacy
 		return legacy_skill_data
 	return default_block
 
-static func _warn_if_passive_slot_present(data: Dictionary, slot_root_key: String, tower_name: String) -> void:
+static func _resolve_passive_block(data: Dictionary, slot_root_key: String) -> Dictionary:
 	if not data.has(slot_root_key):
-		return
-
+		return {}
 	var slot_root = data[slot_root_key]
 	if not (slot_root is Dictionary):
-		return
-	if slot_root.has("passive") and slot_root["passive"] != null:
-		push_warning("Tower YAML '" + tower_name + "': '" + slot_root_key + ".passive' is currently ignored until passive skill runtime exists.")
+		return {}
+	var passive = slot_root.get("passive", null)
+	if passive is Dictionary:
+		return passive
+	return {}
 
 static func _parse_skill_data(skill_data: Dictionary, default_name: String, tower_name: String, source_name: String) -> Skill:
 	var skill := Skill.new()

--- a/scripts/skill/passive/passive_crit_pierce.gd
+++ b/scripts/skill/passive/passive_crit_pierce.gd
@@ -1,0 +1,93 @@
+class_name PassiveCritPierce
+extends RefCounted
+
+# Crit-pierce passive (Josuiji Shinri "Bull Eyes" / "Heartpierce Shot").
+#
+# Loop:
+#   - Each NON-crit auto-attack -> +1 Bull Eyes stack. Stacks are kept as a single
+#     counter and pushed as ONE CRIT_CHANCE buff = crit_chance_per_stack * stacks
+#     (state stays O(1); no per-stack BuffInstance churn). No cap -- overcap is a
+#     deliberate buffer against enemy crit-chance debuffs.
+#   - The auto-attack that CRITS fires a guaranteed-crit pierce arrow (w1xhN line)
+#     toward the crit target instead of the normal single hit (tower replaces the
+#     instant hit with this). The crit shot does not grant a stack.
+#   - After the crit: reset_on_crit true  -> clear stacks (Bull Eyes normal form)
+#                     reset_on_crit false -> keep stacks (Heartpierce Shot / evolve)
+#
+# Crit roll itself stays in TowerData.calculateFinalDamage (uses getCritChance,
+# which already includes the Bull Eyes CRIT_CHANCE buff), so the ramp is automatic.
+
+const BULL_EYES_KEY := "bull_eyes"
+
+var tower: Tower
+var crit_chance_per_stack: float
+var reset_on_crit: bool
+var bonus_crit_damage: Array          # per-level additive crit damage (x); index by level-1
+var projectile_scene: PackedScene
+var arrow_speed: float                # tiles/sec
+var arrow_range: float                # tiles
+var stacks: int = 0
+
+func _init(owner: Tower, params: Dictionary) -> void:
+	tower = owner
+	# Designer-tunable numbers live under `parameters` (matches active-skill YAML).
+	var parameters: Dictionary = params.get("parameters", {})
+	crit_chance_per_stack = float(parameters.get("critChancePerStack", 5))
+	bonus_crit_damage = parameters.get("bonusCritDamage", [0.0])
+	# Structural/runtime params stay top-level.
+	reset_on_crit = bool(params.get("reset_on_crit", true))
+	arrow_speed = float(params.get("arrow_speed", 12.0))
+	arrow_range = float(params.get("arrow_range", 4.0))
+	var path: String = str(params.get("projectile", ""))
+	if path != "" and ResourceLoader.exists(path):
+		projectile_scene = load(path)
+
+# Does a crit replace the normal instant hit with the arrow? (Tower asks before attacking.)
+func replaces_attack_on_crit() -> bool:
+	return projectile_scene != null
+
+# Called after a NON-crit auto-attack landed.
+func on_normal_attack() -> void:
+	stacks += 1
+	tower.data.addCritChanceBuff(crit_chance_per_stack * stacks, BULL_EYES_KEY)
+
+# Called when the auto-attack rolled a crit; fires the arrow and updates stacks.
+func on_crit_attack(target: Enemy) -> void:
+	_fire_arrow(target)
+	if reset_on_crit:
+		reset()
+
+# Wave reset / re-setup: drop all stacks and the Bull Eyes buff.
+func reset() -> void:
+	stacks = 0
+	tower.data.removeCritChanceBuff(BULL_EYES_KEY)
+
+func _bonus_for_level() -> float:
+	if not (bonus_crit_damage is Array) or bonus_crit_damage.is_empty():
+		return 0.0
+	var idx: int = clampi(tower.data.level - 1, 0, bonus_crit_damage.size() - 1)
+	return float(bonus_crit_damage[idx])
+
+func _fire_arrow(target: Enemy) -> void:
+	if projectile_scene == null or not is_instance_valid(target) or not is_instance_valid(tower):
+		return
+
+	# Guaranteed-crit arrow damage = TotalAttack * (crit damage + x), additive x.
+	var crit_damage: float = tower.data.getCritDamage() + _bonus_for_level()
+	var value: int = int(tower.data.getTotalAttack() * crit_damage)
+	var dmg := Damage.new(tower, value, tower.data.attackType, true)
+
+	var direction: Vector2 = (target.global_position - tower.global_position).normalized()
+	var lifetime: float = arrow_range / arrow_speed if arrow_speed > 0.0 else 1.0
+
+	var p: Projectile = projectile_scene.instantiate() as Projectile
+	p.global_position = tower.global_position
+	tower.get_tree().root.add_child(p)
+	p.speed = arrow_speed * GridHelper.CELL_SIZE
+	p.prevent_rehit = true
+	p.setup_direction(tower, direction, dmg, lifetime,
+			ProjectileCallback.new(Callable(self, "_on_arrow_hit"), Callable(), Callable()))
+
+func _on_arrow_hit(_projectile: Projectile, hit) -> void:
+	if hit is Enemy and is_instance_valid(hit):
+		(hit as Enemy).recvDamage(_projectile.damage)


### PR DESCRIPTION
**Summary:** Re-lands PR #36 (G3 Passive runtime + Josuiji Shinri "Bull Eyes / Heartpierce Shot") onto `main`. #36 was merged to the wrong base (`fix/tower-skill-template`), so its passive system never reached `main`. Cherry-picks the two passive commits (`64e6f6d`, `674be3a`) onto current `main` (post-#41) and combines them with the Amelia projectile path.

**How it works:** Passive slots load via `_resolve_passive_block` (replaces the `_warn_if_passive_slot_present` stub). `PassiveCritPierce` (`passive_crit_pierce.gd`) implements Shinri's crit-replace: on a crit, fire a pierce arrow instead of the normal hit, accumulating "Bull Eyes" stacks. `Tower.attackEnemy()` branches: passive crit-replace -> else (projectile or hitscan). Loader threads `passive`/`evolutionPassive` onto `TowerData`.

**Implementation Notes:**
- Re-land only — code was already Lead-approved in #36; this fixes the wrong-base merge.
- Combined cleanly with #41 (Amelia projectile) in `attackEnemy`: passive wrapper + projectile/hitscan inner branch.
- Cherry-picked the specific commits (NOT the stale `fix/tower-skill-template` branch) -> does not revert #38 shader-warm / #39.
- After merge: retire `fix/tower-skill-template`.
