### PR TITLE
refactor(bullet): shader defaults own the look; YAML overrides only set uniforms

### DIFF
--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -10,9 +10,9 @@ evolve_sound: "evo_shinri"
 
 # Normal attack = homing arrow bullet (dynamic arrow VFX). Damage lands ONCE per shot
 # (projectile mode); on a crit the passive fires the citrine pierce arrow instead.
-# Colours MUST be set here: TowerAttackConfig defaults are warm-gold, and the bullet
-# visual always pushes core_color/mid_color into the shader. Shape is baked in
-# shinri_arrow.gdshader; speed/size/glow/colour are tunable here. size = arrow HEIGHT px.
+# Colours set here OVERRIDE shinri_arrow.gdshader's own defaults; omit a colour to keep
+# the shader default. Shape is baked in the shader; speed/size/glow/colour are tunable
+# here. size = arrow HEIGHT px.
 attack:
   mode: projectile
   projectile: "res://resources/combat/bullets/shinri_normal_bullet.tscn"

--- a/scripts/entity/attack_controller.gd
+++ b/scripts/entity/attack_controller.gd
@@ -121,9 +121,10 @@ func _onProjectileHit(proj: Projectile, target, saved_gen: int) -> void:
 		(target as Enemy).recvDamage(proj.damage)
 		executeModifier()
 
-# Scales sprite + collision to cfg.size and pushes the Soft Glow uniforms. Duplicates
-# the shared ShaderMaterial / CircleShape2D so per-bullet (and per-tower) tuning never
-# mutates the scene's shared resources.
+# Scales sprite + collision to cfg.size and pushes ONLY the shader-uniform overrides the
+# YAML actually set (cfg.visual_overrides); anything omitted keeps the shader's own default.
+# Duplicates the shared ShaderMaterial / CircleShape2D so per-bullet (and per-tower) tuning
+# never mutates the scene's shared resources.
 func _applyBulletVisual(proj: Projectile, cfg: TowerAttackConfig) -> void:
 	for child in proj.get_children():
 		if child is Sprite2D:
@@ -133,10 +134,8 @@ func _applyBulletVisual(proj: Projectile, cfg: TowerAttackConfig) -> void:
 			if spr.material is ShaderMaterial:
 				var mat := (spr.material as ShaderMaterial).duplicate() as ShaderMaterial
 				spr.material = mat
-				mat.set_shader_parameter("core_color", cfg.core_color)
-				mat.set_shader_parameter("mid_color", cfg.mid_color)
-				mat.set_shader_parameter("edge_color", cfg.edge_color)
-				mat.set_shader_parameter("glow_softness", cfg.glow_softness)
+				for uniform_name in cfg.visual_overrides:
+					mat.set_shader_parameter(uniform_name, cfg.visual_overrides[uniform_name])
 		elif child is CollisionShape2D:
 			var cs := child as CollisionShape2D
 			if cs.shape is CircleShape2D:

--- a/scripts/entity/tower/tower_attack_config.gd
+++ b/scripts/entity/tower/tower_attack_config.gd
@@ -6,24 +6,30 @@ extends RefCounted
 ##
 ## mode "projectile": the tower fires `burst` homing bullets at its target. Only
 ## ONE bullet carries damage (design A: the burst is visual; damage lands once),
-## so balance is unchanged vs a single hitscan hit. Visual tunables (size, colours,
-## glow_softness) drive the bullet's ShaderMaterial; speed is tiles/sec.
+## so balance is unchanged vs a single hitscan hit. `speed` is tiles/sec; `size` is
+## the bullet height/diameter px (drives sprite scale AND collision radius).
+##
+## Visual model: the bullet's SHADER owns the default look. The `attack:` block may
+## OVERRIDE shader uniforms (core_color/mid_color/edge_color/glow_softness); only keys
+## present in YAML go into visual_overrides and get pushed (see _applyBulletVisual), so
+## an omitted uniform keeps the shader's OWN default - never another tower's value.
 
 const MODE_HITSCAN := "hitscan"
 const MODE_PROJECTILE := "projectile"
+
+# Colour uniforms the `attack:` block may override (parsed from "#rrggbb" or [r,g,b(,a)]).
+const COLOR_KEYS = ["core_color", "mid_color", "edge_color"]
 
 var mode: String = MODE_HITSCAN
 var projectile_scene: PackedScene = null
 var vfx_shader: String = ""          # shader path, for ResourceManager warm (avoids first-fire hitch)
 var speed: float = 9.0               # tiles/sec (converted to px at spawn via GridHelper.CELL_SIZE)
