### PR TITLE
Finalize Regis Altare: skill priority, combo targeting, new structure

### DIFF
--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -103,6 +103,7 @@ skills:
         data:
           width: 1
           height: 3
+          cancel_when_empty: false    # combo beat: whiff (play anim, no dmg), don't cancel
       - type: play_animation
         data:
           animation: "skill_2"
@@ -126,7 +127,7 @@ evolutionStat:
   mana: 120
   intialMana: 40
 
-# Evolved Active Skill — "Blue Hero Finish" (same combo, stronger + longer gun line).
+# Evolved Active Skill — "Heroic Requiem" (same combo, stronger + longer gun line).
 evolution_skills:
   active:
     name: "Heroic Requiem"
@@ -188,6 +189,7 @@ evolution_skills:
         data:
           width: 1
           height: 6
+          cancel_when_empty: false    # combo beat: whiff (play anim, no dmg), don't cancel
       - type: play_animation
         data:
           animation: "skill_2"

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -4,7 +4,6 @@ generation: tempus
 attackType: physic
 evolutionCost: 1
 
-# skill: "res://resources/database/skill/takanashi_kiara_skill.tres"
 attack_sound: "hit_altare"
 open_sound: "debut_altare"
 evolve_sound: "evo_altare"
@@ -12,79 +11,193 @@ evolve_sound: "evo_altare"
 stats:
   - damage: 80
     attackRange: 1.0
-    attackSpeed: 110
-    mana: 120
-    intialMana: 40
+    attackSpeed: 90.0
     critChance: 0
     critMultiplier: 1.5
+    mana: 120
+    intialMana: 40
 
   - damage: 140
     attackRange: 1.0
-    attackSpeed: 110.0
-    mana: 120
-    intialMana: 40
+    attackSpeed: 90.0
     critChance: 0
     critMultiplier: 1.5
+    mana: 120
+    intialMana: 40
 
   - damage: 200
     attackRange: 1.0
-    attackSpeed: 110.0
-    mana: 120
-    intialMana: 40
+    attackSpeed: 90.0
     critChance: 0
     critMultiplier: 1.5
+    mana: 120
+    intialMana: 40
 
-skill:
-  name: "Skill"
-  desc: "Just a skill"
-  actions:
-    - type: find_multi_enemy
-      data:
-        width: 3
-        height: 1
-        cancel_when_empty: true
-    - type: play_animation        # beat 1: clip scaled to 0.5s; impact lands ~0.4s
-      data:
-        animation: "skill_1"
-        duration: 0.5
-    - type: attack
-      data:
-        damage: 100
-        damage_type: physic
-    - type: clear_enemy
-    - type: find_multi_enemy
-      data:
-        width: 1
-        height: 3
-        cancel_when_empty: false
-    - type: play_animation        # beat 2: clip scaled to 1.0s; impact lands ~0.8s
-      data:                        # pacing lives in duration — no trailing delay
-        animation: "skill_2"
-        duration: 1.0
-    - type: attack
-      data:
-        damage: 150
-        damage_type: magic
-    - type: play_animation
-      data:
-        animation: "idle"
+# Active Skill — "Gun and Blade" combo (2 beats, both physic).
+# Reference example for: combo beat model + armor-shred debuff + guaranteed crit.
+skills:
+  active:
+    name: "Gun and Blade"
+    names: ["Gun and Blade I", "Gun and Blade II", "Gun and Blade III"]
+    desc: "Altare strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals physical damage and reduces armor by 5% for 2s, then a gun volley down a 1x3 lane deals physical damage with a guaranteed critical."
+    desc_template: "Altare strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} physical damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a gun volley down a 1x3 lane deals {beat2Damage:percent} physical damage with a guaranteed critical."
+    icon: ""
+    tags:
+      - damage
+      - attack
+      - aoe
+      - combo
+      - debuff
+      - enemy
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Gun Blade Slash"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+      - name: "Armor Break"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+      - name: "Gun Volley"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    parameters:
+      beat1Damage:
+        - 1.5
+        - 1.75
+        - 2.25
+      beat2Damage:
+        - 1.2
+        - 1.4
+        - 1.6
+      armorShred: 0.05
+      shredDuration: 2.0
+    actions:
+      - type: find_multi_enemy        # beat 1: slash, 3 wide x 1 deep
+        data:
+          width: 3
+          height: 1
+      - type: play_animation
+        data:
+          animation: "skill_1"
+          duration: 0.5
+      - type: attack
+        data:
+          damage_multiplier_param_name: "beat1Damage"
+          damage_type: physic
+          status_effects:
+            - type: "DecreaseDefBuff"           # positive magnitude in YAML, applied as a reduction
+              decreaseValue_param: "armorShred"
+              duration_param: "shredDuration"
+              refresh_on_apply: true
+      - type: clear_enemy
+      - type: find_multi_enemy        # beat 2: gun line, 1 wide x 3 deep
+        data:
+          width: 1
+          height: 3
+      - type: play_animation
+        data:
+          animation: "skill_2"
+          duration: 1.0
+      - type: attack
+        data:
+          damage_multiplier_param_name: "beat2Damage"
+          damage_type: physic
+          force_crit: true                       # guaranteed critical
+      - type: play_animation
+        data:
+          animation: "idle"
+  passive: null
 
 evolutionStat:
   damage: 300
   attackRange: 1.0
