### PR TITLE
Per-beat duration for combo skill animation

### DIFF
--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -62,7 +62,8 @@ skills:
           target_team: enemy
           target_type: enemy
           target_shape: area
-    cast_time: 0.0
+    # cast_time: 0.0   # DISABLED — skill/combo timing lives in play_animation `duration` (see combo template below).
+    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     parameters:
       damageBonus:
         - 0.10
@@ -112,6 +113,49 @@ skills:
       - type: play_animation
         data:
           animation: "idle"
+      # ─────────────────────────────────────────────────────────────────
+      # COMBO SKILL (หลายท่าใน cast เดียว) — pattern แบบ "beat"
+      #
+      # 1 beat = play_animation(1 คลิป non-loop) + duration(วินาที) + effect ต่อท้าย
+      #   • duration ยืด/ย่อคลิปให้พอดีเวลา → ดาเมจ/effect ลงที่ ~80% ของ duration
+      #   • ชื่อคลิป: skill_1, skill_2, ... skill_N (ต้องมีใน SpriteFrames ของ .tscn, loop=false)
+      #   • ท่าเชื่อม (เช่น ควงปืน) วาดไว้ "หัวคลิป" ของ beat ถัดไป — ไม่มีคลิป "pre" แยก
+      #   • beat สุดท้ายปิดด้วย play_animation "idle" เสมอ (คืน speed ปกติ)
+      #   • ห้ามต่อ delay หลัง play_animation ของ beat — คุมจังหวะที่ duration พอ
+      #   • cast_time ตั้ง 0 สำหรับคอมโบ (ท่าชาร์จก่อนฟันใส่หัวคลิป beat 1)
+      #   • ใช้ได้ทั้ง skills.active และ evolution_skills.active เหมือนกัน
+      #
+      # ตัวอย่าง 2 beat (ฟันดาบ → ควงปืนยิง) — ของจริงดู regis_altare.yaml:
+      #   actions:
+      #     - type: find_multi_enemy
+      #       data:
+      #         width: 3
+      #         height: 1
+      #     - type: play_animation        # beat 1: ดาเมจฟันลง ~0.4s
+      #       data:
+      #         animation: "skill_1"
+      #         duration: 0.5
+      #     - type: attack
+      #       data:
+      #         damage: 100
+      #         damage_type: physic
+      #     - type: clear_enemy
+      #     - type: find_multi_enemy
+      #       data:
+      #         width: 1
+      #         height: 3
+      #     - type: play_animation        # beat 2: ท่าควงปืนอยู่หัวคลิปนี้, ยิงลง ~0.8s
+      #       data:
+      #         animation: "skill_2"
+      #         duration: 1.0
+      #     - type: attack
+      #       data:
+      #         damage: 150
+      #         damage_type: magic
+      #     - type: play_animation
+      #       data:
+      #         animation: "idle"
+      # ─────────────────────────────────────────────────────────────────
   passive: null
 
 # evolutionStat = stat ตอน evolve (block เดียว ไม่ใช่ array)
@@ -146,7 +190,8 @@ evolution_skills:
           target_team: enemy
           target_type: enemy
           target_shape: area
-    cast_time: 0.0
+    # cast_time: 0.0   # DISABLED — skill/combo timing lives in play_animation `duration` (see combo template below).
+    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     parameters:
       damageBonus:
         - 0.30

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -58,7 +58,8 @@ skills:
           target_team: enemy
           target_type: tower
           target_shape: area
-    cast_time: 0.0   # combo/skill timing now lives in play_animation duration
+    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
+    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     parameters:
       damageMultiplier:
         - 1.2
@@ -125,7 +126,8 @@ evolution_skills:
           target_team: enemy
           target_type: tower
           target_shape: area
-    cast_time: 0.0   # combo/skill timing now lives in play_animation duration
+    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
+    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     parameters:
       damageMultiplier:
         - 2.0

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -58,13 +58,20 @@ skills:
           target_team: enemy
           target_type: tower
           target_shape: area
-    cast_time: 0.5
+    cast_time: 0.0   # combo/skill timing now lives in play_animation duration
     parameters:
       damageMultiplier:
         - 1.2
         - 1.3
         - 1.5
     actions:
+      - type: "play_animation"
+        data:
+          animation: "skill"
+          duration: 0.5   # cast pose only (generic clip; verify in-engine)
+      - type: "play_animation"
+        data:
+          animation: "idle"   # return to idle BEFORE the 10s persistent storm so the cast pose doesn't hold during it
       - type: "create_circle_projectile"
         data:
           # circle_radius: orbit radius in tile units (1.0 = projectiles trace a circle 1 tile from the tower).
@@ -118,11 +125,18 @@ evolution_skills:
           target_team: enemy
           target_type: tower
           target_shape: area
-    cast_time: 0.5
+    cast_time: 0.0   # combo/skill timing now lives in play_animation duration
     parameters:
       damageMultiplier:
         - 2.0
     actions:
