### PR TITLE
feat(shinri): normal-attack dynamic-arrow bullet VFX

### DIFF
--- a/resources/combat/bullets/shinri_normal_bullet.tscn
+++ b/resources/combat/bullets/shinri_normal_bullet.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=7 format=3 uid="uid://cshinriarrowbul0"]
+
+[ext_resource type="Script" path="res://scripts/combat/projectile.gd" id="1_proj"]
+[ext_resource type="Shader" path="res://resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/normal_effect/shinri_arrow.gdshader" id="2_shdr"]
+
+[sub_resource type="Gradient" id="Gradient_w"]
+offsets = PackedFloat32Array(0, 1)
+colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradTex_w"]
+gradient = SubResource("Gradient_w")
+width = 154
+height = 64
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_b"]
+shader = ExtResource("2_shdr")
+
+[sub_resource type="CircleShape2D" id="Circle_b"]
+radius = 36.0
+
+[node name="ShinriNormalBullet" type="Area2D"]
+script = ExtResource("1_proj")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+material = SubResource("ShaderMaterial_b")
+texture = SubResource("GradTex_w")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("Circle_b")

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -8,6 +8,22 @@ attack_sound: "hit_shinri"
 open_sound: "debut_shinri"
 evolve_sound: "evo_shinri"
 
+# Normal attack = homing arrow bullet (dynamic arrow VFX). Damage lands ONCE per shot
+# (projectile mode); on a crit the passive fires the citrine pierce arrow instead.
+# Colours MUST be set here: TowerAttackConfig defaults are warm-gold, and the bullet
+# visual always pushes core_color/mid_color into the shader. Shape is baked in
+# shinri_arrow.gdshader; speed/size/glow/colour are tunable here. size = arrow HEIGHT px.
+attack:
+  mode: projectile
+  projectile: "res://resources/combat/bullets/shinri_normal_bullet.tscn"
+  vfx_shader: "res://resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/normal_effect/shinri_arrow.gdshader"
+  speed: 12
+  size: 72
+  burst: 1
+  glow_softness: 0.12
+  core_color: [1.0, 1.0, 1.0]
+  mid_color: [0.90, 0.94, 1.0]
+
 # Josuiji Shinri has no Active skill and no Energy — her kit is a pure Passive.
 # Stats omit mana/intialMana on purpose: with no active skill the tower builds
 # no Energy bar (see Tower._hasActiveSkill / _setupPassive).

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/normal_effect/shinri_arrow.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/normal_effect/shinri_arrow.gdshader
@@ -1,0 +1,62 @@
+shader_type canvas_item;
+render_mode blend_add;
+
+// Josuiji Shinri - normal-attack bullet (dynamic arrow). First production bullet drawn
+// entirely in-shader (no sprite texture sampled, so no black rim), mirroring Watson
+// Amelia's Soft Glow. A swept arrowHEAD (triangle minus a back notch -> two arms + concave
+// back) UNIONed with a thin TAIL spike that tapers to a back point + a soft additive glow.
+// STATIC by design (no internal TIME) - the motion is the projectile's transform. The bullet
+// .tscn quad is authored WIDE (154x64) so the long axis = local +X = travel/forward; the
+// Projectile node (projectile.gd) rotates to face its target. White/blue-white only =>
+// blend_add is safe (shader.md). Do NOT use MODULATE (custom-COLOR fragment won't apply it).
+//
+// attack_controller._applyBulletVisual pushes core_color / mid_color / glow_softness from the
+// tower's attack_config (YAML). arm_hh / notch / tail_hh / intensity are NOT pushed, so their
+// defaults below ARE the shipped shape (V1) - tune the shape here, tune colour/glow in YAML.
+
+uniform vec4  core_color : source_color = vec4(1.0, 1.0, 1.0, 1.0);
+uniform vec4  mid_color  : source_color = vec4(0.90, 0.94, 1.0, 1.0);
+uniform float arm_hh  : hint_range(0.25, 0.50) = 0.46;     // arrowhead arm spread (half-height)
+uniform float notch   : hint_range(0.0, 0.85) = 0.50;      // back V-notch depth (arm separation)
+uniform float tail_hh : hint_range(0.03, 0.20) = 0.11;     // tail spike thickness
+uniform float glow_softness : hint_range(0.0, 0.5) = 0.12; // glow halo width past the silhouette
+uniform float intensity : hint_range(0.0, 2.5) = 1.20;     // baked (config never pushes this)
+uniform float alpha_mul : hint_range(0.0, 1.0) = 1.0;      // spawn-in / fade hook
+
+void fragment() {
+	vec2 q = UV - 0.5;          // -0.5..0.5; +x = forward (tip), y = across
+	float ay = abs(q.y);
+	float aa = 0.010;
+
+	float tipx  = 0.48;         // front point
+	float hbx   = -0.10;        // arrowhead base x (arm tips sit here, swept back)
+	float tailx = -0.48;        // tail back point
+	float tf    = 0.06;         // tail front x (overlaps the head base so they fuse)
+
+	// ARROWHEAD: outer triangle (tip -> base) minus a back notch = two swept arms.
+	float in_head = step(hbx, q.x) * step(q.x, tipx);
+	float oh = arm_hh * clamp((tipx - q.x) / (tipx - hbx), 0.0, 1.0);
+	float outer = (1.0 - smoothstep(oh - aa, oh + aa, ay)) * in_head;
+	float nx = mix(hbx, tipx - 0.08, notch);
+	float in_notch = step(hbx, q.x) * step(q.x, nx);
+	float nh = arm_hh * clamp((nx - q.x) / max(nx - hbx, 0.001), 0.0, 1.0);
+	float notch_a = (1.0 - smoothstep(nh - aa, nh + aa, ay)) * in_notch;
+	float head = clamp(outer - notch_a, 0.0, 1.0);
+
+	// TAIL: thin spike tapering from the head base to a back point.
+	float in_tail = step(tailx, q.x) * step(q.x, tf);
+	float th = tail_hh * clamp((q.x - tailx) / (tf - tailx), 0.0, 1.0);
+	float tail = (1.0 - smoothstep(th - aa, th + aa, ay)) * in_tail;
+
+	float body = clamp(max(head, tail), 0.0, 1.0);
+
+	// GLOW: halo hugging the outer silhouette (arms + tail), kept out of the carved notch.
+	float head_glow = clamp((1.0 - smoothstep(oh, oh + glow_softness, ay)) * in_head - notch_a, 0.0, 1.0);
+	float tail_glow = (1.0 - smoothstep(th, th + glow_softness, ay)) * in_tail;
+	float glow = max(head_glow, tail_glow);
+	float tip_bloom = (1.0 - smoothstep(0.0, 0.09, length(q - vec2(tipx, 0.0)))) * 0.35;
+
+	float a = clamp(max(body, max(glow * 0.5, tip_bloom)), 0.0, 1.0);
+	vec3 col = mix(mid_color.rgb, core_color.rgb, body) * intensity;
+	COLOR = vec4(col, a * alpha_mul);
+}


