### PR TITLE
MOBA-style toggle-cancel for staff skill button

### DIFF
--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -34,6 +34,8 @@ var _active_popup: UITowerSelect = null
 # Staff skill casting state — indicator follows mouse; LeftClick commits, RightClick / ESC cancels.
 var _skill_cast_indicator: SkillCastIndicator = null
 var _state_before_skill_cast: String = ""
+# Ref to the Staff HUD widget so _input can ask whether a click landed on the skill button.
+var _staff_widget: StaffWidget = null
 
 func _input(event):
 	if state == "tower_placement" and event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
@@ -48,6 +50,10 @@ func _input(event):
 	elif state == "staff_skill_casting":
 		if event is InputEventMouseButton and event.pressed:
 			if event.button_index == MOUSE_BUTTON_LEFT:
+				# Click on the skill button itself -> let the button's pressed signal
+				# toggle-cancel (MOBA-style); do NOT commit a cast under the button.
+				if _staff_widget != null and _staff_widget.is_skill_button_hovered():
+					return
 				_commit_staff_skill_cast()
 			elif event.button_index == MOUSE_BUTTON_RIGHT:
 				_cancel_staff_skill_cast()
@@ -135,11 +141,11 @@ func setup_staff():
 	Utility.ConnectSignal(staff, "died", Callable(self, "_on_staff_died"))
 
 	# Wire HUD widget — replaces the legacy ManagerImg / PlayerUI HealthBar binding.
-	var staff_widget: StaffWidget = get_node_or_null("GameUI/PlayerUI/Player/StaffWidget") as StaffWidget
-	if staff_widget != null:
-		staff_widget.setup(staff)
-		# Widget button click → Staff.requestCastSkill (emits skill_cast_requested if usable).
-		Utility.ConnectSignal(staff_widget, "skill_pressed", Callable(staff, "requestCastSkill"))
+	_staff_widget = get_node_or_null("GameUI/PlayerUI/Player/StaffWidget") as StaffWidget
+	if _staff_widget != null:
+		_staff_widget.setup(staff)
+		# Widget button click → toggle: cancel if already aiming, else request a cast.
+		Utility.ConnectSignal(_staff_widget, "skill_pressed", Callable(self, "_on_staff_skill_button_pressed"))
 	else:
 		push_warning("GameScene.setup_staff: StaffWidget not found at GameUI/PlayerUI/Player/StaffWidget")
 
@@ -186,9 +192,24 @@ func _on_staff_died():
 
 # === Staff skill casting ===
 
+func _on_staff_skill_button_pressed():
+	# Skill button toggle (MOBA-style): press while aiming = cancel, otherwise request a cast.
+	if staff == null:
+		return
+	# Guard against re-entry across the wave-end popup beat (PR #51): never enter aiming
+	# once a popup is open or the run is over.
+	if _popup_open or state == "game_over":
+		return
+	if state == "staff_skill_casting":
+		_cancel_staff_skill_cast()
+	else:
+		staff.requestCastSkill()
+
 func _on_staff_skill_cast_requested():
 	# Player pressed the Staff Widget skill button + Staff confirmed cast is valid.
 	# Enter input-mode "staff_skill_casting"; mouse position drives the indicator.
+	if state == "staff_skill_casting":
+		return  # already aiming; guard a future re-entrant caller from clobbering _state_before_skill_cast
 	if staff == null or _skill_cast_indicator == null:
 		return
 	_state_before_skill_cast = state

--- a/scripts/ui/staff_widget.gd
+++ b/scripts/ui/staff_widget.gd
@@ -65,6 +65,11 @@ func _on_hp_changed(current: int, max_hp: int) -> void:
 func _on_skill_button_pressed() -> void:
 	skill_pressed.emit()
 
+# True when the cursor is over the skill button — GameScene uses this so a click on the
+# button during skill targeting cancels (via the button) instead of committing a cast.
+func is_skill_button_hovered() -> bool:
+	return _skill_icon != null and _skill_icon.is_hovered()
+
 func _on_skill_used() -> void:
 	# A charge was consumed. Grey out only when all charges depleted (charges == 0).
 	# -1 = unlimited (never greys); > 0 = still has charges; 0 = depleted.


### PR DESCRIPTION
**Summary:** Pressing the Staff skill button again while already in skill-targeting mode now cancels the cast (MOBA-style ability toggle). Addresses a slip risk: players who re-press the button expect a cancel.

**How it works:** Today the cast-confirm/cancel click is read in `_input()`, which runs before Godot's GUI layer. So re-clicking the skill button while aiming was caught by `_input` first and committed a cast under the button, then the button's `pressed` signal re-entered targeting. The fix keeps the world-click commit in `_input` but skips it when the cursor is over the skill button (`StaffWidget.is_skill_button_hovered()` via the button's `is_hovered()`), letting the button's `pressed` signal drive the toggle. `skill_pressed` is rewired from `staff.requestCastSkill` to a new `_on_staff_skill_button_pressed()` that cancels when already aiming, else requests a cast.

**Implementation Notes:**
- Chose a targeted `is_hovered()` guard over moving world-clicks to `_unhandled_input`: the broader refactor would create invisible no-commit dead zones under HUD Controls (e.g. `CurrencyUI`, a STOP Control whose child is hidden) and regress right-click-cancel-anywhere, requiring `mouse_filter` edits across several `.tscn`. The guard keeps field-commit working everywhere and touches no scenes.
- The toggle handler is guarded against re-entry across the wave-end popup beat (`_popup_open` / `game_over`); a re-entry guard in `_on_staff_skill_cast_requested` also protects `_state_before_skill_cast`.
- Right-click / ESC cancel and field-click commit are unchanged.
- Out of scope (flagged): clicking other HUD buttons during targeting still commits at that point, and `tower_placement` shares the same `_input`-ordering pattern; a full fix is a larger `_unhandled_input` + `mouse_filter` refactor.