-  attackSpeed: 110
-  mana: 120
-  intialMana: 40
+  attackSpeed: 90.0
   critChance: 50.0
   critMultiplier: 1.5
+  mana: 120
+  intialMana: 40
 
-
-# Optional (only if tower has evolution stats)
-# evolutionStat:
-#   damage: 250
-#   attackRange: 1.2
-#   attackSpeed: 110.0
-#   critChance: 25.0
-#   critMultiplier: 2.0
-#   mana: 80
-#   intialMana: 20
+# Evolved Active Skill — "Blue Hero Finish" (same combo, stronger + longer gun line).
+evolution_skills:
+  active:
+    name: "Heroic Requiem"
+    desc: "Altare's finisher strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals physical damage and reduces armor by 5% for 2s, then a long gun volley down a 1x6 lane deals physical damage with a guaranteed critical."
+    desc_template: "Altare's finisher strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} physical damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a long gun volley down a 1x6 lane deals {beat2Damage:percent} physical damage with a guaranteed critical."
+    icon: ""
+    tags:
+      - damage
+      - attack
+      - aoe
+      - combo
+      - debuff
+      - enemy
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Gun Blade Slash"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+      - name: "Armor Break"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+      - name: "Gun Volley"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    parameters:
+      beat1Damage: 3.0
+      beat2Damage: 2.0
+      armorShred: 0.05
+      shredDuration: 2.0
+    actions:
+      - type: find_multi_enemy        # beat 1: slash, 3 wide x 1 deep
+        data:
+          width: 3
+          height: 1
+      - type: play_animation
+        data:
+          animation: "skill_1"
+          duration: 0.5
+      - type: attack
+        data:
+          damage_multiplier_param_name: "beat1Damage"
+          damage_type: physic
+          status_effects:
+            - type: "DecreaseDefBuff"
+              decreaseValue_param: "armorShred"
+              duration_param: "shredDuration"
+              refresh_on_apply: true
+      - type: clear_enemy
+      - type: find_multi_enemy        # beat 2: longer gun line, 1 wide x 6 deep
+        data:
+          width: 1
+          height: 6
+      - type: play_animation
+        data:
+          animation: "skill_2"
+          duration: 1.0
+      - type: attack
+        data:
+          damage_multiplier_param_name: "beat2Damage"
+          damage_type: physic
+          force_crit: true
+      - type: play_animation
+        data:
+          animation: "idle"
+  passive: null

--- a/scripts/combat/hitbox.gd
+++ b/scripts/combat/hitbox.gd
@@ -74,7 +74,6 @@ func _detect():
 
 	# Check areas and bodies so we cover both area-based and body-based enemies
 	for node in get_overlapping_areas() + get_overlapping_bodies():
