### PR TITLE
Projectile muzzle offset + skill-VFX origin polish

### DIFF
--- a/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gd
@@ -58,9 +58,11 @@ func setup(tower, context = null) -> void:
 
 	# Push the rect forward so the corridor mouth (slash) sits ~MOUTH_AHEAD cells
 	# ahead of the caster. The rect centre is (hx - cx) author-units ahead of the
-	# corridor's left edge; 1 author-unit == eff.y px.
+	# corridor's left edge; 1 author-unit == eff.y px. Add the shared muzzle offset
+	# (matches the damage projectile) so the rush leaves the character edge, not its belly.
 	var center_ahead_px := (hx - cx) * eff.y
-	global_position += forward * (center_ahead_px + MOUTH_AHEAD * cell)
+	var muzzle_px := Utility.MUZZLE_OFFSET_TILES * cell
+	global_position += forward * (muzzle_px + center_ahead_px + MOUTH_AHEAD * cell)
 
 	_spawn_effect(eff, aspect, hx, hy, cx)
 

--- a/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gdshader
@@ -12,7 +12,7 @@ render_mode blend_premul_alpha;   // premultiplied: dark magma bands show over t
 // (progress, scale_p, aspect, corridor_hx/hy/cx) + orients onto the 3×5 lane.
 // Plays the whole rush internally via `progress`; damage is the separate
 // wide-pierce kiara_skill_projectile. In-rect only — no scene FX.
-// Perf: the fbm() calls are gated (born / slash-active / passed) so the
+// Perf: the fbm() calls are gated (born / slash-active) so the
 // padded rect doesn't pay full noise cost where alpha is 0 — no look change.
 // ════════════════════════════════════════════════════════════════
 
@@ -32,6 +32,7 @@ uniform float feather_count    : hint_range(4.0, 16.0) = 9.0;
 uniform float outline_strength : hint_range(0.0, 1.0) = 0.6;
 uniform float wing_sweep       : hint_range(0.0, 1.2) = 0.8;
 uniform int   burst_mode  : hint_range(0, 2) = 1;        // baked: no terminal burst
+uniform float edge_fade   : hint_range(0.02, 0.6) = 0.30; // lane-end envelope fade band: bigger = softer dissolve near the caster (was a hard 0.05 scissor)
 
 const vec3 P_CORE = vec3(1.00, 0.99, 0.92);
 const vec3 P_B1   = vec3(1.00, 0.82, 0.28);
