### PR TITLE
Fix EffectArea signal arity error spam

### DIFF
--- a/scripts/area/effect_area.gd
+++ b/scripts/area/effect_area.gd
@@ -5,9 +5,7 @@ var collisionShape = null
 
 func _base_setup(shape: Shape2D,callback: EffectAreaCallback = null):
 	Utility.ConnectSignal(self, "area_entered", callback.onEnter)
-	Utility.ConnectSignal(self, "area_shape_entered", callback.onEnter)
 	Utility.ConnectSignal(self, "area_exited", callback.onExit)
-	Utility.ConnectSignal(self, "area_shape_exited", callback.onExit)
 
 	if(collisionShape == null):
 		collisionShape = CollisionShape2D.new()


### PR DESCRIPTION
**Problem:** `EffectArea._base_setup` wired Godot's 4-arg `area_shape_entered`/`area_shape_exited` signals to the 1-arg `onEnter`/`onExit` callbacks.
**Impact:** Red error spam ("Method expected 1 arguments, but called with 4") on every area overlap; those handlers never executed.
**Fix:** Drop the two `area_shape_*` connections in `scripts/area/effect_area.gd`. The existing 1-arg `area_entered`/`area_exited` connections already perform all detection, so the removed lines were both redundant and broken. No consumer reads shape-index data; single-shape geometry on both enemy and effect areas makes the signal families 1:1 equivalent.