+      - type: "play_animation"
+        data:
+          animation: "skill"
+          duration: 0.5   # cast pose only (generic clip; verify in-engine)
+      - type: "play_animation"
+        data:
+          animation: "idle"   # return to idle BEFORE the 10s persistent storm so the cast pose doesn't hold during it
       - type: "create_circle_projectile"
         data:
           circle_radius: 1.25

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -43,9 +43,10 @@ skill:
         width: 3
         height: 1
         cancel_when_empty: true
-    - type: play_animation
+    - type: play_animation        # beat 1: clip scaled to 0.5s; impact lands ~0.4s
       data:
         animation: "skill_1"
+        duration: 0.5
     - type: attack
       data:
         damage: 100
@@ -56,12 +57,10 @@ skill:
         width: 1
         height: 3
         cancel_when_empty: false
-    - type: play_animation
-      data:
+    - type: play_animation        # beat 2: clip scaled to 1.0s; impact lands ~0.8s
+      data:                        # pacing lives in duration — no trailing delay
         animation: "skill_2"
-    - type: delay
-      data:
-        delay: 0.5
+        duration: 1.0
     - type: attack
       data:
         damage: 150

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -60,7 +60,8 @@ skills:
           target_team: enemy
           target_type: enemy
           target_shape: area
-    cast_time: 0.2
+    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
+    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     # Single source for balance + desc: skill actions read these via
     # damage_multiplier_param_name / *_param, and desc_template tokens render the
     # same values — edit here to retune both at once.
@@ -80,6 +81,7 @@ skills:
       - type: "play_animation"
         data:
           animation: "skill"
+          duration: 0.2   # skill clip scaled to 0.2s; effect lands ~0.16s (tune in-engine)
       - type: "play_effect"
         data:
           # Flame Slash crescent VFX — orients toward tower.enemy and lands
@@ -137,7 +139,8 @@ evolution_skills:
           target_team: enemy
           target_type: enemy
           target_shape: area
-    cast_time: 0.2
+    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
+    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     # Single source for balance + desc: actions read these (projectile damage via
     # damage_multiplier_param_name default, DOT via *_param); desc_template tokens
     # render the same values. Projectile knobs (speed/lifetime/max_range) live in
@@ -158,6 +161,7 @@ evolution_skills:
       - type: "play_animation"
         data:
           animation: "skill"
+          duration: 0.2   # skill clip scaled to 0.2s; effect lands ~0.16s (tune in-engine)
       - type: "play_effect"
         data:
           # Hinotori phoenix VFX (Wingsweep, magma-violet) — orients onto the

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -65,7 +65,8 @@ skills:
           target_team: self
           target_type: tower
           target_shape: single
-    cast_time: 0.5
+    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
+    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     parameters:
       attackSpeedBuff:
         - 0.10
@@ -75,6 +76,7 @@ skills:
       - type: "play_animation"
         data:
           animation: "skill"
+          duration: 0.5   # skill clip scaled to 0.5s; effect lands ~0.4s (tune in-engine)
       - type: "play_effect"
         data:
           effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gd"
@@ -125,7 +127,8 @@ evolution_skills:
           target_team: self
           target_type: tower
           target_shape: single
-    cast_time: 0.5
+    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
+    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     parameters:
       attackSpeedBuff:
         - 0.50
@@ -135,6 +138,7 @@ evolution_skills:
       - type: "play_animation"
         data:
           animation: "skill"
+          duration: 0.5   # skill clip scaled to 0.5s; effect lands ~0.4s (tune in-engine)
       - type: "play_effect"
         data:
           effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gd"

--- a/scripts/animation_controller.gd
+++ b/scripts/animation_controller.gd
@@ -8,8 +8,10 @@ func _init(animSprite: AnimatedSprite2D, defaultAnimation: String):
 	anim = animSprite;
 	default = defaultAnimation if defaultAnimation != "" else "idle";
 
-	#anim.connect("animation_finished", Callable(self, "anim_finish"))
+	# frame_changed drives the ~80% early finish; animation_finished is a backstop so a
+	# 1-frame clip (which never emits frame_changed) still resolves and can't hang a skill.
 	Utility.ConnectSignal(anim,"frame_changed", Callable(self, "anim_finish"))
+	Utility.ConnectSignal(anim,"animation_finished", Callable(self, "anim_finish"))
 	play(defaultAnimation);
 
 func playDefault():

--- a/scripts/animation_controller.gd
+++ b/scripts/animation_controller.gd
@@ -25,9 +25,26 @@ func play(animationName: String, speed: float = 1):
 	return true;
 
 func anim_finish():
-	var currFrame: float = anim.frame;
 	var maxFrame: float = anim.sprite_frames.get_frame_count(current) - 1;