-		print("overlapping node:", node)
 		var enemy_node := _resolve_enemy(node)
 		if enemy_node == null:
 			continue

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -116,13 +116,18 @@ func _process(delta):
 		position = GridHelper.snapToGrid(get_viewport().size, get_global_mouse_position());
 		updateTowerState();
 
-	if skillController && !usingSkill:
-		if(skillController.currentMana == skillController.maxMana && !attacking):
-			await useSkill();
-			if not is_instance_valid(self):
-				return
+	# Energy-full skill takes priority over auto-attack: while skillReady, the attack
+	# below is suppressed so a swing can't kill the target before the skill fires. Cast
+	# only with a locked target; a fizzle (target outside the skill box) keeps Energy
+	# full by design and the attack stays suppressed until find lands a target.
+	var skillReady := skillController != null && skillController.currentMana == skillController.maxMana
 
-	if enableAttack && !attacking && !usingSkill:
+	if skillReady && !usingSkill && !attacking && is_instance_valid(enemy):
+		await useSkill();
+		if not is_instance_valid(self):
+			return
+
+	if enableAttack && !attacking && !usingSkill && !skillReady:
 		attackEnemy();
 
 func setup(id: String, onPlace: Callable, onRemove: Callable):

--- a/scripts/skill/skillActions/skill_action_attack.gd
+++ b/scripts/skill/skillActions/skill_action_attack.gd
@@ -19,6 +19,10 @@ class_name SkillActionAttack
 # Crit toggle — false disables crit roll for this skill (e.g. Kiara fire blade)
 @export var canCrit: bool = true
 
+# Guaranteed crit — true forces every hit to crit regardless of crit chance
+# (e.g. Regis Altare beat-2 gun shot). Still applies the normal crit multiplier.
+@export var forcedCrit: bool = false
+
 # Damage type — defaults to tower.data.attackType (set damageTypeOverride=true to use this)
 @export var damageType: Damage.DamageType = Damage.DamageType.PHYSIC
 @export var damageTypeOverride: bool = false
@@ -76,7 +80,8 @@ func execute(context: SkillContext):
 			if not is_instance_valid(target) or not target.has_method("recvDamage"):
 				continue
 			# randi_range(1, 100) → 100 values for exact critChance/100 probability (§6.2 #1 fix)
-			var isCrit: bool = canCrit and critChance > 0 and randi_range(1, 100) <= critChance
+			# forcedCrit overrides the roll (guaranteed crit, e.g. Altare beat 2).
+			var isCrit: bool = forcedCrit or (canCrit and critChance > 0 and randi_range(1, 100) <= critChance)
 			var hitDamage: float = hitBase
 			if isCrit:
 				# §5: Critical Damage = 1 + (1 × (ΣCD − 1)) = ΣCD

--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -43,14 +43,25 @@ func find_targets_in_rotated_range(context: SkillContext):
 		center_on_anchor = true
 	elif context.user is Tower:
 		var tower := context.user as Tower
-		if tower.enemy == null:
-			return
-		user_rotation = get_user_rotation(tower, tower.enemy)
-		# Snapshot aim direction while tower.enemy is valid — survives the skill's
-		# animation await even if the enemy dies before play_effect/projectile run.
-		var aim := tower.enemy.global_position - tower.global_position
-		if aim.length() > 0.001:
-			context.extra["aim_dir"] = aim.normalized()
+		if tower.enemy != null:
+			user_rotation = get_user_rotation(tower, tower.enemy)
+			# Snapshot aim direction while tower.enemy is valid — survives the skill's
+			# animation await even if the enemy dies before play_effect/projectile run.
+			var aim := tower.enemy.global_position - tower.global_position
+			if aim.length() > 0.001:
+				context.extra["aim_dir"] = aim.normalized()
+		else:
+			# Combo beat fallback: the locked enemy died (e.g. an earlier beat killed it),
+			# so reuse the snapshotted aim direction. The box still fires along the cast
+			# direction and hits live enemies in it, instead of no-op'ing on an empty target.
+			# aim_dir is the first-beat snapshot UNLESS an earlier beat re-locked a live
+			# enemy via the detector and refreshed it — both are correct.
+			# aim_dir.angle() - PI/2 matches get_user_rotation's angle_to_point(target) - PI/2 (Godot 4.x).
+			var aim_dir = context.extra.get("aim_dir", null)
+			if aim_dir is Vector2:
+				user_rotation = aim_dir.angle() - PI / 2
+			else:
+				return
 
 	# Calculate actual dimensions from cell counts
 	var cellSize = GridHelper.CELL_SIZE

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -172,6 +172,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 					hdArr.append(float(v))
 				skill.hitDistribution = hdArr
 			skill.canCrit = skillData.get("can_crit", true)
