### PR TITLE
Fix Pause/popup input lock by raising HUD controls above selection popups

### DIFF
--- a/resources/ui_component/game_ui.tscn
+++ b/resources/ui_component/game_ui.tscn
@@ -249,7 +249,10 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxTexture_v8yjg")
 
-[node name="TopRightControls" type="HBoxContainer" parent="."]
+[node name="TopControlsLayer" type="CanvasLayer" parent="."]
+layer = 3
+
+[node name="TopRightControls" type="HBoxContainer" parent="TopControlsLayer"]
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
@@ -260,14 +263,14 @@ offset_bottom = 58.0
 grow_horizontal = 0
 theme_override_constants/separation = 20
 
-[node name="SpeedButton" type="Button" parent="TopRightControls"]
+[node name="SpeedButton" type="Button" parent="TopControlsLayer/TopRightControls"]
 custom_minimum_size = Vector2(76, 42)
 layout_mode = 2
 focus_mode = 0
 text = "x2"
 script = ExtResource("7_6qfka")
 
-[node name="Button" type="Button" parent="TopRightControls"]
+[node name="Button" type="Button" parent="TopControlsLayer/TopRightControls"]
 custom_minimum_size = Vector2(76, 42)
 layout_mode = 2
 text = "Pause"


### PR DESCRIPTION
**Problem:** Pressing Pause at the same instant a tower-select / deck-add popup opens could set `get_tree().paused` while the popup's full-screen modal scrim (`CanvasLayer` layer 2) covered the Pause button. The popup root is `PROCESS_MODE_INHERIT`, so it froze while paused, and the now-covered Pause button could not be clicked to unpause -- both UIs became unclickable.
**Impact:** Permanent input lock mid-run; the player had to quit and restart the game.
**Fix:** Move the top-right HUD controls (x2 speed + Pause) onto a dedicated `CanvasLayer` (layer 3) above the popup scrim, so they win the GUI input pick over the modal and stay clickable while paused (both buttons already run `PROCESS_MODE_ALWAYS`). The rest of the HUD stays under the modal popup. One scene reparent, no script changes; covers both the tower-select and the deck-add popup (same scene).
**Touched scenes:** resources/ui_component/game_ui.tscn