-var size: float = 84.0               # bullet diameter px (drives sprite scale AND collision radius)
+var size: float = 84.0               # bullet height/diameter px (drives sprite scale AND collision radius)
 var burst: int = 3                   # rounds fired per attack (visual; damage still lands once)
-var glow_softness: float = 0.3       # Soft Glow halo width
 
-# Warm-gold defaults mirror amelia_bullet.gdshader's uniform defaults.
-var core_color: Color = Color(1.0, 0.98, 0.86)
-var mid_color: Color = Color(1.0, 0.84, 0.45)
-var edge_color: Color = Color(0.86, 0.52, 0.18)
+# Shader-uniform overrides explicitly set in YAML (uniform name -> value). ONLY these are
+# pushed onto the bullet material; any uniform not here keeps the shader's own default.
+var visual_overrides: Dictionary = {}
 
 func is_projectile() -> bool:
 	return mode == MODE_PROJECTILE
@@ -35,10 +41,19 @@ static func from_dict(d: Dictionary) -> TowerAttackConfig:
 	cfg.speed = float(d.get("speed", cfg.speed))
 	cfg.size = float(d.get("size", cfg.size))
 	cfg.burst = max(1, int(d.get("burst", cfg.burst)))   # never 0 bullets
-	cfg.glow_softness = float(d.get("glow_softness", cfg.glow_softness))
-	cfg.core_color = _parse_color(d.get("core_color", null), cfg.core_color)
-	cfg.mid_color = _parse_color(d.get("mid_color", null), cfg.mid_color)
-	cfg.edge_color = _parse_color(d.get("edge_color", null), cfg.edge_color)
+
+	# Store ONLY the visual uniforms the YAML actually sets (presence = `d.has(key)`), so
+	# the shader's own defaults stand for anything omitted - a bullet never inherits
+	# another tower's colours. A present-but-malformed colour warns and is skipped.
+	for key in COLOR_KEYS:
+		if d.has(key):
+			var parsed = _try_parse_color(d[key])
+			if parsed is Color:
+				cfg.visual_overrides[key] = parsed
+			else:
+				push_warning("TowerAttackConfig: malformed colour for '" + key + "' (" + str(d[key]) + "); keeping the shader default.")
+	if d.has("glow_softness"):
+		cfg.visual_overrides["glow_softness"] = float(d["glow_softness"])
 
 	var scene_path := str(d.get("projectile", ""))
 	if scene_path != "":
@@ -54,11 +69,12 @@ static func from_dict(d: Dictionary) -> TowerAttackConfig:
 
 	return cfg
 
-# Accepts a "#rrggbb"/"#rrggbbaa" hex string OR an [r,g,b(,a)] float array; else default.
-static func _parse_color(value, default_color: Color) -> Color:
+# Returns a Color from a "#rrggbb"/"#rrggbbaa" string or an [r,g,b(,a)] float array,
+# or null when the value is not a usable colour (caller keeps the shader default).
+static func _try_parse_color(value) -> Variant:
 	if value is String and value != "":
 		return Color(value)
 	if value is Array and value.size() >= 3:
 		var a: float = float(value[3]) if value.size() >= 4 else 1.0
 		return Color(float(value[0]), float(value[1]), float(value[2]), a)
-	return default_color
+	return null


### PR DESCRIPTION
**Summary:** Bullet colours now follow "shader default wins; YAML `attack:` overrides only the uniforms it sets". Removes the trap where a new projectile-bullet tower that omitted colours silently inherited Amelia's warm-gold config default (an artist-UX surprise hit during PR #59).

**How it works:** `TowerAttackConfig` records only the visual uniforms the YAML explicitly sets (`visual_overrides`); `attack_controller._applyBulletVisual` pushes only those, so any omitted uniform keeps the bullet shader's OWN default - a bullet never inherits another tower's colours.

**Implementation Notes:**
- Behaviour-preserving (Director-tested in Godot): Amelia omits colours and `amelia_bullet.gdshader`'s defaults equal the old config defaults, so it falls through to the same warm-gold; Shinri sets white explicitly. Both render identically.
- Single consumer: bullet colours were pushed only at `_applyBulletVisual:136-139`; nothing else read them. Removed the warm-gold default colour fields from `TowerAttackConfig`.
- A present-but-malformed colour warns and is skipped (shader default applies).
- Scope: bullet family only - does not touch PR #57's lane-helper / skill-effect family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
