### PR TITLE
Shared lane-VFX frame/origin helpers (migrate 4 lane effects)

### DIFF
--- a/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gd
@@ -47,11 +47,7 @@ func setup(tower, context = null) -> void:
 	# Orient toward the locked target — same lane as find_multi_enemy. Falls back
 	# to the snapshotted aim_dir if the enemy died during the cast animation.
 	var forward := Vector2.RIGHT
-	var aim := Vector2.ZERO
-	if tower != null and tower.enemy != null and is_instance_valid(tower.enemy):
-		aim = tower.enemy.global_position - tower.global_position
-	elif context != null and context.extra.has("aim_dir"):
-		aim = context.extra["aim_dir"]
+	var aim := SkillVfx.resolve_aim(tower, context)
 	if aim.length() > 0.001:
 		forward = aim.normalized()
 		rotation = forward.angle() + ROT_OFFSET
@@ -67,13 +63,8 @@ func setup(tower, context = null) -> void:
 	_spawn_effect(eff, aspect, hx, hy, cx)
 
 func _spawn_effect(eff: Vector2, aspect: float, hx: float, hy: float, cx: float) -> void:
-	var rect := ColorRect.new()
-	rect.size = eff
-	rect.position = -eff * 0.5            # centre on the node origin
-	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
-
-	var mat := ShaderMaterial.new()
-	mat.shader = load(SHADER_PATH)
+	var rect := SkillVfx.make_lane_rect(self, eff, SHADER_PATH)
+	var mat := rect.material as ShaderMaterial
 	# dynamic uniforms only — the look (shape/evo/show_*/body_scale/burst) is
 	# baked as defaults in the shader.
 	mat.set_shader_parameter("progress", 0.0)
@@ -82,8 +73,6 @@ func _spawn_effect(eff: Vector2, aspect: float, hx: float, hy: float, cx: float)
 	mat.set_shader_parameter("corridor_hx", hx)
 	mat.set_shader_parameter("corridor_hy", hy)
 	mat.set_shader_parameter("corridor_cx", cx)
-	rect.material = mat
-	add_child(rect)
 
 	var pop := create_tween()
 	pop.set_ease(Tween.EASE_OUT)

--- a/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_evo_skill_effect.gdshader
@@ -3,6 +3,8 @@ render_mode blend_premul_alpha;   // premultiplied: dark magma bands show over t
                                   // map (true colour) while bright core/glow still adds.
                                   // (blend_add washed the violet/crimson over a lit bg.)
 
+#include "res://resources/tower/shared/lane_fx.gdshaderinc"
+
 // ════════════════════════════════════════════════════════════════
 // Kiara · Hinotori (evo) — production VFX (magma-violet Wingsweep phoenix)
 // Ported from test/kiara_vfx_preview/evo3_magma.gdshader with the chosen
