### PR TITLE
fix: preload enemies for the selected map, not hardcoded forest01

### DIFF
--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -80,7 +80,9 @@ func _ready():
 
 	show_popup_panel();
 
-	ResourceManager.preloadEnemy("forest01", ["boss","elite", "normal"]);
+	# Map folder name = selected_map_file minus ".yaml" (e.g. "forest01.yaml" -> "forest01"),
+	# so a new map preloads its own enemy set instead of always forest01's.
+	ResourceManager.preloadEnemy(TowerCenter.selected_map_file.get_basename(), ["boss","elite", "normal"]);
 
 	mission = Mission.new();
 


### PR DESCRIPTION
**Problem:** `game_scene._ready()` preloaded enemies with a literal map name — `ResourceManager.preloadEnemy("forest01", …)` — while the wave data itself loads from `TowerCenter.selected_map_file`. The two sources could disagree.

**Impact:** With only `forest01` in the demo this is invisible, but a second map would load forest01's enemy textures and tier mapping instead of its own (missing sprites, wrong Elite/Normal damage tier).

**Fix:** Derive the map folder from `TowerCenter.selected_map_file` (`get_basename()` strips `.yaml`) so the preload always matches the map being played. Review finding R8.