@@ -275,17 +276,12 @@ void fragment() {
 	sc += mix(P_B2, P_B3, hash(cell + 4.0)) * spark * 1.9;
 	sa = max(sa, spark);
 
-	// ── Lingering scorched bed (fbm `bednz` gated by `passed`) ──
-	float in_lane = step(LEFT - 0.05, uv.x) * step(uv.x, RIGHT + 0.05);
-	float passed = smoothstep(0.0, 0.06, head_x - uv.x) * in_lane;
-	float bed = passed * (1.0 - smoothstep(hy * 0.80, hy, abs(uv.y)));
-	float bednz = (passed > 0.0) ? fbm(vec2(uv.x * 4.0 - progress * 2.0, uv.y * 6.0 + progress)) : 0.0;
-	float linger = bed * mix(0.12, 0.45, bednz) * (0.45 + 0.55 * smoothstep(1.0, 0.40, progress));
-	col += mix(P_B3, P_B4, 0.5) * linger * 0.9;
-	a = max(a, linger * 0.55);
+	// (Lingering scorched bed removed — its magenta corridor trail read as a rectangle behind
+	//  the phoenix. Director cut it; the bird silhouette carries the read on its own.)
 
 	// ── Envelope + VANISH (body fade + sparkles that outlive it) ─
-	float ex = 1.0 - smoothstep(aspect * 0.5 - 0.05, aspect * 0.5, abs(uv.x));
+	// edge_fade widens the lane-end fade so bright mouth layers dissolve instead of hard-cutting.
+	float ex = 1.0 - smoothstep(aspect * 0.5 - edge_fade, aspect * 0.5, abs(uv.x));
 	float ey = 1.0 - smoothstep(0.47, 0.50, abs(uv.y));
 	float env = ex * ey * smoothstep(0.0, 0.04, progress);
 	float keep = 1.0 - smoothstep(0.80, 0.95, progress);

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gd
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gd
@@ -23,7 +23,10 @@ func setup(tower, aim_dir: Vector2, travel_dur: float) -> void:
 		aim_dir = Vector2.RIGHT
 	aim_dir = aim_dir.normalized()
 	var lane_len := RANGE_TILES * float(GridHelper.CELL_SIZE)
-	global_position = tower.global_position + aim_dir * (lane_len * 0.5)
+	# Lane origin starts at the muzzle point (off the tower centre along the aim),
+	# matching the damage projectile so the visible arrow leaves the character edge.
+	var muzzle := Utility.muzzle_origin(tower.global_position, aim_dir)
+	global_position = muzzle + aim_dir * (lane_len * 0.5)
 	rotation = aim_dir.angle()
 	_spawn_effect(lane_len, maxf(travel_dur, 0.05))
 

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gdshader
@@ -19,6 +19,7 @@ uniform float tail_len     : hint_range(0.10, 1.20) = 0.50;
 uniform float beam_width   : hint_range(0.008, 0.12) = 0.035;
 uniform float intensity    : hint_range(0.0, 2.5)   = 1.1;
 uniform float spark_amount : hint_range(0.0, 1.5)   = 0.6;
+uniform float origin_soft  : hint_range(0.0, 0.30)  = 0.08;   // soft tail fade at the lane origin (was a hard scissor at the tower)
 
 const float XR = 2.5;   // x-unit px / y-unit px -> isotropic hearts/knot
 const vec3 PCORE = vec3(1.00, 0.99, 0.97);
@@ -69,7 +70,7 @@ void fragment(){
 	float launch = smoothstep(0.0, 0.10, progress);
 	float bolt_life = 1.0 - smoothstep(0.88, 1.0, progress);
 	float pop = mix(0.6, 1.0, smoothstep(0.0, 0.55, clamp(scale_p, 0.01, 1.2)));
-	float tower_gate = step(0.0, x);
+	float tower_gate = smoothstep(0.0, origin_soft, x);   // soft fade-in instead of a hard cut at the origin
 
 	float dx = head_x - x;
 	float tt = clamp(dx / L, 0.0, 1.0);

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gd
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gd
@@ -25,9 +25,13 @@ func setup(tower, aim_dir: Vector2, travel_dur: float) -> void:
 		aim_dir = Vector2.RIGHT
 	aim_dir = aim_dir.normalized()
 	var lane_len := RANGE_TILES * float(GridHelper.CELL_SIZE)
-	# Push forward half a lane so lane-x 0 lands on the tower and lane-x 1 on the range end
-	# (the ColorRect is centred on this node; the padded quad spans the lane midpoint).
-	global_position = tower.global_position + aim_dir * (lane_len * 0.5)
+	# Lane origin (lane-x 0) starts at the muzzle point (pushed off the tower centre
+	# along the aim), matching the damage projectile so the visible arrow leaves the
+	# character edge, not its belly. Then push forward half a lane so lane-x 1 lands
+	# on the range end (the ColorRect is centred on this node; the padded quad spans
+	# the lane midpoint).
+	var muzzle := Utility.muzzle_origin(tower.global_position, aim_dir)
+	global_position = muzzle + aim_dir * (lane_len * 0.5)
 	rotation = aim_dir.angle()
 	_spawn_effect(lane_len, maxf(travel_dur, 0.05))
 

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gdshader
@@ -16,6 +16,7 @@ uniform float tail_len     : hint_range(0.10, 1.20) = 0.50;
 uniform float beam_width   : hint_range(0.008, 0.12) = 0.035;
 uniform float intensity    : hint_range(0.0, 2.5)   = 1.1;
 uniform float spark_amount : hint_range(0.0, 1.5)   = 0.6;
+uniform float origin_soft  : hint_range(0.0, 0.30)  = 0.08;   // soft tail fade at the lane origin (was a hard scissor at the tower)
 
 const vec3 NM_BODY = vec3(1.00, 0.95, 0.55);   // Citrine
 const vec3 NM_EDGE = vec3(1.00, 0.78, 0.26);
@@ -32,7 +33,7 @@ void fragment(){
 	float launch = smoothstep(0.0, 0.10, progress);
 	float life   = 1.0 - smoothstep(0.88, 1.0, progress);
 	float pop    = mix(0.6, 1.0, smoothstep(0.0, 0.55, clamp(scale_p, 0.01, 1.2)));
-	float tower_gate = step(0.0, x);
+	float tower_gate = smoothstep(0.0, origin_soft, x);   // soft fade-in instead of a hard cut at the origin
 
 	float dx = head_x - x;
 	float bw = max(beam_width, 1e-3);

--- a/scripts/entity/attack_controller.gd
+++ b/scripts/entity/attack_controller.gd
@@ -92,7 +92,8 @@ func _spawnBullet(target: Enemy, cfg: TowerAttackConfig, dmg: Damage, saved_gen:
 	if proj == null:
 		return
 	tower.get_tree().root.add_child(proj)
-	proj.global_position = tower.global_position
+	var aim_dir := (target.global_position - tower.global_position).normalized()
+	proj.global_position = Utility.muzzle_origin(tower.global_position, aim_dir)
 	proj.speed = cfg.speed * GridHelper.CELL_SIZE
 	_applyBulletVisual(proj, cfg)
 

--- a/scripts/skill/passive/passive_crit_pierce.gd
+++ b/scripts/skill/passive/passive_crit_pierce.gd
@@ -87,7 +87,7 @@ func _fire_arrow(target: Enemy) -> void:
 	var lifetime: float = arrow_range / arrow_speed if arrow_speed > 0.0 else 1.0
 
 	var p: Projectile = projectile_scene.instantiate() as Projectile
-	p.global_position = tower.global_position
+	p.global_position = Utility.muzzle_origin(tower.global_position, direction)
 	tower.get_tree().root.add_child(p)
 	p.speed = arrow_speed * GridHelper.CELL_SIZE
 	p.prevent_rehit = true

--- a/scripts/skill/skillActions/skill_create_directional_projectile.gd
+++ b/scripts/skill/skillActions/skill_create_directional_projectile.gd
@@ -33,6 +33,12 @@ func setupProjectile(projectile: Projectile, i: int, context: SkillContext):
 		# Snapshotted at find_multi_enemy time — survives the enemy dying mid-cast.
 		direction = context.extra["aim_dir"]
 
+	# Push the spawn out from the tower center toward the aim direction (muzzle
+	# offset) so the projectile/VFX leaves the character edge, not its belly.
+	# execute() spawned it at the center before the direction was known; now that
+	# direction is resolved, override the origin before setup_direction reads it.
+	projectile.global_position = Utility.muzzle_origin(tower.global_position, direction)
+
 	# Cap travel by range if specified. Pierce projectiles can have a long
 	# configured lifetime but should stop at the AOE corridor edge.
 	var effective_lifetime: float = lifetime

--- a/scripts/utility/utility.gd
+++ b/scripts/utility/utility.gd
@@ -15,6 +15,18 @@ static func get_angle_to_target(from_position: Vector2, target_position: Vector2
 	var direction = target_position - from_position
 	return direction.angle()
 
+# Muzzle origin: push a projectile's spawn point out from the caster center
+# along the aim direction, so the projectile/VFX leaves the character edge
+# instead of its belly. Shared by every directional/homing projectile spawn.
+# MUZZLE_OFFSET_TILES is the single tuning knob (in tiles); circle/orbit
+# projectiles deliberately keep spawning at the caster center (orbit pivot).
+const MUZZLE_OFFSET_TILES: float = 0.5
+
+static func muzzle_origin(caster_position: Vector2, aim_dir: Vector2) -> Vector2:
+	if aim_dir.length() < 0.001:
+		return caster_position
+	return caster_position + aim_dir.normalized() * (MUZZLE_OFFSET_TILES * GridHelper.CELL_SIZE)
+
 static func show_damage_text(position: Vector2, parent: Node2D, damage: int, color: Color = Color(1, 0, 0)):
 	var atkNumber = load("res://resources/ui_component/damage_number.tscn").instantiate() as DamageNumber;
 	atkNumber.setup(damage, color);


### PR DESCRIPTION
**Summary:** Projectiles now spawn offset from the caster centre along the aim direction (a "muzzle" point) so shots leave the character edge instead of its belly, plus a polish pass so the lane-static skill VFX no longer show a hard edge at the origin.

**How it works:** A shared `Utility.muzzle_origin(caster_pos, aim_dir)` (single `MUZZLE_OFFSET_TILES` knob, in tiles) is called at the three directional/homing projectile spawns (Shinri arrow, Kiara directional, normal-attack bullet) AND at the separate lane-static VFX controllers (Shinri normal/evolve, Kiara Hinotori), so the visible effect and the damage projectile stay in sync. Circle/orbit projectiles (Gura) keep spawning at the caster centre (the orbit pivot) and are excluded.

**Implementation Notes:**
- A skill's VISUAL lives in one of two layers and both must apply the offset: projectile-drawn (Amelia's shader bullet rides the projectile) vs a separate effect controller positioned in its own `setup()` (Shinri/Kiara).
- VFX origin polish: softened the Shinri arrow shaders' hard `step(0.0, x)` origin gate (`origin_soft`), widened the Kiara phoenix lane-end envelope fade (`edge_fade`), and removed the Kiara lingering scorched-bed layer whose magenta corridor trail read as a rectangle behind the bird.
- Follow-up logged: a skill-VFX structure refactor + future-agent guideline to stop these hard-edge / frame-clip / rectangular-layer failure modes recurring.
- Builds on the Shinri VFX from #55 (now merged).