+	if maxFrame <= 0:
+		# 1-frame clip (maxFrame == 0 -> 0/0 = NaN) or missing clip (count 0 -> -1):
+		# treat as instantly finished so a skill await never hangs.
+		on_animation_finished.emit(anim.animation);
+		return;
+	var currFrame: float = anim.frame;
 	if (currFrame / maxFrame > 0.8):
 		on_animation_finished.emit(anim.animation);
+
+func get_native_duration(name: String) -> float:
+	if not anim.sprite_frames.has_animation(name):
+		return 0.0;
+	var frames: int = anim.sprite_frames.get_frame_count(name);
+	var fps: float = anim.sprite_frames.get_animation_speed(name);
+	if frames <= 0 or fps <= 0.0:
+		return 0.0;
+	return frames / fps;
+
+func has_animation(name: String) -> bool:
+	return anim.sprite_frames.has_animation(name);
 
 signal on_animation_finished(name: String)

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -307,6 +307,16 @@ func play_animation(name: String, speed: float = 1):
 		return anim.play(name, speed);
 	return false;
 
+func get_animation_duration(name: String) -> float:
+	if(anim != null):
+		return anim.get_native_duration(name);
+	return 0.0;
+
+func has_animation(name: String) -> bool:
+	if(anim != null):
+		return anim.has_animation(name);
+	return false;
+
 func play_animation_default():
 	if(anim != null):
 		anim.playDefault();

--- a/scripts/skill/skillActions/skill_action_play_anim.gd
+++ b/scripts/skill/skillActions/skill_action_play_anim.gd
@@ -3,6 +3,7 @@ class_name SkillActionPlayAnimation
 
 @export var animationName: String = ""
 @export var animationSpeed: float = 1.0
+@export var duration: float = 0.0
 
 func execute(context: SkillContext):
 	if animationName == "":
@@ -11,7 +12,25 @@ func execute(context: SkillContext):
 	if !context.user.has_method("play_animation"):
 		context.cancel = true;
 
-	if !context.user.play_animation(animationName, animationSpeed):
+	if(context.cancel):
+		return
+
+	# Missing clip: skip this beat instead of hanging the await. (anim_finish
+	# also guards 1-frame/missing clips, but a missing clip may never emit
+	# frame_changed.) Skip without cancelling so the rest of the combo runs.
+	if context.user.has_method("has_animation") and !context.user.has_animation(animationName):
+		push_warning("SkillActionPlayAnimation: missing animation '" + animationName + "' - skipping beat");
+		return
+
+	# duration (seconds) stretches/compresses the clip to fit; falls back to
+	# animationSpeed when unset. The ~80% impact point scales automatically.
+	var speed: float = animationSpeed
+	if duration > 0.0 and context.user.has_method("get_animation_duration"):
+		var native: float = context.user.get_animation_duration(animationName)
+		if native > 0.0:
+			speed = native / duration
+
+	if !context.user.play_animation(animationName, speed):
 		context.cancel = true;
 
 	if(context.cancel):

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -133,6 +133,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill = SkillActionPlayAnimation.new();
 			var skillData = data.get("data", {});
 			skill.animationName = skillData.get("animation", "");
+			skill.duration = float(skillData.get("duration", 0.0));
 		"attack":
 			skill = SkillActionAttack.new();
 			var skillData = data.get("data", {});


### PR DESCRIPTION
**Summary:** Adds a per-beat `duration` (seconds) knob to the `play_animation` skill action so combo Active Skills can be authored as an ordered list of timed "beats" — one non-looping clip per beat, the gameplay effect resolving at ~80% of each beat. Formalizes the combo authoring convention (tech + artist) that previously existed only ad-hoc in Regis Altare.

**How it works:** `play_animation` takes an optional `duration`; `SkillActionPlayAnimation` scales the clip via `speed = native_clip_seconds / duration` (native length from `AnimationController.get_native_duration`). The existing ~80% frame-ratio finish point (`anim_finish`) shifts proportionally, so the effect lands at ~`0.8 × duration`. Omitting `duration` keeps native speed (`animationSpeed`), so existing skills are unchanged. Beats play back-to-back via the existing per-action `await` in `BaseSkillController`.

**Implementation Notes:**
- Anti-hang at the root: `anim_finish` now treats 1-frame / missing clips (`maxFrame <= 0`) as instantly finished; `SkillActionPlayAnimation` also skips a missing-clip beat with a warning (a missing clip may never emit `frame_changed`).
- Demo towers migrate `cast_time` → per-beat `duration` (Kiara / Amelia / Gura). `cast_time` (an idle pre-delay *before* the cast, not a skill-anim window) is commented out and kept for possible future use — team decision pending.
- Gura's skill is persistent (10s storm that `await`s its lifetime); it returns to `idle` before the storm so the cast pose does not hold for the whole channel.
- `getAttackAnimationSpeed` (tower_stat.gd) is dead code and was intentionally NOT reused; the scale is computed fresh.
- Regis Altare's combo is not testable in-engine yet (pre-existing area-detection issue, tracked separately); the `duration` mechanism was verified via Kiara / Amelia / Gura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