@@ -280,10 +282,10 @@ void fragment() {
 	//  the phoenix. Director cut it; the bird silhouette carries the read on its own.)
 
 	// ── Envelope + VANISH (body fade + sparkles that outlive it) ─
-	// edge_fade widens the lane-end fade so bright mouth layers dissolve instead of hard-cutting.
-	float ex = 1.0 - smoothstep(aspect * 0.5 - edge_fade, aspect * 0.5, abs(uv.x));
-	float ey = 1.0 - smoothstep(0.47, 0.50, abs(uv.y));
-	float env = ex * ey * smoothstep(0.0, 0.04, progress);
+	// Frame vignette via the shared corner-free helper (was ex*ey, which left a rectangle).
+	// fade_x = edge_fade; fade_y = 0.03 (the old 0.47->0.50 band). Identical on the edges
+	// where content lives; only the empty corner is rounded. See lane_fx.gdshaderinc.
+	float env = lane_frame_mask(uv, aspect, edge_fade, 0.03) * smoothstep(0.0, 0.04, progress);
 	float keep = 1.0 - smoothstep(0.80, 0.95, progress);
 	float body_env = env * keep;
 	float spark_env = env * (1.0 - smoothstep(0.90, 1.04, progress));

--- a/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_skill_effect.gd
@@ -29,11 +29,7 @@ func setup(tower, context = null) -> void:
 	# Aim from the live target, else the snapshotted aim_dir (set in
 	# find_multi_enemy while the enemy was valid) — so a target dying during the
 	# skill animation no longer leaves the slash centred on the tower.
-	var forward := Vector2.ZERO
-	if tower != null and tower.enemy != null and is_instance_valid(tower.enemy):
-		forward = tower.enemy.global_position - tower.global_position
-	elif context != null and context.extra.has("aim_dir"):
-		forward = context.extra["aim_dir"]
+	var forward := SkillVfx.resolve_aim(tower, context)
 	if forward.length() > 0.001:
 		forward = forward.normalized()
 		global_position += forward * (GridHelper.CELL_SIZE * FORWARD_CELLS)
@@ -44,18 +40,11 @@ func _spawn_effect() -> void:
 	var width := AREA_W_CELLS * GridHelper.CELL_SIZE * WIDTH_PAD
 	var height := width / EFFECT_ASPECT
 
-	var rect := ColorRect.new()
-	rect.size = Vector2(width, height)
-	rect.position = -rect.size * 0.5          # centre on the node origin
-	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
-
-	var mat := ShaderMaterial.new()
-	mat.shader = load(SHADER_PATH)
+	var rect := SkillVfx.make_lane_rect(self, Vector2(width, height), SHADER_PATH)
+	var mat := rect.material as ShaderMaterial
 	mat.set_shader_parameter("progress", 0.0)
 	mat.set_shader_parameter("scale_p", 0.0)
 	mat.set_shader_parameter("aspect", EFFECT_ASPECT)
-	rect.material = mat
-	add_child(rect)
 
 	var pop := create_tween()
 	pop.set_ease(Tween.EASE_OUT)

--- a/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_skill_effect.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/kiara/skill_effect/kiara_skill_effect.gdshader
@@ -1,6 +1,8 @@
 shader_type canvas_item;
 render_mode blend_add;
 
+#include "res://resources/tower/shared/lane_fx.gdshaderinc"
+
 // ════════════════════════════════════════════════════════════════
 // Kiara · Flame Slash — normal skill VFX
 // A single leaf-tapered crescent blade swung along an arc (วงฟัน):
@@ -113,10 +115,10 @@ void fragment() {
 	a = max(a, ember);
 
 	// ── Envelope + life applied to the whole stack ───────────
-	float ex   = 1.0 - smoothstep(aspect * 0.5 - 0.12, aspect * 0.5 - 0.02, abs(uv.x));
-	float ey   = 1.0 - smoothstep(0.44, 0.49, abs(uv.y));
 	float life = smoothstep(0.0, 0.05, progress) * (1.0 - smoothstep(0.66, 1.0, progress));
-	float mask = ex * ey * life;
+	// Frame vignette via the shared corner-free helper (was ex*ey; fade starts match the old
+	// 0.12/0.05 bands, only the empty corner is rounded). See lane_fx.gdshaderinc.
+	float mask = lane_frame_mask(uv, aspect, 0.12, 0.06) * life;
 	col *= mask;
 	a   *= mask;
 

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gd
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gd
@@ -35,20 +35,13 @@ func _spawn_effect(lane_len: float, bolt_dur: float) -> void:
 	var visual_len := lane_len * (1.0 + 2.0 * LANE_PAD)
 	var visual_h := VISUAL_H_CELLS * float(GridHelper.CELL_SIZE)
 
-	var rect := ColorRect.new()
-	rect.size = Vector2(visual_len, visual_h)
-	rect.position = -rect.size * 0.5
-	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
-
-	var mat := ShaderMaterial.new()
-	mat.shader = load(SHADER_PATH)
+	var rect := SkillVfx.make_lane_rect(self, Vector2(visual_len, visual_h), SHADER_PATH)
+	var mat := rect.material as ShaderMaterial
 	mat.set_shader_parameter("progress", 0.0)
 	mat.set_shader_parameter("life_t", 0.0)
 	mat.set_shader_parameter("scale_p", 0.0)
 	mat.set_shader_parameter("lane_pad", LANE_PAD)
 	mat.set_shader_parameter("shot_frac", SHOT_FRAC)
-	rect.material = mat
-	add_child(rect)
 
 	var pop := create_tween()
 	pop.set_ease(Tween.EASE_OUT)

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_evo_skill_effect.gdshader
@@ -1,6 +1,8 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha;
 
+#include "res://resources/tower/shared/lane_fx.gdshaderinc"
+
 // Josuiji Shinri "Heartpierce Shot" crit pierce-arrow VFX - EVOLVE tier.
 // Seamless pink COMET core (cel bands + living fbm warp) + braided light FILAMENTS tied to a
 // binding KNOT at the front tip + scattered sparkle/heart charm dots that linger past the bolt.
@@ -59,8 +61,9 @@ float heart(vec2 d, float s){
 }
 
 void fragment(){
-	float x = mix(-lane_pad, 1.0 + lane_pad, UV.x);
-	float y = UV.y - 0.5;
+	vec2 lc = lane_coord(UV, lane_pad);
+	float x = lc.x;
+	float y = lc.y;
 
 	float hr = max(head_r, 1e-3)    * 1.55;
 	float bw = max(beam_width, 1e-3)* 1.40;
@@ -70,7 +73,7 @@ void fragment(){
 	float launch = smoothstep(0.0, 0.10, progress);
 	float bolt_life = 1.0 - smoothstep(0.88, 1.0, progress);
 	float pop = mix(0.6, 1.0, smoothstep(0.0, 0.55, clamp(scale_p, 0.01, 1.2)));
-	float tower_gate = smoothstep(0.0, origin_soft, x);   // soft fade-in instead of a hard cut at the origin
+	float tower_gate = lane_origin_gate(x, origin_soft);   // soft fade-in at the lane origin (shared helper)
 
 	float dx = head_x - x;
 	float tt = clamp(dx / L, 0.0, 1.0);

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gd
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gd
@@ -39,18 +39,11 @@ func _spawn_effect(lane_len: float, dur: float) -> void:
 	var visual_len := lane_len * (1.0 + 2.0 * LANE_PAD)
 	var visual_h := VISUAL_H_CELLS * float(GridHelper.CELL_SIZE)
 
-	var rect := ColorRect.new()
-	rect.size = Vector2(visual_len, visual_h)
-	rect.position = -rect.size * 0.5           # centre on the node origin
-	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
-
-	var mat := ShaderMaterial.new()
-	mat.shader = load(SHADER_PATH)
+	var rect := SkillVfx.make_lane_rect(self, Vector2(visual_len, visual_h), SHADER_PATH)
+	var mat := rect.material as ShaderMaterial
 	mat.set_shader_parameter("progress", 0.0)
 	mat.set_shader_parameter("scale_p", 0.0)
 	mat.set_shader_parameter("lane_pad", LANE_PAD)
-	rect.material = mat
-	add_child(rect)
 
 	var pop := create_tween()
 	pop.set_ease(Tween.EASE_OUT)

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/skill_effect/shinri_skill_effect.gdshader
@@ -1,6 +1,8 @@
 shader_type canvas_item;
 render_mode blend_add;
 
+#include "res://resources/tower/shared/lane_fx.gdshaderinc"
+
 // Josuiji Shinri "Bull Eyes" crit pierce-arrow VFX - NORMAL tier.
 // Citrine comet: head orb + seamless tapered tail + release flash + Burst & Streak particles.
 // Lane-static: the head travels across the 1x4 lane via `progress` (0->1); the controller
@@ -26,14 +28,15 @@ float hash11(float x){ return fract(sin(x * 127.1) * 43758.5453); }
 float headx_at(float p){ return smoothstep(0.08, 0.95, p) * (1.0 + lane_pad * 0.35); }
 
 void fragment(){
-	float x = mix(-lane_pad, 1.0 + lane_pad, UV.x);
-	float y = UV.y - 0.5;
+	vec2 lc = lane_coord(UV, lane_pad);
+	float x = lc.x;
+	float y = lc.y;
 
 	float head_x = headx_at(progress);
 	float launch = smoothstep(0.0, 0.10, progress);
 	float life   = 1.0 - smoothstep(0.88, 1.0, progress);
 	float pop    = mix(0.6, 1.0, smoothstep(0.0, 0.55, clamp(scale_p, 0.01, 1.2)));
-	float tower_gate = smoothstep(0.0, origin_soft, x);   // soft fade-in instead of a hard cut at the origin
+	float tower_gate = lane_origin_gate(x, origin_soft);   // soft fade-in at the lane origin (shared helper)
 
 	float dx = head_x - x;
 	float bw = max(beam_width, 1e-3);

--- a/resources/tower/shared/lane_fx.gdshaderinc
+++ b/resources/tower/shared/lane_fx.gdshaderinc
@@ -1,0 +1,28 @@
+// Shared lane-effect shader helpers (Holo.Ve) - functions only, NO uniforms (each shader
+// keeps its own uniforms + ranges). #include this into lane-static directional skill-VFX
+// shaders so the bug-prone frame/origin math lives in ONE corner-free place.
+// See docs/shader.md "Skill-VFX families + checklist" for when to use these.
+
+// Soft fade-in at the lane origin. Replaces a hard step(0.0, lane_x) scissor at the caster,
+// which clipped the head/tail into a hard edge. softness = fade band in lane-x units.
+float lane_origin_gate(float lane_x, float softness) {
+	return smoothstep(0.0, max(softness, 1e-4), lane_x);
+}
+
+// Corner-free frame vignette. Replaces the axis-aligned ex*ey product, which leaves straight
+// rect edges + sharp corners (the recurring "rectangle behind the effect" bug).
+// fade_x / fade_y = fade band width per axis in UV units (x measured past aspect*0.5,
+// y past 0.5). IDENTICAL to ex*ey ON the edges (fy=0 -> 1-fx; fx=0 -> 1-fy) where content
+// lives; only the corner (both axes fading at once) is rounded by the Euclidean combine,
+// so a square corner can never appear.
+float lane_frame_mask(vec2 uv, float aspect, float fade_x, float fade_y) {
+	float fx = smoothstep(aspect * 0.5 - fade_x, aspect * 0.5, abs(uv.x));
+	float fy = smoothstep(0.5 - fade_y, 0.5, abs(uv.y));
+	return 1.0 - min(1.0, length(vec2(fx, fy)));
+}
+
+// Lane coordinate: UV.x -> lane-x in [-lane_pad, 1+lane_pad] (0 = caster/muzzle, 1 = range
+// end), and lane-y centred at 0. The standard mapping every lane shader hand-rolled.
+vec2 lane_coord(vec2 uv_in, float lane_pad) {
+	return vec2(mix(-lane_pad, 1.0 + lane_pad, uv_in.x), uv_in.y - 0.5);
+}

--- a/scripts/combat/skill_vfx.gd
+++ b/scripts/combat/skill_vfx.gd
@@ -1,0 +1,34 @@
+class_name SkillVfx
+
+# Shared helpers for lane-static skill-VFX controllers (composition, NOT a base class -
+# each controller keeps its own lifecycle/geometry/tweens). Pairs with the shader-side
+# helpers in resources/tower/shared/lane_fx.gdshaderinc. See docs/shader.md "Skill-VFX
+# families + checklist".
+
+# Resolve the RAW aim vector for a lane effect, caster-agnostic (no `as Tower`, so a future
+# non-Tower caster like a Staff works once SkillActionPlayEffect stops gating on Tower).
+# Ladder: live locked target on the caster -> snapshotted aim_dir (survives the target
+# dying mid-cast) -> ZERO. Un-normalized on purpose: each caller checks length() and applies
+# its own "no aim" fallback (Kiara normal skips orienting; Kiara evo keeps facing RIGHT).
+static func resolve_aim(caster, context) -> Vector2:
+	if caster != null:
+		var e = caster.get("enemy")
+		if e != null and is_instance_valid(e):
+			return e.global_position - caster.global_position
+	if context != null and context.extra.has("aim_dir"):
+		return context.extra["aim_dir"]
+	return Vector2.ZERO
+
+# Create a centred, click-through ColorRect running `shader_path`, parented to `parent`.
+# Returns the rect; the caller sets effect-specific uniforms on `rect.material` and drives
+# the tweens. (Uniforms set after add_child are fine - it is just material state.)
+static func make_lane_rect(parent: Node, size: Vector2, shader_path: String) -> ColorRect:
+	var rect := ColorRect.new()
+	rect.size = size
+	rect.position = -size * 0.5
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	var mat := ShaderMaterial.new()
+	mat.shader = load(shader_path)
+	rect.material = mat
+	parent.add_child(rect)
+	return rect


### PR DESCRIPTION
**Summary:** Extract the bug-prone frame-mask / origin-gate / lane-UV shader math and the aim-resolution + rect-creation GDScript boilerplate that the lane skill-VFX hand-rolled into one shared shader include + one `SkillVfx` helper, and migrate the 4 lane effects onto them. Look- and behaviour-preserving refactor (no intended visual change).

**How it works:**
- `resources/tower/shared/lane_fx.gdshaderinc` (functions-only, `#include`d by each lane shader): `lane_frame_mask(uv, aspect, fade_x, fade_y)` combines the two axis fades via `length()` so a square corner can never appear (replaces `ex*ey`); `lane_origin_gate(lane_x, softness)` (replaces `step(0.0,x)`); `lane_coord(UV, lane_pad)`. Identical to the old masks on the edges where content lives; only the empty frame corner is rounded.
- `scripts/combat/skill_vfx.gd` (`SkillVfx`): `resolve_aim(caster, context)` (the duplicated aim ladder, caster-agnostic) + `make_lane_rect(parent, size, shader_path)` (ColorRect+ShaderMaterial boilerplate).
- Migrated: Shinri nm/evo + Kiara nm/evo (shaders + controllers). Net +36 lines (+95/-59) at 4 effects - the win is single-source frame/origin math, not line count; the dedup pays off as more lane effects land. Amelia aura + Gura orbit are other VFX families, untouched.

**Implementation Notes:**
- Three VFX families by bug-surface (lane / aura / projectile-bullet); only the lane family carries the frame/origin bug class, so only it uses the helpers. A taxonomy + checklist for future effects lives in `docs/shader.md` (separate claude-state repo, not in this PR).
- Stacked on #56 (the muzzle offset) - these shaders build on its edits. Retarget to `main` once #56 merges.
- `resolve_aim` returns the raw aim or ZERO so each controller keeps its own no-target fallback; `caster.get("enemy")` is null-safe for a future non-Tower (staff) caster.

