### PR TITLE
Warm shaders for mid-run deck unlock

### DIFF
--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -115,6 +115,11 @@ static func getSprite(group: String, key: String):
 # is smooth. Data-driven: reads each tower's normal + evolved play_effect
 # actions and resolves the effect script's `SHADER_PATH` const — no per-tower
 # hardcoding. Fire-and-forget coroutine; needs a host Node for the scene tree.
+#
+# Process-wide guard: a shader path warmed once stays warmed (its compiled GPU
+# pipeline persists because we keep the Shader ref alive here), so repeated calls
+# - e.g. a mid-run deck unlock via addDeck - only warm genuinely-new shaders.
+static var _warmed_shaders: Dictionary = {}
 static func warmSkillEffectShaders(host: Node) -> void:
 	if host == null or not is_instance_valid(host):
 		return
@@ -142,7 +147,12 @@ static func warmSkillEffectShaders(host: Node) -> void:
 		if data.attack_config != null and data.attack_config.vfx_shader != "":
 			shaderPaths[data.attack_config.vfx_shader] = true
 
-	if shaderPaths.is_empty():
+	# Skip shaders already warmed this process; only compile genuinely-new ones.
+	var toWarm: Array = []
+	for sp in shaderPaths.keys():
+		if not _warmed_shaders.has(sp):
+			toWarm.append(sp)
+	if toWarm.is_empty():
 		return
 
 	# Draw each pipeline for two frames on a throwaway CanvasLayer, then free.
@@ -153,8 +163,12 @@ static func warmSkillEffectShaders(host: Node) -> void:
 	# for two frames is imperceptible.
 	var layer := CanvasLayer.new()
 	host.add_child(layer)
-	for sp in shaderPaths.keys():
+	for sp in toWarm:
 		var shader = load(sp)
+		# Mark the resolved path warmed regardless of load result (a missing file
+		# must not retry every unlock); keep the Shader ref so its compiled
+		# pipeline survives scene changes and the skip stays valid next run.
+		_warmed_shaders[sp] = shader if shader != null else true
 		if shader == null:
 			continue
 		var mat := ShaderMaterial.new()

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -75,10 +75,8 @@ func _ready():
 	TowerCenter.addDeck(TowerCenter.selected_deck)
 	var default = TowerDataLoader.load_data("res://resources/database/towers/", "default_tower")
 	TowerCenter.setDefaultTowerData(default)
-	# (tower-scene cache is built inside TowerCenter.addDeck above)
-	# Compile skill-effect shader pipelines now (behind the deck/loading screen)
-	# so the first in-run cast doesn't hitch. Fire-and-forget coroutine.
-	ResourceManager.warmSkillEffectShaders(self)
+	# (tower-scene cache + skill-effect shader warm are both handled inside
+	# TowerCenter.addDeck above)
 
 	# Staff system: load data → instantiate entity → wire widget → spawn endpoint sprite.
 	setup_staff()

--- a/scripts/tower_center.gd
+++ b/scripts/tower_center.gd
@@ -63,6 +63,11 @@ func addDeck(deck_key: String) -> bool:
 	# unlock) has its tower .tscn loaded; otherwise getTower misses and the new
 	# deck's towers fall back to the default/placeholder scene.
 	ResourceManager.loadResources();
+	# Pre-compile this deck's skill/bullet shaders (behind the deck / loading
+	# screen, or the wave-clear popup for a mid-run unlock) so the first in-run
+	# cast doesn't hitch. self (TowerCenter autoload) is the in-tree host; the
+	# _warmed guard makes repeat calls only warm new shaders. Fire-and-forget.
+	ResourceManager.warmSkillEffectShaders(self);
 	return true
 
 func getAvailableDecks() -> Array:


### PR DESCRIPTION
**Problem:** A tower from a deck unlocked mid-run (the wave-clear deck-unlock popup) hitched once on its first skill/bullet cast. `ResourceManager.warmSkillEffectShaders` ran only once in `game_scene._ready` over the then-owned towers, so a mid-run deck's shaders were never pre-compiled and the GPU pipeline compiled on the visible cast frame.

**Impact:** Visible one-frame stutter the first time each newly-unlocked tower casts - worst on heavy effect shaders.

**Fix:** Mirror the tower-scene-cache fix (PR #53): move the warm call into `TowerCenter.addDeck` (next to `loadResources`) and drop the redundant `game_scene._ready` call, so every deck add - start-of-run and mid-run - warms its shaders. A static `_warmed_shaders` guard holds each warmed Shader ref, so repeat calls compile only genuinely-new shaders and the skip stays valid across runs.