### PR DESCRIPTION
**Summary:** Adds Josuiji Shinri's normal-attack projectile bullet - a white / blue-white dynamic arrow - so her normal shot finally has a VFX (it was hitscan with no visual). Crit shots still fire the existing citrine pierce arrow.

**How it works:** Reuses the existing "Projectile-drawn bullet" pipeline (the YAML `attack:` block, mirroring Watson Amelia's Soft Glow). A new `attack: mode: projectile` block in `josuiji_shinri.yaml` points at a new bullet scene + shader; `TowerDataLoader` / `attack_controller` / `ResourceManager` (all unchanged) spawn the homing bullet, push colour/glow uniforms, scale the sprite, and pre-warm the shader. The arrow is drawn entirely in-shader (swept arrowhead + tapered tail + additive glow); the long-low aspect comes from a wide 154x64 quad. Data + assets only - no engine code changes.

**Implementation Notes:**
- Colours are set explicitly in the YAML because `TowerAttackConfig`'s defaults are warm-gold (they mirror Amelia's bullet); omitting them would render Shinri's arrow gold. Cleanup of that shared-default trap is tracked as a separate task.
- Shape params (arm / notch / tail / intensity) are baked as shader defaults since `_applyBulletVisual` only pushes colour/glow; speed / size / glow / colour stay YAML-tunable.
- Non-crit shots now deal damage on hit (slight travel) instead of instantly (hitscan) - accepted; matches the Amelia bullet. Bull Eyes stacking + the crit pierce path are unaffected.
- Director-tested in Godot: normal arrow visual, crit pierce coexistence, first-shot shader warm, damage/evolve regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
