### PR TITLE
Pacing beat before wave-end tower-select popup

### DIFF
--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -23,6 +23,10 @@ var staff: Staff = null
 # (currently 2.5 s) so the popup arrives during the last fade beat.
 const BOSS_WAVE_END_POPUP_DELAY := 2.2
 
+# Pacing beat between a regular (non-boss) wave end and the wave-end popup, so the
+# wave-clear effects land before the UI cuts in. Inspector-editable feel knob.
+@export var wave_end_popup_delay: float = 0.6
+
 var mission: Mission = null;
 var t: Tower = null
 var state: String = ""
@@ -219,16 +223,22 @@ func on_wave_ended():
 	if towerFactory != null:
 		towerFactory.onWaveEnd()
 
-	# Hold the wave-end popup back briefly on boss waves so the token drop
-	# visual at the boss death position is readable before the popup covers it.
-	if waveController != null and waveController.isBossWave:
-		await get_tree().create_timer(BOSS_WAVE_END_POPUP_DELAY).timeout
-		# Re-entry guard: scene may have been freed mid-wait (e.g. game-over) OR the staff
-		# may have died during the await window leaving the scene alive but the game over.
-		if !is_instance_valid(self):
-			return
-		if state == "game_over":
-			return
+	# Pacing beat before the popup so wave-clear effects land first. Boss waves hold
+	# longer (token-drop visual); regular waves get the short feel beat.
+	var popup_delay: float = BOSS_WAVE_END_POPUP_DELAY if (waveController != null and waveController.isBossWave) else wave_end_popup_delay
+	await get_tree().create_timer(popup_delay).timeout
+	# Re-entry guard: scene may have been freed mid-wait (e.g. game-over) OR the staff
+	# may have died during the await window leaving the scene alive but the game over.
+	if !is_instance_valid(self):
+		return
+	if state == "game_over":
+		return
+	# The beat keeps state == "wave", so the staff-skill button stays live during it.
+	# If the player entered targeting mid-beat, cancel it so the popup does not open over
+	# the cast indicator and a card-click cannot also commit a (limited-use) staff skill
+	# onto the now-empty field. Field is clear, so a pending cast has no value anyway.
+	if state == "staff_skill_casting":
+		_cancel_staff_skill_cast()
 
 	# At configured wave milestones, offer one of the remaining decks BEFORE
 	# the normal tower-select popup. Pre-filter empty decks so the popup never


### PR DESCRIPTION
**Summary:** Add a short, designer-tunable pacing beat before the wave-end tower-select / deck popup on regular waves, so the wave-clear effects land before the UI cuts in. Addresses feedback that the popup appeared too abruptly.

**How it works:** `on_wave_ended()` in `game_scene.gd` now awaits a delay for every wave before showing the popup: boss waves keep the existing 2.2s token-drop hold (`BOSS_WAVE_END_POPUP_DELAY`), regular waves use the new `@export var wave_end_popup_delay` (default 0.6s, tunable in the inspector). The boss and regular paths share one await + the existing re-entry guards (scene-freed / game-over), so the deck-unlock-wave popup gets the beat for free.

**Implementation Notes:**
- Persistent-FX cleanup timing is intentionally unchanged: `towerFactory.onWaveEnd()` / `resetForWave()` still run immediately at clear, so the fixed beat never waits on long-lived effects (Gura storm, auras) - it only delays the popup.
- The beat keeps `state == "wave"`, leaving the staff-skill button live during the wait. A new guard cancels any in-progress staff-skill cast before the popup opens, preventing a card-click from also committing a limited-use staff skill onto the cleared field. This also closes the same pre-existing race on boss waves.
- New delay uses `@export` (not `const`) so it is inspector-tunable, matching the existing `deck_unlock_waves` precedent; `BOSS_WAVE_END_POPUP_DELAY` stays a `const` (system timing locked to the token-drop animation).
