### PR TITLE
feat(kiara): bind Phoenix DOT + skill damage to parameters (re-stage #40)

### DIFF
--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -38,7 +38,7 @@ skills:
     name: "Flame Slash"
     names: ["Flame Slash I", "Flame Slash II", "Flame Slash III"]
     desc: "Kiara swings her immortal phoenix flame sword forward through a 3×1 tile area, dealing physical damage. All enemies hit are scorched by Phoenix Flame, taking magic damage every second for 5 seconds."
-    desc_template: "Kiara swings her immortal phoenix flame sword forward through a 3×1 tile area, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every {phoenixInterval} second(s) for {phoenixDuration} seconds."
+    desc_template: "Kiara swings her immortal phoenix flame sword forward through a 3×1 tile area, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
     icon: ""
     tags:
       - damage
@@ -61,8 +61,9 @@ skills:
           target_type: enemy
           target_shape: area
     cast_time: 0.2
-    # Parameters bound to desc_template tokens + read by skill actions.
-    # Edit numbers here to retune balance; descriptions auto-sync via {token}.
+    # Single source for balance + desc: skill actions read these via
+    # damage_multiplier_param_name / *_param, and desc_template tokens render the
+    # same values — edit here to retune both at once.
     parameters:
       # Per-tier direct hit scaling — Skill Multiplier (% of Kiara attack).
       # Direct damage = damageMultiplier × Kiara totalAttack.
@@ -70,8 +71,7 @@ skills:
       # Phoenix Flame DOT — per-tick magic damage = phoenixAtk×attack + phoenixHp×targetMaxHp.
       phoenixAtk: 0.10       # 10% of Kiara's attack stat per tick (snapshot at apply)
       phoenixHp: 0.01        # 1% of target's max HP per tick
-      phoenixDuration: 5.0   # Total DOT duration in seconds
-      phoenixInterval: 1.0   # Seconds between ticks (5 ticks over 5s with default)
+      phoenixDuration: 5.0   # Total DOT duration in seconds (bound to runtime)
     actions:
       - type: "find_multi_enemy"
         data:
@@ -87,16 +87,15 @@ skills:
           effect_script: "res://resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_skill_effect.gd"
       - type: "attack"
         data:
-          # Per-tier skill multiplier — matches `parameters.damageMultiplier`.
-          # SkillActionAttack reads this array directly (no param_name needed).
-          damage_multiplier: [1.4, 1.5, 1.7]
+          # Skill multiplier reads parameters.damageMultiplier (single source w/ desc).
+          damage_multiplier_param_name: "damageMultiplier"
           can_crit: false   # Kiara design: skill cannot crit
           status_effects:
             - type: "phoenix_flame"
-              duration: 5.0
-              interval: 1.0
-              attack_percent: 0.10
-              max_hp_percent: 0.01
+              duration_param: "phoenixDuration"   # binds to parameters (single source)
+              interval: 1.0                       # fixed default tick
+              attack_percent_param: "phoenixAtk"
+              max_hp_percent_param: "phoenixHp"
       - type: "play_animation"
         data:
           animation: "idle"
@@ -115,7 +114,7 @@ evolution_skills:
   active:
     name: "Hinotori"
     desc: "Kiara empowers her sword with sacred phoenix fire and unleashes a devastating slash forward through a 3×5 tile corridor, dealing massive physical damage. All enemies hit are scorched by Phoenix Flame, taking magic damage every second for 5 seconds."
-    desc_template: "Kiara empowers her sword with sacred phoenix fire and unleashes a devastating slash forward through a 3×5 tile corridor, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every {phoenixInterval} second(s) for {phoenixDuration} seconds."
+    desc_template: "Kiara empowers her sword with sacred phoenix fire and unleashes a devastating slash forward through a 3×5 tile corridor, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
     icon: ""
     tags:
       - damage
@@ -139,9 +138,10 @@ evolution_skills:
           target_type: enemy
           target_shape: area
     cast_time: 0.2
-    # Parameters bound to desc_template tokens + read by skill actions.
-    # Projectile knobs (speed/lifetime/max_range) live in the action data below
-    # — they're not duplicated here to avoid drift between display and runtime.
+    # Single source for balance + desc: actions read these (projectile damage via
+    # damage_multiplier_param_name default, DOT via *_param); desc_template tokens
+    # render the same values. Projectile knobs (speed/lifetime/max_range) live in
+    # the action data below.
     parameters:
       # Direct hit scaling — Skill Multiplier (% of Kiara attack).
       # Direct damage = damageMultiplier × Kiara totalAttack (≈ 300 × 3.0 = 900).
@@ -149,8 +149,7 @@ evolution_skills:
       # Phoenix Flame DOT (same formula as Normal; applied to every enemy in path).
       phoenixAtk: 0.10       # 10% of Kiara's attack stat per tick
       phoenixHp: 0.01        # 1% of target's max HP per tick
-      phoenixDuration: 5.0   # Total DOT duration in seconds
-      phoenixInterval: 1.0   # Seconds between ticks
+      phoenixDuration: 5.0   # Total DOT duration in seconds (bound to runtime)
     actions:
       - type: "find_multi_enemy"
         data:
@@ -175,15 +174,15 @@ evolution_skills:
           speed: 12.0          # Tiles per second (12 tiles/s ≈ fast straight shot)
           lifetime: 1.5        # Max lifetime cap in seconds (failsafe if max_range unset)
           max_range: 5.0       # Max travel distance in tiles — projectile despawns past this
-          damage_multiplier: 3.0   # Used when damage_multiplier_param_name is empty
+          damage_multiplier: 3.0   # Fallback; runtime reads parameters.damageMultiplier (default param name)
           damage_type: "physic"
           can_crit: false
           status_effects:
             - type: "phoenix_flame"
-              duration: 5.0
-              interval: 1.0
-              attack_percent: 0.10
-              max_hp_percent: 0.01
+              duration_param: "phoenixDuration"   # binds to parameters (single source)
+              interval: 1.0                       # fixed default tick
+              attack_percent_param: "phoenixAtk"
+              max_hp_percent_param: "phoenixHp"
       - type: "play_animation"
         data:
           animation: "idle"

--- a/scripts/entity/staff/staff_data_loader.gd
+++ b/scripts/entity/staff/staff_data_loader.gd
@@ -38,7 +38,7 @@ static func load_data(prefix: String, name: String) -> StaffData:
 
 		var actions: Array[SkillAction] = []
 		for action_data in skill_dict.get("actions", []):
-			var action = SkillUtility.ParseAction(action_data)
+			var action = SkillUtility.ParseAction(action_data, skill.parameters)
 			if action != null:
 				actions.append(action)
 			else:

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -133,9 +133,12 @@ static func _parse_skill_data(skill_data: Dictionary, default_name: String, towe
 	var skill := Skill.new()
 	var skillActions: Array[SkillAction] = []
 	var action_data_list = skill_data.get("actions", [])
+	# Read parameters before the action loop so actions can bind to them
+	# (skill.parameters is set later in _apply_skill_data).
+	var parameters = skill_data.get("parameters", {})
 	if action_data_list is Array:
 		for act in action_data_list:
-			var action = SkillUtility.ParseAction(act)
+			var action = SkillUtility.ParseAction(act, parameters)
 			if action != null:
 				skillActions.append(action)
 			else:

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -27,7 +27,7 @@ static func ParseSkill(skillDataList: Array) -> Array[Skill]:
 			print("Warning: Skill", s, "not found");
 	return result
 
-static func ParseAction(data: Dictionary) -> SkillAction:
+static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillAction:
 	var skillType = data.get("type", "");
 	var skill: SkillAction;
 	match skillType:
@@ -137,8 +137,25 @@ static func ParseAction(data: Dictionary) -> SkillAction:
 			skill = SkillActionAttack.new();
 			var skillData = data.get("data", {});
 			skill.damage = skillData.get("damage", 0);
-			# Phase 3 Block C — Skill Multiplier
-			if skillData.has("damage_multiplier"):
+			# Phase 3 Block C — Skill Multiplier. A param-name (single source with
+			# desc) wins over a literal; resolved here at parse time into
+			# damageMultiplierPerLevel/damageMultiplier. (The projectile actions
+			# instead resolve via context.getParameter at runtime — both give
+			# correct per-level behavior.)
+			if skillData.has("damage_multiplier_param_name"):
+				var pname = skillData["damage_multiplier_param_name"]
+				if parameters.has(pname):
+					var pval = parameters[pname]
+					if typeof(pval) == TYPE_ARRAY:
+						var pArr: Array[float] = []
+						for v in pval:
+							pArr.append(float(v))
+						skill.damageMultiplierPerLevel = pArr
+					else:
+						skill.damageMultiplier = float(pval)
+				else:
+					push_warning("attack: damage_multiplier_param_name '" + str(pname) + "' not in skill parameters.")
+			elif skillData.has("damage_multiplier"):
 				var dm = skillData["damage_multiplier"]
 				if typeof(dm) == TYPE_ARRAY:
 					var dmArr: Array[float] = []
@@ -163,7 +180,7 @@ static func ParseAction(data: Dictionary) -> SkillAction:
 			if attackStatusEffectDataList.size() > 0:
 				var attackStatusEffects: Array[StatusEffect] = [];
 				for statusEffectData in attackStatusEffectDataList:
-					var se: StatusEffect = StatusEffectUtility.ParseStatusEffect(statusEffectData);
+					var se: StatusEffect = StatusEffectUtility.ParseStatusEffect(statusEffectData, parameters);
 					if se:
 						attackStatusEffects.append(se);
 				skill.statusEffects = attackStatusEffects;
@@ -200,14 +217,10 @@ static func ParseAction(data: Dictionary) -> SkillAction:
 			var statusEffects: Array[StatusEffect] = [];
 			var statusEffectDataList = skillData.get("status_effects", []);
 			if(statusEffectDataList.size() > 0):
-				print("data list:", statusEffectDataList, ", skill data keys:", skillData.keys());
 				for statusEffectData in statusEffectDataList:
-					print("parsing status effect data: ", statusEffectData);
-					var se: StatusEffect = StatusEffectUtility.ParseStatusEffect(statusEffectData);
+					var se: StatusEffect = StatusEffectUtility.ParseStatusEffect(statusEffectData, parameters);
 					if se:
 						statusEffects.append(se);
-				print("skill statusEffects:", skill.statusEffects);
-				print("status effect ", statusEffects)
 				skill.statusEffects = statusEffects;
 			skill.projectileTemplate = load(skillData.get("projectile", "res://resources/combat/bullets/gawr_gura_skill_projectile.tscn"));
 		"create_directional_projectile":
@@ -226,7 +239,7 @@ static func ParseAction(data: Dictionary) -> SkillAction:
 			if dirStatusEffectDataList.size() > 0:
 				var dirStatusEffects: Array[StatusEffect] = [];
 				for statusEffectData in dirStatusEffectDataList:
-					var se: StatusEffect = StatusEffectUtility.ParseStatusEffect(statusEffectData);
+					var se: StatusEffect = StatusEffectUtility.ParseStatusEffect(statusEffectData, parameters);
 					if se:
 						dirStatusEffects.append(se);
 				skill.statusEffects = dirStatusEffects;

--- a/scripts/status_effect/status_effect_utility.gd
+++ b/scripts/status_effect/status_effect_utility.gd
@@ -1,8 +1,10 @@
 class_name StatusEffectUtility
 
-static func ParseStatusEffect(data: Dictionary):
+static func ParseStatusEffect(data: Dictionary, parameters: Dictionary = {}):
 	var type = data.get("type", "");
-	var duration = data.get("duration", 0);
+	# Numeric fields prefer parameters[<field>_param] when present (single source
+	# shared with desc_template tokens), else the literal.
+	var duration = _resolveField(data, parameters, "duration", "duration_param", 0);
 	var statusEffect: StatusEffect;
 	match (type):
 		"stun":
@@ -29,12 +31,30 @@ static func ParseStatusEffect(data: Dictionary):
 			# Kiara's DOT debuff. Damage formula resolves at tick time using
 			# snapshot of caster attack captured in _on_apply (set_applier
 			# is called by the cast site between duplicate() and addStatusEffect).
+			# interval stays a fixed default tick; duration / attack% / max-hp% can
+			# bind to parameters via *_param for single-source retuning.
 			var interval = float(data.get("interval", 1.0));
-			var atkPct = float(data.get("attack_percent", 0.10));
-			var hpPct = float(data.get("max_hp_percent", 0.01));
+			var atkPct = float(_resolveField(data, parameters, "attack_percent", "attack_percent_param", 0.10));
+			var hpPct = float(_resolveField(data, parameters, "max_hp_percent", "max_hp_percent_param", 0.01));
 			statusEffect = PhoenixFlameEffect.new(float(duration), interval, atkPct, hpPct);
 		_:
 			push_error("invalid type for status effect, type: ", type);
 			return null;
 
 	return statusEffect;
+
+# Resolve a numeric field: when data has <param_key>, read a SCALAR from
+# parameters[name] (keeps desc + runtime in sync); arrays aren't valid for a
+# status-effect scalar, so warn and fall back to the literal field.
+static func _resolveField(data: Dictionary, parameters: Dictionary, literal_key: String, param_key: String, default_value):
+	if data.has(param_key):
+		var pname = data[param_key];
+		if parameters.has(pname):
+			var pval = parameters[pname];
+			if typeof(pval) == TYPE_ARRAY:
+				push_warning("Status effect param '" + str(pname) + "' is an array; expected scalar — using literal '" + literal_key + "'.");
+			else:
+				return pval;
+		else:
+			push_warning("Status effect param '" + str(pname) + "' not in skill parameters — using literal '" + literal_key + "'.");
+	return data.get(literal_key, default_value);


### PR DESCRIPTION
**Summary:** Re-stages PR #40 (Kiara Phoenix DOT + skill damage bound to `parameters`) onto current `main`. The original #40 branch was cut from a stale pre-#38 base; this is a clean cherry-pick of its real commit `0fed4d8` onto fresh main. Supersedes #40 (close the old PR after this merges).

**How it works:** `parameters` drive BOTH description and runtime, killing display/runtime drift. `ParseAction(data, parameters)` threads params into the attack action (`damage_multiplier_param_name`) and status effects; `ParseStatusEffect` resolves `<field>_param` scalars (duration / atk% / maxHP%) with an array guard; tower & staff loaders pass skill `parameters` through. `takanashi_kiara.yaml` binds Phoenix duration/atk%/hp% + normal damage via `*_param`; interval fixed 1s.

**Implementation Notes:**
- Re-stage only — code is Tiew's original #40 work; this fixes the stale base.
- Cherry-pick `0fed4d8` applied clean onto main (post-#42); 5 files, no conflicts.
- Removes 4 leftover debug prints in `skill_utility.gd`.
