### PR TITLE
Load tower-scene cache for mid-run deck unlock

### DIFF
--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -65,7 +65,7 @@ func _ready():
 	TowerCenter.addDeck(TowerCenter.selected_deck)
 	var default = TowerDataLoader.load_data("res://resources/database/towers/", "default_tower")
 	TowerCenter.setDefaultTowerData(default)
-	ResourceManager.loadResources();
+	# (tower-scene cache is built inside TowerCenter.addDeck above)
 	# Compile skill-effect shader pipelines now (behind the deck/loading screen)
 	# so the first in-run cast doesn't hitch. Fire-and-forget coroutine.
 	ResourceManager.warmSkillEffectShaders(self)

--- a/scripts/tower_center.gd
+++ b/scripts/tower_center.gd
@@ -59,6 +59,10 @@ func addDeck(deck_key: String) -> bool:
 	added_decks.append(deck_key)
 
 	ResourceManager.preloadSynergy();
+	# Rebuild the tower-scene cache so a deck added mid-run (the wave-clear deck
+	# unlock) has its tower .tscn loaded; otherwise getTower misses and the new
+	# deck's towers fall back to the default/placeholder scene.
+	ResourceManager.loadResources();
 	return true
 
 func getAvailableDecks() -> Array:


### PR DESCRIPTION
**Problem:** Picking an additional deck from the wave-clear deck-unlock popup left that deck's towers rendering as the default/placeholder scene (the template tower art) instead of their own. Tower data (stats/skills) was correct; only the visual scene was wrong.

**Impact:** Mid-run unlocked towers were visually indistinguishable from the placeholder, so the player could not tell which tower they had just placed.

**Fix:** `ResourceManager` built the tower-scene cache (`towerCollection`) once at game start; the mid-run `TowerCenter.addDeck` refreshed synergy icons but never rebuilt that cache, so `getTower` missed and `TowerFactory` fell back to the template scene. Rebuild the cache inside `addDeck` (next to the existing `preloadSynergy`), making it the single hook that refreshes both synergy icons and tower scenes for start-of-run and mid-run deck adds. The now-redundant `loadResources()` call in `game_scene._ready` is removed.