+			skill.forcedCrit = skillData.get("force_crit", false)
 			if skillData.has("damage_type"):
 				skill.damageType = Utility.parse_string_to_enum(Damage.DamageType, skillData["damage_type"])
 				skill.damageTypeOverride = true

--- a/scripts/status_effect/status_effect_utility.gd
+++ b/scripts/status_effect/status_effect_utility.gd
@@ -15,6 +15,16 @@ static func ParseStatusEffect(data: Dictionary, parameters: Dictionary = {}):
 		"IncreaseDefBuff":
 			var increaseValue = data.get("increaseValue", 0.0);
 			statusEffect = IncreaseDefBuff.new(duration, increaseValue);
+		"DecreaseDefBuff":
+			# Armor shred. Designer enters a POSITIVE magnitude in YAML (e.g. 0.05 =
+			# "reduce armor by 5%") so desc tokens read cleanly; applied as an armor
+			# DECREASE by reusing IncreaseDefBuff with the value negated.
+			# decreaseValue is param-bindable (single source with desc_template).
+			# refresh_on_apply keeps one entry per enemy + refreshes duration on re-apply,
+			# so expiry is reliable instead of relying on the strongest-effect tick path.
+			var decreaseValue = _resolveField(data, parameters, "decreaseValue", "decreaseValue_param", 0.0);
+			statusEffect = IncreaseDefBuff.new(duration, -float(decreaseValue));
+			statusEffect.refresh_on_apply = data.get("refresh_on_apply", false);
 		"IncreaseMArmorPercentBuff":
 			var increaseValue = data.get("increaseValue", 0.0);
 			statusEffect = IncreaseMArmorPercentBuff.new(duration, increaseValue);


### PR DESCRIPTION
**Summary:** Finalize Regis Altare (tech + balance + mechanics) and migrate it from the legacy `skill:` block to the new `skills.active` / `evolution_skills.active` structure. Also makes Energy-full skills take priority over auto-attack and adds a robust combo beat-targeting standard.

**How it works:**
- **Energy-full cast priority** — in `tower.gd` `_process`, a full-Energy tower suppresses its auto-attack and casts when a target is locked (`is_instance_valid(enemy)`), holding for a target instead of letting a swing kill it first. Uniform across all skill towers.
- **Combo beat targeting** — `find_multi_enemy` falls back to an aim-direction snapshot (`context.extra["aim_dir"]`) when the locked enemy died, so later beats fire along the cast direction and hit followers. The first beat cancels on no target (Energy-safe, same as a single-beat skill like Kiara); later beats whiff (play the anim, no damage).
- **Altare skill** — combo "Gun and Blade" / evo "Heroic Requiem": beat 1 slash (w3×h1) + armor-shred debuff, beat 2 guaranteed-crit gun line (w1×h3, evo w1×h6). `attackSpeed` 110→90. All balance values are YAML `parameters`; `desc_template` is fully tokenized.

**Implementation Notes:**
- New opt-in skill knobs, no new class: `force_crit` on `SkillActionAttack`; a `DecreaseDefBuff` status type that reuses `IncreaseDefBuff` with a negated value (designer enters a positive magnitude via `decreaseValue_param`, plus `refresh_on_apply` for reliable single-entry expiry).
- Structural skill numbers (beat areas, anim `duration`) intentionally stay in action `data`; a tracked follow-up will parameterize them post-demo.
- VFX is out of scope for this pass.
