### PR TITLE
Remove orphaned debug script test_effect_area.gd

### DIFF
--- a/scripts/area/test_effect_area.gd
+++ b/scripts/area/test_effect_area.gd
@@ -1,7 +1,0 @@
-extends CollisionShape2D
-
-func _on_circle_effect_area_area_entered(area: Area2D) -> void:
-	print(area, " entered in area entered");
-
-func _on_circle_effect_area_area_shape_entered(area_rid: RID, area: Area2D, area_shape_index: int, local_shape_index: int) -> void:
-	print(area, " entered in area shape entered");


### PR DESCRIPTION
**Summary:** Remove the orphaned debug script `scripts/area/test_effect_area.gd` — dead code left over from a deleted scene.
**How it works:** The script is a `CollisionShape2D` that only `print()`s on area overlap, via editor-auto-generated `_on_circle_effect_area_*` handlers. It is referenced by nothing: no `.tscn`/`.tres`, no `project.godot` entry, no `preload`/`load`, and no `class_name`. `CircleEffectArea` is constructed in code (`.new()`) and never instantiated from a scene, so the node this script was meant to attach to does not exist anywhere in the project.
**Implementation Notes:** Godot 4.3 emits no `.gd.uid` files, so there is no uid-based reference path either. The only on-disk reference is the regenerable Godot editor filesystem cache. Pure deletion; no other files touched. Flagged by /scrutinize during PR #47.
