### PR TITLE
Shinri crit pierce-arrow VFX (normal + evolve)

### DIFF
--- a/resources/combat/bullets/shinri_skill_projectile.tscn
+++ b/resources/combat/bullets/shinri_skill_projectile.tscn
@@ -8,10 +8,6 @@ size = Vector2(640, 512)
 [node name="ShinriSkillProjectile" type="Area2D"]
 script = ExtResource("1_proj")
 
-[node name="Placeholder" type="Polygon2D" parent="."]
-color = Color(1, 0.85, 0.2, 0.55)
-polygon = PackedVector2Array(0, -64, 640, -64, 640, 64, 0, 64)
-
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(320, 0)
 shape = SubResource("RectangleShape2D_shinri")

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -66,6 +66,7 @@ skills:
     behavior: "crit_pierce"
     reset_on_crit: true
     projectile: "res://resources/combat/bullets/shinri_skill_projectile.tscn"
+    effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gd"
     arrow_speed: 12.0   # tiles/sec
     arrow_range: 4.0    # tiles (pierce line length)
 
@@ -108,5 +109,6 @@ evolution_skills:
     behavior: "crit_pierce"
     reset_on_crit: false
     projectile: "res://resources/combat/bullets/shinri_skill_projectile.tscn"
+    effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gd"
     arrow_speed: 12.0
     arrow_range: 4.0

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gd
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gd
@@ -1,0 +1,62 @@
+extends Node2D
+# ════════════════════════════════════════════════════════════════
+# Josuiji Shinri · "Heartpierce Shot" crit pierce-arrow VFX controller — EVOLVE tier.
+#
+# Same lane-static spawn as the normal controller, but the evolve shader has TWO clocks:
+#   - progress : the bolt (head travels the lane), runs over `travel_dur`.
+#   - life_t   : the charm particles/hearts, runs over the LONGER `total_dur` so they
+#                linger and fade AFTER the bolt is gone. shot_frac = travel_dur/total_dur
+#                tells the shader the life_t value at which the bolt ends.
+# The wide-pierce DAMAGE is the separate shinri_skill_projectile.
+# ════════════════════════════════════════════════════════════════
+
+const SHADER_PATH := "res://resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gdshader"
+
+const LANE_PAD       := 0.25    # must match the shader lane_pad uniform
+const RANGE_TILES    := 4.0     # arrow_range — lane length in tiles
+const VISUAL_H_CELLS := 1.6     # lane visual height
+const POP_FRAC       := 0.22    # scale_p elastic pop length (fraction of bolt travel)
+const SHOT_FRAC      := 0.55    # bolt = first SHOT_FRAC of the total; particles linger after
+
+func setup(tower, aim_dir: Vector2, travel_dur: float) -> void:
+	if aim_dir.length() <= 0.001:
+		aim_dir = Vector2.RIGHT
+	aim_dir = aim_dir.normalized()
+	var lane_len := RANGE_TILES * float(GridHelper.CELL_SIZE)
+	global_position = tower.global_position + aim_dir * (lane_len * 0.5)
+	rotation = aim_dir.angle()
+	_spawn_effect(lane_len, maxf(travel_dur, 0.05))
+
+func _spawn_effect(lane_len: float, bolt_dur: float) -> void:
+	var total_dur := bolt_dur / SHOT_FRAC      # bolt + lingering particles
+	var visual_len := lane_len * (1.0 + 2.0 * LANE_PAD)
+	var visual_h := VISUAL_H_CELLS * float(GridHelper.CELL_SIZE)
+
+	var rect := ColorRect.new()
+	rect.size = Vector2(visual_len, visual_h)
+	rect.position = -rect.size * 0.5
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+	var mat := ShaderMaterial.new()
+	mat.shader = load(SHADER_PATH)
+	mat.set_shader_parameter("progress", 0.0)
+	mat.set_shader_parameter("life_t", 0.0)
+	mat.set_shader_parameter("scale_p", 0.0)
+	mat.set_shader_parameter("lane_pad", LANE_PAD)
+	mat.set_shader_parameter("shot_frac", SHOT_FRAC)
+	rect.material = mat
+	add_child(rect)
+
+	var pop := create_tween()
+	pop.set_ease(Tween.EASE_OUT)
+	pop.set_trans(Tween.TRANS_ELASTIC)
+	pop.tween_method(func(v: float): mat.set_shader_parameter("scale_p", v), 0.0, 1.0, bolt_dur * POP_FRAC)
+
+	# bolt travels over bolt_dur
+	var run := create_tween()
+	run.tween_method(func(v: float): mat.set_shader_parameter("progress", v), 0.0, 1.0, bolt_dur)
+
+	# particles/hearts run over the longer total_dur, then free
+	var life := create_tween()
+	life.tween_method(func(v: float): mat.set_shader_parameter("life_t", v), 0.0, 1.0, total_dur)
+	life.tween_callback(queue_free)

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gdshader
@@ -1,0 +1,152 @@
+shader_type canvas_item;
+render_mode blend_premul_alpha;
+
+// Josuiji Shinri "Heartpierce Shot" crit pierce-arrow VFX - EVOLVE tier.
+// Seamless pink COMET core (cel bands + living fbm warp) + braided light FILAMENTS tied to a
+// binding KNOT at the front tip + scattered sparkle/heart charm dots that linger past the bolt.
+// Premultiplied so the saturated pink/magenta survives over a lit map (Kiara Hinotori technique).
+// Lane-static: head travels via `progress`; the lingering particles run on `life_t` (longer clock).
+// Driven by progress / life_t / scale_p, never internal TIME.
+
+uniform float progress  : hint_range(0.0, 1.0) = 0.0;
+uniform float life_t     : hint_range(0.0, 1.0) = 0.0;   // full-cycle clock (dots/hearts linger after the bolt)
+uniform float shot_frac  : hint_range(0.05, 1.0) = 0.55; // travel_dur / total_dur (life_t value when the bolt ends)
+uniform float scale_p    : hint_range(0.01, 1.2) = 1.0;
+uniform float lane_pad   : hint_range(0.0, 0.5) = 0.25;  // must match the controller LANE_PAD
+
+uniform float head_r       : hint_range(0.01, 0.12) = 0.030;
+uniform float tail_len     : hint_range(0.10, 1.20) = 0.50;
+uniform float beam_width   : hint_range(0.008, 0.12) = 0.035;
+uniform float intensity    : hint_range(0.0, 2.5)   = 1.1;
+uniform float spark_amount : hint_range(0.0, 1.5)   = 0.6;
+
+const float XR = 2.5;   // x-unit px / y-unit px -> isotropic hearts/knot
+const vec3 PCORE = vec3(1.00, 0.99, 0.97);
+const vec3 CHARM = vec3(1.00, 0.40, 0.66);
+
+float hash11(float x){ return fract(sin(x * 127.1) * 43758.5453); }
+float hash21(vec2 p){ return fract(sin(dot(p, vec2(41.3, 289.1))) * 43758.5453); }
+float headx_at(float p){ return smoothstep(0.08, 0.95, p) * (1.0 + lane_pad * 0.35); }
+
+float vnoise(vec2 p){
+	vec2 i = floor(p); vec2 f = fract(p);
+	float a = hash21(i), b = hash21(i + vec2(1.0, 0.0)), c = hash21(i + vec2(0.0, 1.0)), d = hash21(i + vec2(1.0, 1.0));
+	vec2 u = f * f * (3.0 - 2.0 * f);
+	return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+float fbm(vec2 p){ float s = 0.0, a = 0.5; for (int i = 0; i < 3; i++){ s += a * vnoise(p); p *= 2.0; a *= 0.5; } return s; }
+
+vec3 cel_rose(float t){
+	t = clamp(t, 0.0, 1.0);
+	if (t < 0.16) return vec3(1.00, 0.98, 0.96);
+	if (t < 0.42) return vec3(1.00, 0.72, 0.86);
+	if (t < 0.70) return vec3(1.00, 0.40, 0.62);
+	return vec3(0.88, 0.22, 0.58);
+}
+
+vec4 over(vec4 d, vec4 s){
+	float a = s.a + d.a * (1.0 - s.a);
+	vec3 rgb = (s.rgb * s.a + d.rgb * d.a * (1.0 - s.a)) / max(a, 1e-4);
+	return vec4(rgb, a);
+}
+
+float heart(vec2 d, float s){
+	vec2 p = d / max(s, 1e-4);
+	float a = dot(p, p) - 1.0;
+	float h = a * a * a - p.x * p.x * p.y * p.y * p.y;
+	return 1.0 - smoothstep(-0.4, 0.5, h);
+}
+
+void fragment(){
+	float x = mix(-lane_pad, 1.0 + lane_pad, UV.x);
+	float y = UV.y - 0.5;
+
+	float hr = max(head_r, 1e-3)    * 1.55;
+	float bw = max(beam_width, 1e-3)* 1.40;
+	float L  = max(tail_len, 1e-3)  * 1.40;
+
+	float head_x = headx_at(progress);
+	float launch = smoothstep(0.0, 0.10, progress);
+	float bolt_life = 1.0 - smoothstep(0.88, 1.0, progress);
+	float pop = mix(0.6, 1.0, smoothstep(0.0, 0.55, clamp(scale_p, 0.01, 1.2)));
+	float tower_gate = step(0.0, x);
+
+	float dx = head_x - x;
+	float tt = clamp(dx / L, 0.0, 1.0);
+	float along = tt;
+	float born = launch * pop;
+	float warp = (fbm(vec2(x * 7.0 - progress * 3.5, y * 9.0 + progress * 1.5)) - 0.5) * 0.30;
+
+	vec4 acc = vec4(0.0);
+
+	// ===== seamless comet core (head orb + tail that ramps from under the head) =====
+	float head_d = length(vec2(dx / hr, y / bw));
+	float head = exp(-head_d * head_d) * born * bolt_life;
+	acc = over(acc, vec4(cel_rose(smoothstep(0.20, 1.0, head_d) + warp), head * 0.95));
+
+	float tgate = smoothstep(0.0, hr * 2.0, dx) * step(dx, L) * step(0.0, x);
+	float tw = bw * (1.0 - 0.70 * tt);
+	float tail = exp(-(y * y) / (2.0 * max(tw, 1e-4) * max(tw, 1e-4))) * pow(1.0 - tt, 1.35) * tgate * born * bolt_life;
+	acc = over(acc, vec4(cel_rose(0.30 + 0.55 * tt + warp), tail * 0.92));
+
+	float inner = exp(-head_d * head_d * 2.4) * born * bolt_life;
+	acc = over(acc, vec4(PCORE, inner * 0.6));
+	float flash = exp(-(dx * dx) / (2.0 * (hr * 1.6) * (hr * 1.6)))
+			* exp(-(y * y) / (2.0 * (bw * 1.6) * (bw * 1.6))) * (1.0 - smoothstep(0.0, 0.18, progress));
+	acc = over(acc, vec4(PCORE, flash * 0.7 * tower_gate));
+
+	// ===== braided light filaments tied to a binding KNOT at the front tip, fanning down the body =====
+	{
+		float front = smoothstep(-hr * 0.2, hr * 0.6, dx);
+		float fbody = front * step(dx, L) * step(0.0, x) * born * bolt_life;
+		float fw = bw * 0.18;
+		float tie_dx = -hr * 0.7;                  // tie point at the very FRONT tip, ahead of centre
+		float fil = 0.0;
+		for (int i = 0; i < 4; i++){
+			float fi = float(i);
+			float amp = bw * (1.3 + fi * 0.45) * 0.85;   // moderate fan (not too wide)
+			float freq = 6.0 + fi * 2.5;
+			float phase = fi * 1.9 + progress * 5.0 + hash11(fi * 3.1) * 6.2831;
+			float conv = smoothstep(0.0, hr * 1.3, dx - tie_dx);   // converge to the front-tip tie point
+			float cy = amp * conv * sin(along * freq + phase);
+			float d = (y - cy) / fw;
+			fil = max(fil, exp(-d * d) * pow(1.0 - along, 1.1));
+		}
+		acc = over(acc, vec4(cel_rose(0.22), fil * fbody * 0.95));
+
+		// bright binding node - the single tie point at the very front tip
+		float node = exp(-((dx - tie_dx) * (dx - tie_dx)) / (2.0 * (hr * 0.42) * (hr * 0.42)))
+				* exp(-(y * y) / (2.0 * (bw * 0.36) * (bw * 0.36))) * born * bolt_life;
+		acc = over(acc, vec4(mix(PCORE, CHARM, 0.25), node * 0.95 * tower_gate));
+	}
+
+	// ===== charm particles: scattered sparkle DOTS + ~1/3 hearts, twinkle, linger past the bolt =====
+	for (int i = 0; i < 10; i++){
+		float fi = float(i);
+		float s1 = hash11(fi * 5.3 + 0.2);
+		float s2 = hash11(fi * 9.1 + 1.7);
+		float s3 = hash11(fi * 3.7 + 4.1);
+		float pe_prog = 0.05 + s1 * 0.90;
+		float emT = pe_prog * shot_frac;
+		float local = life_t - emT;
+		float app = smoothstep(0.0, 0.04, local);
+		float linger = 1.0 - smoothstep(0.74, 1.0, life_t);
+		float k = clamp(local / 0.9, 0.0, 1.0);
+		float emX = headx_at(pe_prog);
+		float sx = emX - 0.05 * local;
+		float sy = (s2 - 0.5) * bw * 4.0 + (s3 - 0.5) * bw * 2.0 * k;   // scattered around the trail
+		float tw = 0.30 + 0.70 * (0.5 + 0.5 * sin(life_t * 20.0 + s1 * 30.0));   // twinkle
+		float dot;
+		if (s3 < 0.32) {
+			dot = heart(vec2((x - sx) * XR, y - sy), bw * 0.5 * (1.0 - 0.3 * k));   // charm hearts
+		} else {
+			float dd = length(vec2((x - sx) * XR, y - sy));
+			dot = exp(-(dd * dd) / (2.0 * (bw * 0.16) * (bw * 0.16)));              // round sparkle
+		}
+		acc = over(acc, vec4(mix(PCORE, CHARM, s3), dot * app * linger * tw * step(0.0, x) * spark_amount));
+	}
+
+	acc.rgb *= intensity * 1.30;
+	float a = clamp(acc.a, 0.0, 1.0) * tower_gate;
+	COLOR = vec4(acc.rgb * a, a);
+}

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gd
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gd
@@ -1,0 +1,58 @@
+extends Node2D
+# ════════════════════════════════════════════════════════════════
+# Josuiji Shinri · "Bull Eyes" crit pierce-arrow VFX controller — NORMAL tier.
+#
+# Spawned by PassiveCritPierce._fire_arrow on a crit: a bare Node2D is created,
+# this script attached, then setup(tower, aim_dir, travel_dur). We orient one
+# lane-static ColorRect (running shinri_skill_effect.gdshader) so the arrow's
+# 1×4 lane lies along the crit direction; the head travels the lane via
+# `progress` (0→1). The wide-pierce DAMAGE is the separate shinri_skill_projectile.
+#
+# Convention (kiara_skill_effect): progress 0→1 = the shot, scale_p does the
+# elastic pop-in; the effect frees itself when done.
+# ════════════════════════════════════════════════════════════════
+
+const SHADER_PATH := "res://resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gdshader"
+
+const LANE_PAD       := 0.25    # must match the shader lane_pad uniform
+const RANGE_TILES    := 4.0     # arrow_range — lane length in tiles
+const VISUAL_H_CELLS := 1.6     # lane visual height (1 tile + glow headroom)
+const POP_FRAC       := 0.30    # scale_p elastic pop length (fraction of travel)
+
+# Called by PassiveCritPierce after the node is in the tree.
+func setup(tower, aim_dir: Vector2, travel_dur: float) -> void:
+	if aim_dir.length() <= 0.001:
+		aim_dir = Vector2.RIGHT
+	aim_dir = aim_dir.normalized()
+	var lane_len := RANGE_TILES * float(GridHelper.CELL_SIZE)
+	# Push forward half a lane so lane-x 0 lands on the tower and lane-x 1 on the range end
+	# (the ColorRect is centred on this node; the padded quad spans the lane midpoint).
+	global_position = tower.global_position + aim_dir * (lane_len * 0.5)
+	rotation = aim_dir.angle()
+	_spawn_effect(lane_len, maxf(travel_dur, 0.05))
+
+func _spawn_effect(lane_len: float, dur: float) -> void:
+	var visual_len := lane_len * (1.0 + 2.0 * LANE_PAD)
+	var visual_h := VISUAL_H_CELLS * float(GridHelper.CELL_SIZE)
+
+	var rect := ColorRect.new()
+	rect.size = Vector2(visual_len, visual_h)
+	rect.position = -rect.size * 0.5           # centre on the node origin
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+	var mat := ShaderMaterial.new()
+	mat.shader = load(SHADER_PATH)
+	mat.set_shader_parameter("progress", 0.0)
+	mat.set_shader_parameter("scale_p", 0.0)
+	mat.set_shader_parameter("lane_pad", LANE_PAD)
+	rect.material = mat
+	add_child(rect)
+
+	var pop := create_tween()
+	pop.set_ease(Tween.EASE_OUT)
+	pop.set_trans(Tween.TRANS_ELASTIC)
+	pop.tween_method(func(v: float): mat.set_shader_parameter("scale_p", v), 0.0, 1.0, dur * POP_FRAC)
+
+	var run := create_tween()
+	run.tween_method(func(v: float): mat.set_shader_parameter("progress", v), 0.0, 1.0, dur)
+	run.tween_callback(queue_free)

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gdshader
@@ -1,0 +1,87 @@
+shader_type canvas_item;
+render_mode blend_add;
+
+// Josuiji Shinri "Bull Eyes" crit pierce-arrow VFX - NORMAL tier.
+// Citrine comet: head orb + seamless tapered tail + release flash + Burst & Streak particles.
+// Lane-static: the head travels across the 1x4 lane via `progress` (0->1); the controller
+// (shinri_skill_effect.gd) orients the quad toward the crit target. Driven by progress/scale_p,
+// never internal TIME. (Evolve = shinri_evo_skill_effect.gdshader, premultiplied.)
+
+uniform float progress : hint_range(0.0, 1.0) = 0.0;
+uniform float scale_p  : hint_range(0.01, 1.2) = 1.0;
+uniform float lane_pad : hint_range(0.0, 0.5) = 0.25;   // must match the controller LANE_PAD
+
+uniform float head_r       : hint_range(0.01, 0.12) = 0.030;
+uniform float tail_len     : hint_range(0.10, 1.20) = 0.50;
+uniform float beam_width   : hint_range(0.008, 0.12) = 0.035;
+uniform float intensity    : hint_range(0.0, 2.5)   = 1.1;
+uniform float spark_amount : hint_range(0.0, 1.5)   = 0.6;
+
+const vec3 NM_BODY = vec3(1.00, 0.95, 0.55);   // Citrine
+const vec3 NM_EDGE = vec3(1.00, 0.78, 0.26);
+const vec3 PCORE   = vec3(1.00, 0.99, 0.86);
+
+float hash11(float x){ return fract(sin(x * 127.1) * 43758.5453); }
+float headx_at(float p){ return smoothstep(0.08, 0.95, p) * (1.0 + lane_pad * 0.35); }
+
+void fragment(){
+	float x = mix(-lane_pad, 1.0 + lane_pad, UV.x);
+	float y = UV.y - 0.5;
+
+	float head_x = headx_at(progress);
+	float launch = smoothstep(0.0, 0.10, progress);
+	float life   = 1.0 - smoothstep(0.88, 1.0, progress);
+	float pop    = mix(0.6, 1.0, smoothstep(0.0, 0.55, clamp(scale_p, 0.01, 1.2)));
+	float tower_gate = step(0.0, x);
+
+	float dx = head_x - x;
+	float bw = max(beam_width, 1e-3);
+	float hr = max(head_r, 1e-3);
+	float L  = max(tail_len, 1e-3);
+	float tt = clamp(dx / L, 0.0, 1.0);
+	float born = launch * pop;
+
+	vec3 col = vec3(0.0);
+
+	float head_d = length(vec2(dx / hr, y / bw));
+	float head = exp(-head_d * head_d) * born;
+	col += mix(NM_BODY, NM_EDGE, smoothstep(0.25, 1.0, head_d)) * head * 1.2;
+
+	float tgate = smoothstep(0.0, hr * 2.0, dx) * step(dx, L) * step(0.0, x);
+	float tw = bw * (1.0 - 0.70 * tt);
+	float tail = exp(-(y * y) / (2.0 * max(tw, 1e-4) * max(tw, 1e-4))) * pow(1.0 - tt, 1.35) * tgate * born;
+	col += mix(NM_BODY, NM_EDGE, 0.25 + 0.60 * tt) * tail * 1.05;
+
+	float flash = exp(-(dx * dx) / (2.0 * (hr * 1.6) * (hr * 1.6)))
+			* exp(-(y * y) / (2.0 * (bw * 1.6) * (bw * 1.6))) * (1.0 - smoothstep(0.0, 0.18, progress));
+	col += PCORE * flash * 1.3 * tower_gate;
+
+	// release burst from the bow
+	float bl = clamp(progress / 0.28, 0.0, 1.0);
+	for (int j = 0; j < 6; j++){
+		float fj = float(j);
+		float s = hash11(fj * 6.1 + 1.3);
+		float bx = 0.02 + s * 0.10 * bl;
+		float by = (hash11(fj * 2.7) - 0.5) * bw * (1.5 + bl * 9.0);
+		float bd = length(vec2((x - bx) / 0.022, (y - by) / 0.008));
+		col += mix(NM_BODY, PCORE, 0.4) * exp(-bd * bd) * (1.0 - bl) * spark_amount * 1.5 * tower_gate;
+	}
+	// fast motion-stretched streak-sparks (decoupled timing)
+	for (int i = 0; i < 8; i++){
+		float fi = float(i);
+		float seed = hash11(fi * 4.7);
+		float pe = 0.04 + seed * 0.85;
+		float local = progress - pe;
+		float plife = 0.22 + seed * 0.12;
+		float k = clamp(local / plife, 0.0, 1.0);
+		float emX = headx_at(pe);
+		float sx = emX - 0.30 * local - seed * 0.03;
+		float sy = (hash11(fi * 8.3) - 0.5) * bw * 1.0 + (hash11(fi * 3.1) - 0.5) * bw * 7.0 * k;
+		float alive = step(0.0, local) * step(local, plife) * step(0.0, x);
+		float sd = length(vec2((x - sx) / 0.030, (y - sy) / 0.0065));
+		col += NM_BODY * exp(-sd * sd) * (1.0 - k) * alive * spark_amount * 1.6;
+	}
+
+	col *= intensity * life * tower_gate;
+	COLOR = vec4(col, 1.0);
+}

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -140,6 +140,15 @@ static func warmSkillEffectShaders(host: Node) -> void:
 					if sp != "":
 						shaderPaths[sp] = true
 
+		# Passive-fired effect shaders (e.g. Shinri's crit pierce arrow): a passive spawns its own
+		# effect controller, so it never shows up as a play_effect action above. Read effect_script
+		# off the passive + evolutionPassive param dicts and resolve its SHADER_PATH the same way.
+		for passive in [data.passive, data.evolutionPassive]:
+			if passive is Dictionary and str(passive.get("effect_script", "")) != "":
+				var psp := _shaderPathFromEffectScript(str(passive["effect_script"]))
+				if psp != "":
+					shaderPaths[psp] = true
+
 		# Normal-attack projectile bullet shader (not a skill effect) — warm it too
 		# so the first shot doesn't hitch on pipeline compile. Its shader lives in a
 		# ShaderMaterial inside the bullet .tscn, invisible to the SHADER_PATH scan, so

--- a/scripts/skill/passive/passive_crit_pierce.gd
+++ b/scripts/skill/passive/passive_crit_pierce.gd
@@ -24,6 +24,7 @@ var crit_chance_per_stack: float
 var reset_on_crit: bool
 var bonus_crit_damage: Array          # per-level additive crit damage (x); index by level-1
 var projectile_scene: PackedScene
+var effect_script: Script             # lane-static pierce VFX controller (normal or evolve slot)
 var arrow_speed: float                # tiles/sec
 var arrow_range: float                # tiles
 var stacks: int = 0
@@ -41,6 +42,11 @@ func _init(owner: Tower, params: Dictionary) -> void:
 	var path: String = str(params.get("projectile", ""))
 	if path != "" and ResourceLoader.exists(path):
 		projectile_scene = load(path)
+	# Pierce-arrow VFX controller for this slot (normal/evolve picked by tower._setupPassive).
+	# Guard like the projectile: a bad path degrades to "arrow fires, no VFX", never errors.
+	var fx_path: String = str(params.get("effect_script", ""))
+	if fx_path != "" and ResourceLoader.exists(fx_path):
+		effect_script = load(fx_path)
 
 # Does a crit replace the normal instant hit with the arrow? (Tower asks before attacking.)
 func replaces_attack_on_crit() -> bool:
@@ -87,6 +93,22 @@ func _fire_arrow(target: Enemy) -> void:
 	p.prevent_rehit = true
 	p.setup_direction(tower, direction, dmg, lifetime,
 			ProjectileCallback.new(Callable(self, "_on_arrow_hit"), Callable(), Callable()))
+
+	_spawn_vfx(direction, lifetime)
+
+# Spawn the lane-static pierce VFX aimed along the shot. Mirrors SkillActionPlayEffect:
+# a bare Node2D gets the effect controller script, parented to the tower's VFX layer.
+func _spawn_vfx(direction: Vector2, travel_dur: float) -> void:
+	if effect_script == null:
+		return
+	var parent := tower.get_parent()
+	if parent == null or not is_instance_valid(parent):
+		return
+	var fx := Node2D.new()
+	fx.set_script(effect_script)
+	parent.add_child(fx)
+	if fx.has_method("setup"):
+		fx.setup(tower, direction, travel_dur)
 
 func _on_arrow_hit(_projectile: Projectile, hit) -> void:
 	if hit is Enemy and is_instance_valid(hit):


### PR DESCRIPTION
**Summary:** Production VFX for Josuiji Shinri's crit "Heartpierce" pierce-arrow (normal + evolve), ported from the approved preview harness. Replaces the placeholder projectile box with a real lane-static energy-arrow effect, picked per evolution state.

**How it works:** The `crit_pierce` passive (`passive_crit_pierce.gd`) spawns a lane-static skill-effect controller on each crit, mirroring the Kiara `play_effect` pattern but driven directly from the passive (no SkillContext). The controller orients a ColorRect along the shot and tweens the shader `progress` (the head travels the 1x4 lane). Each passive slot names its `effect_script` in `josuiji_shinri.yaml`, so `Tower._setupPassive()`'s normal/evolve choice selects the matching VFX with no code branch. The wide-pierce damage stays the separate `shinri_skill_projectile`.

**Implementation Notes:**
- Normal = blend_add Citrine comet; evolve = blend_premul_alpha pink cel bolt with braided filaments tied to a knot at the tip + charm sparkle/heart particles that linger past the bolt on a second `life_t` clock.
- `ResourceManager.warmSkillEffectShaders` extended to also warm passive effect-script shaders (it previously scanned only `play_effect` actions), so the first crit does not hitch; covers the mid-run deck unlock.
- The pierce-arrow VFX is an intentional BASE quality pass (below the Kiara bar) per Director; not adopted as a new visual standard.

**Touched scenes:** resources/combat/bullets/shinri_skill_projectile.tscn
