### PR TITLE
fix(sound): restore missing evo_* VOICE_NAME enum members (main fails to open)

### DIFF
--- a/resources/database/sound/sound_database.gd
+++ b/resources/database/sound/sound_database.gd
@@ -31,7 +31,17 @@ enum VOICE_NAME {
 	debut_altare,
 	debut_kiara,
 	debut_amelia,
-	evo_kiara
+	evo_syrios,
+	evo_hakka,
+	evo_bettel,
+	evo_gura,
+	evo_shinri,
+	evo_flayon,
+	evo_caliope,
+	evo_ina,
+	evo_altare,
+	evo_kiara,
+	evo_amelia
 }
 
 static var bgm: Dictionary = {


### PR DESCRIPTION
**Problem:** `origin/main` fails to open in Godot — `Parser Error: Cannot find member "evo_syrios" in base "SoundDatabase.VOICE_NAME"`. The evolve-voice dict references 11 `evo_*` voices but the `VOICE_NAME` enum only defined `evo_kiara` (the other 10 were lost in a prior merge).

**Impact:** Project does not parse/run at all — blocks everyone and all testing.

**Fix:** Restore the 10 missing members (`evo_syrios/hakka/bettel/gura/shinri/flayon/caliope/ina/altare/amelia`) to the `VOICE_NAME` enum in `sound_database.gd`. Verified: no remaining used-but-undefined `VOICE_NAME.*` keys. Out-of-scope hotfix (pre-existing main breakage, not from feature work).
