### PR TITLE
Data-driven synergy framework + Myth synergy + synergy UI

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -37,6 +37,10 @@ window/stretch/aspect="expand"
 
 enabled=PackedStringArray("res://addons/load_map_data/plugin.cfg")
 
+[gui]
+
+timers/tooltip_delay_sec=0.15
+
 [input]
 
 move_up={

--- a/resources/database/synergy/assassin.yaml
+++ b/resources/database/synergy/assassin.yaml
@@ -1,0 +1,9 @@
+id: assassin
+name: "Assassin"
+kind: class
+type: normal
+# Placeholder: thresholds carried from the old hardcoded table for UI counting.
+# Effect not wired yet - Director defines it when Assassin enters scope.
+effect: none
+thresholds: [3, 4, 6]
+desc: "Assassin synergy effect not yet defined."

--- a/resources/database/synergy/diva.yaml
+++ b/resources/database/synergy/diva.yaml
@@ -1,0 +1,8 @@
+id: diva
+name: "Diva"
+kind: class
+type: normal
+# Placeholder: thresholds carried for UI counting; effect not wired yet.
+effect: none
+thresholds: [2, 3]
+desc: "Diva synergy effect not yet defined."

--- a/resources/database/synergy/gen1.yaml
+++ b/resources/database/synergy/gen1.yaml
@@ -1,0 +1,8 @@
+id: gen1
+name: "Gen1"
+kind: generation
+type: normal
+# Placeholder: thresholds carried for UI counting; effect not wired yet.
+effect: none
+thresholds: [2, 4]
+desc: "Gen1 synergy effect not yet defined."

--- a/resources/database/synergy/hero.yaml
+++ b/resources/database/synergy/hero.yaml
@@ -1,0 +1,8 @@
+id: hero
+name: "Hero"
+kind: class
+type: normal
+# Placeholder: thresholds carried for UI counting; effect not wired yet.
+effect: none
+thresholds: [3]
+desc: "Hero synergy effect not yet defined."

--- a/resources/database/synergy/myth.yaml
+++ b/resources/database/synergy/myth.yaml
@@ -1,0 +1,17 @@
+id: myth
+name: "Myth"
+kind: generation
+type: normal
+effect: energy_on_skill_cast
+# Proc count required for tier 1 / 2 / 3.
+thresholds: [3, 4, 5]
+# Energy restored per tier (single source for both the effect and the desc).
+parameters:
+  energy_return: [5, 7, 10]
+# Hover header (flavour). {energy_return} resolves to the current tier's value
+# and is auto-highlighted by the UI as the scaling number. Voice: units are
+# people - use they/them, never it/its (see game_copy.md voice rule).
+desc_template: "Myth units possess the power of a primordial age, and whenever they cast a skill, all of them restore {energy_return} Energy."
+# Hover per-tier table line. One entry -> used for every tier (pure scaling).
+tier_effects:
+  - "Restore {energy_return} Energy"

--- a/resources/database/synergy/synergy_list.yaml
+++ b/resources/database/synergy/synergy_list.yaml
@@ -1,0 +1,10 @@
+# Synergy roster manifest. Each id maps to <id>.yaml in this folder.
+# Manifest-driven (not a folder scan) so it works in an exported PCK,
+# matching enemy_list.yaml / decks.yaml.
+synergies:
+  - myth
+  - assassin
+  - diva
+  - hero
+  - gen1
+  - tempus

--- a/resources/database/synergy/tempus.yaml
+++ b/resources/database/synergy/tempus.yaml
@@ -1,0 +1,9 @@
+id: tempus
+name: "Tempus"
+kind: generation
+# Quest-type: tier unlocks by completing a condition (e.g. kill count).
+# Placeholder: the quest mechanic is not wired yet (see agent_lessons P2-C).
+type: quest
+effect: none
+thresholds: [2, 4, 6]
+desc: "Tempus quest synergy not yet defined."

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -41,7 +41,6 @@ var enemy: Enemy = null;
 
 var IDLE_ANIMATION = "idle";
 var ATTACK_ANIMATION = "n_attack";
-var noActionKey = ["synergy_id", "syn_attack_percent", "tier"];
 
 
 func getAttackAnimationSpeed():
@@ -64,6 +63,7 @@ func _ready():
 
 		skillController = SkillController.new(self,maxMana, initMana, data.skill);
 		Utility.ConnectSignal(skillController, "on_mana_updated", Callable(self, "update_mana_bar"));
+		Utility.ConnectSignal(skillController, "cast_succeeded", Callable(self, "_on_cast_succeeded"));
 	elif manaBar != null:
 		# No active skill (e.g. passive-only tower) -> no Energy bar.
 		manaBar.visible = false;
@@ -182,6 +182,7 @@ func evolve():
 			var stat = data.getStat()
 			skillController = SkillController.new(self, stat.mana, stat.intialMana, data.evolutionSkill)
 			Utility.ConnectSignal(skillController, "on_mana_updated", Callable(self, "update_mana_bar"))
+			Utility.ConnectSignal(skillController, "cast_succeeded", Callable(self, "_on_cast_succeeded"))
 			# Refresh manaBar visual to match the new evolved stat:
 			# - setup() re-applies the new max so the bar's full-bar fills at the
 			#   evolved cap (e.g., Kiara 50 -> 80) instead of the base cap.
@@ -338,60 +339,9 @@ func update_mana_bar(current: float):
 
 	manaBar.updateValue(current)
 
-func processActiveBuff(buff: Dictionary, extraKey: String = ""):
-	if(!isReady):
-		call_deferred("processActiveBuff", buff, extraKey);
-		return;
-
-	var synergy_id = buff.get("synergy_id", null)
-	if synergy_id == null:
-		return
-
-	for key in buff.keys():
-		if noActionKey.has(key):
-			continue;
-
-		var value = buff[key]
-		match key:
-			"attack_bonus":
-				var b := BuffInstance.new(
-					str(synergy_id) + extraKey + "_atk_flat",
-					BuffInstance.StatType.ATTACK_FLAT,
-					float(value),
-					BuffInstance.Category.BUFF,
-				)
-				data.buffs.add(b)
-			"attack_bonus_percent":
-				var b := BuffInstance.new(
-					str(synergy_id) + extraKey + "_atk_mult",
-					BuffInstance.StatType.ATTACK_MULT,
-					float(value),
-					BuffInstance.Category.BUFF,
-				)
-				data.buffs.add(b)
-			"rangeBuff":
-				data.addAttackRangeBuff(value, str(synergy_id) + extraKey)
-			"mana_regen":
-				data.addManaRegenBuff(value, str(synergy_id) + extraKey)
-			"crit_chance_bonus_percent":
-				data.addCritChanceBuff(value, str(synergy_id) + extraKey)
-			"on_skill_cast":
-				if(skillController):
-					skillController.addModifier(synergy_id, value)
-			"on_attack":
-				if(attackController):
-					attackController.addModifier(synergy_id, value)
-			"mission":
-				onReceiveMission.emit(value);
-			"interval_action":
-				var isBonus = (value.get("bonus").condition as Callable).call(synergy_id);
-				addIntervalAction(str(synergy_id), value.interval, value.action, value.value if !isBonus else value.bonus.value);
-			"syn_attack_percent":
-				pass;
-			"tier":
-				pass;
-			_:
-				print("Unknown synergy buff key: ", key)
+func _on_cast_succeeded(_skill):
+	# A fully successful skill cast -> notify the synergy system (e.g. Myth team battery).
+	skill_cast_succeeded.emit(self)
 
 func resetForWave():
 	attacking = false
@@ -425,29 +375,6 @@ func resetForWave():
 			child.queue_free()
 
 	play_animation_default()
-
-func addIntervalAction(key,interval: float, action: String, value: float):
-	var callable: Callable;
-	match action:
-		"regen_mana":
-			callable = Callable(self, "regenMana").bind(value);
-
-	if not callable:
-		printerr("invalid interval action: ", action);
-		return
-
-	var exist = find_child(key);
-
-	if(exist):
-		exist.queue_free();
-
-	var timer = Timer.new();
-	timer.name = key;
-	timer.set_wait_time(interval);
-	timer.set_one_shot(false);
-	timer.connect("timeout", callable);
-	add_child(timer);
-	timer.start();
 
 func showAttackRange(show: bool):
 	if enemyDetector != null:
@@ -487,3 +414,5 @@ func removeDecreaseDmgAllPercent(key: String):
 
 signal onReceiveMission(mission: MissionDetail);
 signal on_animation_finished(name: String);
+# Emitted after this tower completes a skill cast (drives synergy effects).
+signal skill_cast_succeeded(tower);

--- a/scripts/entity/tower/tower_factory.gd
+++ b/scripts/entity/tower/tower_factory.gd
@@ -1,9 +1,6 @@
 extends Node
 class_name TowerFactory
 
-const TowerClass = preload("res://scripts/entity/tower/tower_trait.gd").TowerClass
-const TowerGeneration = preload("res://scripts/entity/tower/tower_trait.gd").TowerGeneration
-
 @onready var uiSynergy: UISynergy = $"../GameUI/UISynergy"
 
 @export var towerTemplate: PackedScene
@@ -14,8 +11,7 @@ var towerTrait: TowerTrait = TowerTrait.new()
 var towersByName: Dictionary = {}
 var towers: Dictionary = {}
 var _evolutionList: Dictionary = {}
-var activeSynergies: Dictionary = {}
-var activeMissionBuff: Dictionary = {}
+var synergyController: SynergyController
 
 enum TowerId {
 	Test
@@ -25,8 +21,9 @@ func setup(onPlace: Callable, onRemove: Callable):
 	self.onPlace = onPlace
 	self.onRemove = onRemove
 
-	Utility.ConnectSignal(towerTrait, "synergy_activated", Callable(self, "onActivateSynergy"));
-	Utility.ConnectSignal(towerTrait, "mission_completed", Callable(self, "onMissionCompleted"));
+	synergyController = SynergyController.new()
+	synergyController.setup(self)
+	Utility.ConnectSignal(towerTrait, "synergy_updated", Callable(self, "_on_synergy_updated"));
 
 func getTower(name: String, evoToken: int = 0) -> GetTowerResult:
 	var resource = ResourceManager.getTower(name);
@@ -34,7 +31,6 @@ func getTower(name: String, evoToken: int = 0) -> GetTowerResult:
 	if(resource == null && towerTemplate != null):
 		resource = towerTemplate
 
-	print("resource:", resource, " towerTemplate:", towerTemplate);
 	if (resource == null):
 		return null
 
@@ -68,48 +64,13 @@ func getTower(name: String, evoToken: int = 0) -> GetTowerResult:
 	result.tower = tower;
 	tower.setup(name, onPlace, onRemove)
 	Utility.ConnectSignal(tower, "onReceiveMission", Callable(self, "towerReceiveMission"));
+	Utility.ConnectSignal(tower, "skill_cast_succeeded", Callable(synergyController, "on_tower_cast"));
+	# Register traits in the keyed list BEFORE add_tower_traits so a synergy that
+	# activates on this placement already counts the new tower.
 	for towerSyn in [tower.data.towerClass, tower.data.generation]:
-		if towerSyn == 0:  # Skip default/unset values
-			continue
-
-		# Apply active towerSynergy buffs to new tower
-		var activeSyn = activeSynergies.get(towerSyn, [])
-		for buff: Dictionary in activeSyn:
-			var mission: MissionDetail = buff.get("mission", null);
-			if(mission == null):
-				var tier = buff.get("tier", "")
-				tower.processActiveBuff(buff, str(tier))
-
-			var checkAndProcessActiveMissionSyn = func(synergyId, tier, missionBuff):
-				if synergyId == tower.data.generation || synergyId == tower.data.towerClass:
-					tower.processActiveBuff(missionBuff, str(tier));
-
-			for missionBuff in activeMissionBuff.values():
-				var tier = missionBuff.get("tier", "")
-				var synergyId = missionBuff.get("synergy_id", -1);
-				if not synergyId is Array:
-					checkAndProcessActiveMissionSyn.call(synergyId, tier, missionBuff);
-				else:
-					var synergyArray: Array = synergyId as Array;
-					for syn in synergyArray:
-						checkAndProcessActiveMissionSyn.call(syn, tier, missionBuff);
-
 		addTowerToDict(name, tower, towerSyn)
-
-		if uiSynergy != null:
-			var synName = towerTrait.getSynergyName(towerSyn);
-			if (synName == "Unknown"):
-				printerr("found unknown synergy:", towerSyn);
-				return;
-			# print("setup syn:", synName);
-			if not uiSynergy.hasContent(synName):
-				var maxSyn = towerTrait.getSynergyMaxCount(towerSyn);
-				var minReq = towerTrait.getMinRequirement(towerSyn);
-				uiSynergy.addNewSynergy(synName, minReq, maxSyn);
-
-			uiSynergy.addSynergy(synName);
-
 	towerTrait.add_tower_traits([tower.data.towerClass, tower.data.generation])
+	synergyController.on_tower_added(tower)
 	return result
 
 func returnTower(tower: Tower):
@@ -170,68 +131,24 @@ func evolutionTower(name: String):
 		_evolutionList.erase(dataName);
 		TowerCenter._evolvedList.append(dataName);
 
-func onActivateSynergy(synergy_id: int, tier: int, buff: Dictionary):
-	if not activeSynergies.has(synergy_id):
-		activeSynergies[synergy_id] = []
-
-	activeSynergies[synergy_id].append(buff)
-
-	# Apply buff to all towers with this synergy
-	if towers.has(synergy_id):
-		var starGen1Damage = 0;
-		var isStarGen1 = false;
-
-		for tower: Tower in towers[synergy_id]:
-			tower.processActiveBuff(buff, str(tier));
-
-			if synergy_id == TowerGeneration.Gen1:
-				isStarGen1 = true;
-				starGen1Damage += tower.data.getDamage(null, tower).damage;
-
-		if isStarGen1:
-			towerTrait.setStarGen1Damage(starGen1Damage);
-
-func onMissionCompleted(id: int, buff: Dictionary):
-	var synergyId = buff.get("synergy_id", -1);
-	if not synergyId is Array && synergyId == -1:
-		return;
-	var tier = buff.get("tier", 0);
-	var process = func(syn) -> Array:
-		var towersArr: Array = towers.get(syn, []);
-		for tower: Tower in towersArr:
-			tower.processActiveBuff(buff, str(synergyId) + str(tier));
-		return towersArr;
-
-	if synergyId is Array:
-		var synergyArray = synergyId as Array;
-		print("processing buff to:", synergyArray);
-		for syn in synergyArray:
-			process.call(syn);
-	else:
-		process.call(synergyId);
-
-	activeMissionBuff[id] = buff;
-	#print("on mission complete id:", id, "synergy: ", synergyId, " buff:", buff);
+func _on_synergy_updated(synergy_id: int, count: int, tier: int):
+	synergyController.on_synergy_updated(synergy_id, count, tier)
+	if uiSynergy == null:
+		return
+	# Only show synergies that are actually defined in YAML; an undefined trait
+	# (no data) can never activate, so it is not a meaningful panel row.
+	var data: SynergyData = ResourceManager.getSynergyData(synergy_id)
+	if data == null:
+		return
+	uiSynergy.updateSynergy(data.display_name, count, tier, synergy_id)
 
 func onWaveStart():
-	processGen0Buff()
+	pass   # reserved for future per-wave synergy hooks
 
 func onWaveEnd():
 	for tower: Tower in towersByName.values():
 		if is_instance_valid(tower):
 			tower.resetForWave()
-
-func processGen0Buff():
-	if (!activeSynergies.has(TowerGeneration.Gen0)):
-		return;
-
-	var buffs:Dictionary = activeSynergies.get(TowerGeneration.Gen0);
-	var buffDmgPercent:int = buffs.get("syn_atk_percent", 0);
-
-	var towerList: Array = towers.get(TowerGeneration.Gen0);
-	for t: Tower in towerList:
-		var buff: Dictionary = {"synergy_id": TowerGeneration.Gen0, "attack_bonus": (buffDmgPercent * towerList.size())};
-		t.processActiveBuff(buff)
 
 func towerReceiveMission(mission: MissionDetail):
 	onReceiveMission.emit(mission);

--- a/scripts/entity/tower/tower_trait.gd
+++ b/scripts/entity/tower/tower_trait.gd
@@ -24,100 +24,12 @@ const TOWER_GENERATION_NAMES := {
 	TowerGeneration.Indo1: "Indo1",
 }
 
-# Multi-tier synergy requirements
-const SYNERGY_REQUIREMENTS := {
-	TowerClass.Assassin: [3, 4, 6],
-	TowerClass.Diva: [2, 3],
-	TowerClass.Hero: [3],
-	TowerGeneration.Myth: [2, 3],
-	TowerGeneration.Gen1: [2, 4],
-	TowerGeneration.Tempus: [2, 4, 6]
-	# Add more as needed
-}
-
-# Buffs per tier (indexed by synergy_id and tier index)
-var SYNERGY_BUFFS = {
-	TowerClass.Assassin: [
-		{
-			"crit_chance_bonus_percent": 5,
-			"on_critical": Callable(self, "onAssassinCritHit")
-		},
-		{
-			"crit_chance_bonus_percent": 10
-		},
-	],
-	TowerClass.Diva: [
-		{
-			"interval_action":
-			{
-				"interval": 5,
-				"action": "regen_mana",
-				"value": 5,
-				"bonus":
-					{
-						"condition": Callable(self, "checkBonusDivaSynergy"),
-						"value": 10
-					}
-			}
-		},
-		{
-			"interval_action":
-			{
-				"interval": 5,
-				"action": "regen_mana",
-				"value": 10,
-				"bonus":
-					{
-						"condition": Callable(self, "checkBonusDivaSynergy"),
-						"value": 20
-					}
-			}
-		}
-	],
-	TowerClass.Hero: [
-		{
-			# "aura": Callable(self, "heroSynergyEffect")
-		},
-	],
-	TowerClass.Marksman: [
-		{}
-	],
-	TowerGeneration.Gen0: [
-		{ "syn_attack_percent": 4 },
-		{ "syn_attack_percent": 6 },
-		{ "syn_attack_percent": 10 }
-	],
-	TowerGeneration.Gen1: [
-		{
-			"on_attack": Callable(self, "starGen1SynergySkill").bind(20, 50)
-		},
-		{
-			"on_attack": Callable(self, "starGen1SynergySkill").bind(60, 50)
-		}
-	],
-	TowerGeneration.Indo1: [
-		# No buffs or synergy data given for this group
-	],
-	TowerGeneration.Myth: [
-		{ "on_skill_cast": Callable(self, "mythSynergyEffect").bind(5) },
-		{ "on_skill_cast": Callable(self, "mythSynergyEffect").bind(7) },
-		{ "on_skill_cast": Callable(self, "mythSynergyEffect").bind(10) }
-	],
-	TowerGeneration.Tempus: [
-		{ "mission": MissionDetail.new(0, str(TowerGeneration.Tempus) + "kill_enemy", 0, 500, "Kill 500 monsters", Callable(self, "activeTempusSynergyTier1"))},
-		{ "mission": MissionDetail.new(1, str(TowerGeneration.Tempus) + "kill_enemy", 0, 1000, "Kill 1000 monsters", Callable(self, "activeTempusSynergyTier2"))},
-		{ "mission": MissionDetail.new(2, str(TowerGeneration.Tempus) + "kill_enemy", 0, 2000, "Kill 2000 monsters", Callable(self, "activeTempusSynergyTier3"))},
-	],
-}
-
+# Trait counts on the field, keyed by synergy id (TowerClass / TowerGeneration int).
 var current_counts: Dictionary = {}
-var active_synergy_tiers: Dictionary = {}  # Stores highest tier reached per synergy
-var starGen1Damage: int = 0;
 
-func _init():
-	for synergy_id in SYNERGY_REQUIREMENTS.keys():
-		current_counts[synergy_id] = 0
-		active_synergy_tiers[synergy_id] = -1  # no tier active
+# Emitted on every count change with the current count + current tier (-1 = none).
+# Single source feeding both the Synergy UI and SynergyController.
+signal synergy_updated(synergy_id: int, count: int, tier: int)
 
 func add_tower_traits(synergies: Array[int]) -> void:
 	for synergy_id in synergies:
@@ -128,106 +40,21 @@ func remove_tower_traits(synergies: Array[int]) -> void:
 		_update_synergy(synergy_id, -1)
 
 func _update_synergy(synergy_id: int, delta: int) -> void:
-	current_counts[synergy_id] = max(0, current_counts.get(synergy_id, 0) + delta)
-	_check_synergy_tiers(synergy_id)
+	if synergy_id <= 0:   # skip default/unset trait values
+		return
+	var count: int = max(0, current_counts.get(synergy_id, 0) + delta)
+	current_counts[synergy_id] = count
+	var tier := _tier_for(synergy_id, count)
+	synergy_updated.emit(synergy_id, count, tier)
 
-func _check_synergy_tiers(synergy_id: int) -> void:
-	var thresholds: Array = SYNERGY_REQUIREMENTS.get(synergy_id, [])
-	var current: int = current_counts.get(synergy_id, 0)
-	var prev_tier: int = active_synergy_tiers.get(synergy_id, -1)
-
-	var new_tier := -1
-
-	for i in thresholds.size():
-		if current >= thresholds[i]:
-			new_tier = i
-
-	if new_tier != prev_tier:
-		if new_tier > prev_tier:
-			for tier in range(prev_tier + 1, new_tier + 1):
-				var buff = SYNERGY_BUFFS[synergy_id][tier]
-				buff["tier"] = tier;
-				buff["synergy_id"] = synergy_id  # Mark the buff
-				synergy_activated.emit(synergy_id, tier, buff)
-				print("Synergy activated:", getSynergyName(synergy_id), "Tier", tier + 1)
-
-		active_synergy_tiers[synergy_id] = new_tier
-
-func mythSynergyEffect(tower: Tower, regenAmount: int):
-	if(tower == null):
-		return;
-
-	tower.regenMana(regenAmount);
-
-func setStarGen1Damage(damage: int):
-	starGen1Damage = damage;
-
-func starGen1SynergySkill(tower: Tower, chance: float, dmgPercent: float):
-	if(tower == null || tower.enemy == null):
-		return;
-
-	var rand = randi_range(0, 100);
-	if(rand > chance):
-		return;
-
-	var metheor = Metheor.new(Damage.new(tower, starGen1Damage * (dmgPercent / 100), Damage.DamageType.MAGIC), tower.enemy.position, 0.5);
-	tower.add_sibling(metheor);
-
-func activeTempusSynergyTier1(missionId: int):
-	print("active tempus synergy tier 1");
-	var buff := {
-		"attack_bonus_percent": 10,
-		"synergy_id": TowerGeneration.Tempus,
-		"tier": 0
-	}
-
-	mission_completed.emit(missionId, buff);
-
-func activeTempusSynergyTier2(missionId: int):
-	print("active tempus synergy tier 2");
-	var buff := {
-		"attack_bonus_percent": 10,
-		"synergy_id": TowerGeneration.Tempus,
-		"tier": 1
-	}
-
-	mission_completed.emit(missionId, buff);
-
-func activeTempusSynergyTier3(missionId: int):
-	print("active tempus synergy tier 3");
-	var buff := {
-		"attack_bonus_percent": 10,
-		"synergy_id": [
-			TowerGeneration.Myth,
-			TowerGeneration.Tempus,
-			TowerGeneration.Gen0,
-			TowerGeneration.Gen1,
-			TowerGeneration.Indo1
-		],
-		"tier": 2
-	}
-
-	mission_completed.emit(missionId, buff);
-
-func checkBonusDivaSynergy(synergy_id):
-	return synergy_id == TowerClass.Diva
-
-func getSynergyName(synergy_id: int) -> String:
-	return TOWER_CLASS_NAMES.get(synergy_id, TOWER_GENERATION_NAMES.get(synergy_id, "Unknown"))
-
-func getSynergyMaxCount(synergy_id: int) -> int:
-	var synergyRequirements = SYNERGY_REQUIREMENTS.get(synergy_id, [])
-	if synergyRequirements.is_empty():
-		return 0;
-
-	return synergyRequirements[-1]
-
-func getMinRequirement(synergy_id: int) -> int:
-	var synergyRequirements = SYNERGY_REQUIREMENTS.get(synergy_id, [])
-	if synergyRequirements.is_empty():
-		return 0;
-
-	return synergyRequirements[0]
-
-signal synergy_activated(synergy_id: int, tier: int, buff: Dictionary)
-signal mission_completed(mission_id: int, buff: Dictionary);
+# Highest tier index whose threshold is met (-1 = none). Thresholds come from the
+# synergy YAML (ResourceManager), not a hardcoded table.
+func _tier_for(synergy_id: int, count: int) -> int:
+	var data: SynergyData = ResourceManager.getSynergyData(synergy_id)
+	if data == null:
+		return -1
+	var tier := -1
+	for i in data.thresholds.size():
+		if count >= int(data.thresholds[i]):
+			tier = i
+	return tier

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -52,6 +52,16 @@ static func preloadSynergy():
 			var path = "ui_asset/synergies/" + key + ".png"
 			loadImage("synergy", key, path)
 
+# Synergy definitions (resources/database/synergy/) keyed by TowerTrait enum id.
+# Loaded next to preloadSynergy() at each addDeck; rebuilt (not accumulated).
+static var _synergy_data: Dictionary = {}
+
+static func loadSynergyData() -> void:
+	_synergy_data = SynergyDataLoader.load_all()
+
+static func getSynergyData(synergyId: int) -> SynergyData:
+	return _synergy_data.get(synergyId, null)
+
 static var _enemy_db: Dictionary = {}    # id -> EnemyDBData (stats + skills + tier); normal/elite only
 static var _enemy_tier: Dictionary = {}  # id -> tier string ("elite"/"normal")
 

--- a/scripts/skill/base_skill_controller.gd
+++ b/scripts/skill/base_skill_controller.gd
@@ -6,6 +6,11 @@ var modifier: Dictionary = {}
 
 var cancelled = false;
 
+# Emitted after a fully successful (non-cancelled) cast, post onSuccess. Towers
+# re-emit this as Tower.skill_cast_succeeded for the synergy system; enemies also
+# emit it but nothing listens on the enemy side.
+signal cast_succeeded(skill)
+
 func _init(user: Node, skills: Array[Skill]):
 	self.skills = skills;
 	self.user = user;
@@ -57,6 +62,7 @@ func execute_skill_actions(skill: Skill, context: SkillContext):
 		return
 
 	onSuccess(skill);
+	cast_succeeded.emit(skill);
 
 func resetUsingSkill(skill: Skill):
 	skill.using = false;

--- a/scripts/synergy/synergy_controller.gd
+++ b/scripts/synergy/synergy_controller.gd
@@ -1,0 +1,60 @@
+class_name SynergyController
+extends RefCounted
+
+# Owns active-synergy runtime state and routes events to SynergyEffect objects.
+# Replaces the old SYNERGY_BUFFS apply logic. Tier is run-level state (NOT
+# per-wave): it is ratcheted up and never cleared on wave reset, matching the
+# "synergy is not deactivated mid-run" design rule.
+
+var _factory                       # TowerFactory (tower lists)
+var _active_tier: Dictionary = {}  # synergy_id -> int (highest tier, -1 none)
+var _effects: Dictionary = {}      # synergy_id -> SynergyEffect
+
+func setup(factory) -> void:
+	_factory = factory
+
+# From TowerTrait.synergy_updated. tier is the absolute current tier (-1 = none).
+# Ratchets up only; a lower tier (e.g. a future tower removal) does not downgrade.
+func on_synergy_updated(synergy_id: int, _count: int, tier: int) -> void:
+	var prev: int = _active_tier.get(synergy_id, -1)
+	if tier <= prev:
+		return
+	_active_tier[synergy_id] = tier
+
+	var effect: SynergyEffect = _effects.get(synergy_id, null)
+	if effect == null:
+		effect = _create_effect(synergy_id)
+		if effect == null:
+			return   # placeholder synergy: declared in YAML, no effect handler yet
+		_effects[synergy_id] = effect
+		effect.activate()
+	effect.on_tier_changed(tier)
+
+func _create_effect(synergy_id: int) -> SynergyEffect:
+	var data: SynergyData = ResourceManager.getSynergyData(synergy_id)
+	if data == null:
+		return null
+	var effect := SynergyEffect.create(data.effect)
+	if effect == null:
+		return null
+	effect.setup(data, self)
+	return effect
+
+# From TowerFactory when a new tower is placed: let active effects apply to it.
+func on_tower_added(tower) -> void:
+	for effect in _effects.values():
+		effect.on_tower_added(tower)
+
+# From each tower's skill_cast_succeeded.
+func on_tower_cast(tower) -> void:
+	for effect in _effects.values():
+		effect.on_tower_cast(tower)
+
+func active_tier(synergy_id: int) -> int:
+	return _active_tier.get(synergy_id, -1)
+
+# Towers currently holding a given synergy trait (factory's keyed list).
+func towers_with(synergy_id: int) -> Array:
+	if _factory == null:
+		return []
+	return _factory.towers.get(synergy_id, [])

--- a/scripts/synergy/synergy_data.gd
+++ b/scripts/synergy/synergy_data.gd
@@ -1,0 +1,113 @@
+class_name SynergyData
+
+# One synergy definition loaded from resources/database/synergy/<id>.yaml.
+# Values live in YAML (designer-tunable); behaviour lives in SynergyEffect.
+# Numbers are read through get_parameter so the displayed text and the applied
+# effect share one source (mirrors Skill.parameters / desc_template).
+
+var id: String = ""                # file/data key, e.g. "myth"
+var synergy_id: int = 0            # TowerTrait enum int (resolved at load)
+var display_name: String = ""
+var kind: String = ""             # "class" | "generation"
+var type: String = "normal"       # UI category: normal | quest | special
+var effect: String = ""           # SynergyEffect handler key ("" = placeholder)
+var thresholds: Array = []        # proc count per tier (untyped: YamlParser yields untyped Array)
+var parameters: Dictionary = {}   # name -> per-tier array (or scalar)
+var desc_template: String = ""    # flavour line (hover header), may hold {param} tokens
+var desc: String = ""             # plain fallback when desc_template is empty
+# Per-tier effect lines for the hover table. size 1 -> the one template is used
+# for every tier (pure scaling, e.g. Myth); size == tier_count -> one line per
+# tier (qualitative tiers, e.g. a Tempus-style "unlock" at a higher tier).
+var tier_effects: Array = []
+
+func max_count() -> int:
+	return int(thresholds[-1]) if not thresholds.is_empty() else 0
+
+func min_requirement() -> int:
+	return int(thresholds[0]) if not thresholds.is_empty() else 0
+
+func tier_count() -> int:
+	return thresholds.size()
+
+func threshold_at(tier: int) -> int:
+	if thresholds.is_empty():
+		return 0
+	return int(thresholds[clampi(tier, 0, thresholds.size() - 1)])
+
+# Per-tier parameter value, clamped to the tier index. Clamp matches
+# Skill._get_display_parameter exactly so display and effect never diverge
+# (agent_lessons: a single-element array crashed when one path indexed raw).
+func get_parameter(param_name: String, tier: int):
+	if not parameters.has(param_name):
+		push_warning("Synergy '" + id + "' missing parameter: " + param_name)
+		return null
+	var value = parameters.get(param_name)
+	if value is Array:
+		if value.is_empty():
+			return null
+		var index: int = clampi(tier, 0, value.size() - 1)
+		return value[index]
+	return value
+
+# Flavour line resolved for a tier. highlight_color (BBCode hex) wraps values
+# that come from a per-tier (array) parameter, so the player sees which number
+# scales; "" returns plain text.
+func flavor(tier: int, highlight_color: String = "") -> String:
+	var template := desc_template if desc_template != "" else desc
+	return _render(template, tier, highlight_color)
+
+# One hover-table line for a tier (see tier_effects).
+func tier_effect(tier: int, highlight_color: String = "") -> String:
+	if tier_effects.is_empty():
+		return ""
+	var template: String
+	if tier_effects.size() == 1:
+		template = str(tier_effects[0])
+	else:
+		template = str(tier_effects[clampi(tier, 0, tier_effects.size() - 1)])
+	return _render(template, tier, highlight_color)
+
+func _render(template: String, tier: int, highlight_color: String) -> String:
+	if template == "":
+		return ""
+	var result := template
+	var regex := RegEx.new()
+	regex.compile("\\{([^}:]+)(?::([^}]+))?\\}")
+	var matches := regex.search_all(template)
+	for i in range(matches.size() - 1, -1, -1):
+		var m := matches[i]
+		var pname := m.get_string(1)
+		var fmt := m.get_string(2)
+		var is_scaling: bool = parameters.has(pname) and parameters[pname] is Array
+		var text := _format_value(get_parameter(pname, tier), fmt)
+		if highlight_color != "" and is_scaling:
+			text = "[color=" + highlight_color + "]" + text + "[/color]"
+		result = result.substr(0, m.get_start()) + text + result.substr(m.get_end())
+	return result
+
+func _format_value(value, fmt: String) -> String:
+	if value == null:
+		return ""
+
+	match fmt:
+		"percent":
+			return _format_number(float(value) * 100.0) + "%"
+		"":
+			return _format_number(value)
+		_:
+			push_warning("Unknown synergy desc placeholder format: " + fmt)
+			return _format_number(value)
+
+func _format_number(value) -> String:
+	if value is int:
+		return str(value)
+	if value is float:
+		if is_equal_approx(value, round(value)):
+			return str(int(round(value)))
+		var text := "%.4f" % value
+		while text.ends_with("0"):
+			text = text.substr(0, text.length() - 1)
+		if text.ends_with("."):
+			text = text.substr(0, text.length() - 1)
+		return text
+	return str(value)

--- a/scripts/synergy/synergy_data_loader.gd
+++ b/scripts/synergy/synergy_data_loader.gd
@@ -1,0 +1,72 @@
+class_name SynergyDataLoader
+
+# Reads the synergy manifest + per-file YAML into SynergyData objects, keyed by
+# the resolved TowerTrait enum id. Manifest-driven (not a folder scan) so it
+# works inside an exported PCK, matching the enemy/tower loaders.
+
+const SYNERGY_DIR := "res://resources/database/synergy/"
+const MANIFEST := SYNERGY_DIR + "synergy_list.yaml"
+
+static func load_all() -> Dictionary:
+	var result: Dictionary = {}   # synergy_id (int) -> SynergyData
+	var manifest = YamlParser.load_data(MANIFEST)
+	if manifest == null or not manifest.has("synergies"):
+		push_error("SynergyDataLoader: missing/empty manifest " + MANIFEST)
+		return result
+
+	for entry in manifest.get("synergies", []):
+		var id := str(entry).to_lower()
+		var path := SYNERGY_DIR + id + ".yaml"
+		var raw = YamlParser.load_data(path)
+		if raw == null or raw.is_empty():
+			push_error("SynergyDataLoader: missing/empty synergy file " + path)
+			continue
+		var data := _build(raw, path)
+		if data != null:
+			result[data.synergy_id] = data
+	return result
+
+static func _build(raw: Dictionary, path: String) -> SynergyData:
+	var d := SynergyData.new()
+	d.id = str(raw.get("id", ""))
+	d.display_name = str(raw.get("name", d.id))
+	d.kind = str(raw.get("kind", ""))
+	d.type = str(raw.get("type", "normal"))
+	d.effect = str(raw.get("effect", ""))
+	d.desc = str(raw.get("desc", ""))
+	# YamlParser does not process escapes; translate \n loader-side, only for the
+	# text fields that want it (data_pipeline.md Problem #1).
+	d.desc_template = str(raw.get("desc_template", "")).replace("\\n", "\n")
+	for line in raw.get("tier_effects", []):
+		d.tier_effects.append(str(line).replace("\\n", "\n"))
+
+	for t in raw.get("thresholds", []):
+		d.thresholds.append(int(t))
+
+	var params = raw.get("parameters", {})
+	if params is Dictionary:
+		d.parameters = params
+
+	d.synergy_id = _resolve_synergy_id(d.kind, d.id)
+	if d.synergy_id == 0:
+		push_error("SynergyDataLoader: cannot resolve id for '" + d.id + "' (kind=" + d.kind + ") in " + path)
+		return null
+	return d
+
+# Maps the YAML id string to the TowerTrait enum int via the display-name tables.
+static func _resolve_synergy_id(kind: String, id: String) -> int:
+	var table: Dictionary
+	match kind:
+		"class":
+			table = TowerTrait.TOWER_CLASS_NAMES
+		"generation":
+			table = TowerTrait.TOWER_GENERATION_NAMES
+		_:
+			push_error("SynergyDataLoader: unknown kind '" + kind + "' for id '" + id + "'")
+			return 0
+
+	var target := id.to_lower()
+	for key in table.keys():
+		if str(table[key]).to_lower() == target:
+			return key
+	return 0

--- a/scripts/synergy/synergy_effect.gd
+++ b/scripts/synergy/synergy_effect.gd
@@ -1,0 +1,44 @@
+class_name SynergyEffect
+extends RefCounted
+
+# Behaviour of one active synergy. Constructed by `effect` key (see create),
+# mirroring SkillUtility.ParseAction (SkillAction subclasses) and Tower._setupPassive.
+# Adding a synergy that reuses an existing effect needs only a YAML file; a new
+# effect kind adds one subclass + one match arm here.
+
+var data: SynergyData
+var controller   # SynergyController (tower lists + active tier)
+
+func setup(d: SynergyData, c) -> void:
+	data = d
+	controller = c
+
+# Synergy first reached tier 0 (effect created).
+func activate() -> void:
+	pass
+
+# Active tier increased to new_tier (0-based). Tier never decreases mid-run
+# (no synergy deactivation by design - see tower_synergy.md).
+func on_tier_changed(_new_tier: int) -> void:
+	pass
+
+# A tower joined while this synergy is already active. For stat-style effects,
+# apply the current-tier buff to the newcomer. Live-read effects (e.g. Myth)
+# need nothing here.
+func on_tower_added(_tower) -> void:
+	pass
+
+# A tower cast a skill successfully (routed for every tower; the effect filters).
+func on_tower_cast(_tower) -> void:
+	pass
+
+# effect key -> concrete SynergyEffect. "" / unknown -> null (placeholder, not wired).
+static func create(effect_key: String) -> SynergyEffect:
+	match effect_key:
+		"energy_on_skill_cast":
+			return SynergyEffectEnergyOnCast.new()
+		"", "none":
+			return null   # placeholder synergy: declared but no effect handler yet
+		_:
+			push_warning("Unknown synergy effect: " + effect_key)
+			return null

--- a/scripts/synergy/synergy_effect_energy_on_cast.gd
+++ b/scripts/synergy/synergy_effect_energy_on_cast.gd
@@ -1,0 +1,25 @@
+class_name SynergyEffectEnergyOnCast
+extends SynergyEffect
+
+# Myth: when ANY unit holding this synergy casts a skill, ALL units holding it
+# restore Energy (team battery). Reads the current tier live each cast, so a
+# higher tier simply REPLACES the value (no stacking).
+
+func on_tower_cast(tower) -> void:
+	if tower == null or tower.data == null:
+		return
+	# React only to a caster that holds this synergy's trait.
+	if tower.data.towerClass != data.synergy_id and tower.data.generation != data.synergy_id:
+		return
+
+	var tier: int = controller.active_tier(data.synergy_id)
+	if tier < 0:
+		return
+
+	var amount = data.get_parameter("energy_return", tier)
+	if amount == null:
+		return
+
+	for t in controller.towers_with(data.synergy_id):
+		if is_instance_valid(t):
+			t.regenMana(int(amount))   # regenMana already gates on enableRegenMana / isMoving

--- a/scripts/tower_center.gd
+++ b/scripts/tower_center.gd
@@ -59,6 +59,7 @@ func addDeck(deck_key: String) -> bool:
 	added_decks.append(deck_key)
 
 	ResourceManager.preloadSynergy();
+	ResourceManager.loadSynergyData();
 	# Rebuild the tower-scene cache so a deck added mid-run (the wave-clear deck
 	# unlock) has its tower .tscn loaded; otherwise getTower misses and the new
 	# deck's towers fall back to the default/placeholder scene.

--- a/scripts/ui/synergy/ui_synergy.gd
+++ b/scripts/ui/synergy/ui_synergy.gd
@@ -1,47 +1,21 @@
 extends Control
 class_name UISynergy
 
-var synergyDatas: Dictionary = {};
-var contentList: Dictionary = {};
-
-@onready var camera: Camera2D = $"../../Camera2D"
 @export var contentTemplate: PackedScene;
 
-var currentYPos = 0;
+var contentList: Dictionary = {};   # synergy name -> UISynergyContent
+var currentYPos := 0;
 
-func _ready() -> void:
-	addNewSynergy("test1", 10, 20);
-
-func hasContent(name: String):
-	return synergyDatas.has(name);
-
-func addNewSynergy(name: String, min: int, max: int):
-	if(synergyDatas.has(name)):
-		printerr("adding exist synergy: ", name);
-		return;
-
-	synergyDatas[name] = {"current": 0, "max": max, "min": min};
-
-func addSynergy(synergyName: String):
-	if !synergyDatas.has(synergyName):
-		print("adding not exist synergy: ", synergyName);
-		return;
-
-	var data = synergyDatas.get(synergyName);
-	var newVal = data.get("current", 0) + 1;
-	var minActive = data.get("min", 0);
-	var active = false if minActive <= 0 else newVal >= minActive;
-	synergyDatas[synergyName]["current"] = newVal;
-	if(contentList.has(synergyName)):
-		var existContent: UISynergyContent = contentList.get(synergyName);
-		existContent.setup(synergyName, newVal, data.get("max", 0), active);
-	else:
-		createContent(synergyName, newVal, data.get("max", 0), active);
-
-func createContent(synergyName: String, current: int, maxCount: int, active: bool):
-	var newContent = contentTemplate.instantiate() as UISynergyContent;
-	contentList[synergyName] = newContent;
-	add_child(newContent);
-	newContent.position.y = currentYPos;
-	currentYPos += 100;
-	newContent.setup(synergyName, current, maxCount, active);
+# Create or update a synergy row from the single TowerTrait.synergy_updated signal:
+# count + tier drive the row (count, proc breakpoints, tier colour); synergy_id
+# resolves the SynergyData for the rich hover. Numbers come from SynergyData
+# parameters so the hover text cannot drift from the applied effect.
+func updateSynergy(synergyName: String, count: int, tier: int, synergy_id: int) -> void:
+	var content: UISynergyContent = contentList.get(synergyName, null)
+	if content == null:
+		content = contentTemplate.instantiate() as UISynergyContent
+		contentList[synergyName] = content
+		add_child(content)
+		content.position.y = currentYPos
+		currentYPos += 100
+	content.setup(synergyName, count, tier, ResourceManager.getSynergyData(synergy_id))

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -1,18 +1,100 @@
 extends PanelContainer
 class_name UISynergyContent
 
+# Placeholder template colours (artist refines later). Stepped per tier so the
+# player reads tier order at a glance; the scaling value gets its own accent.
+const INACTIVE_COLOR := "#4D4D4D"
+const TIER_COLORS := ["#CD7F32", "#C0C0C0", "#FFD15A"]   # bronze / silver / gold = tier 1 / 2 / 3
+const SCALING_COLOR := "#5AC8FA"                          # the per-tier value that scales
+const DIM_COLOR := "#7A7A7A"                              # not-yet-reached tier rows in the hover
+const ACTIVE_HIGHLIGHT := "#FFD15A"                       # active tier row in the hover (single gold)
+
 @onready var bg = $"."
 @onready var synergyName = $HBoxContainer/VBoxContainer/SynergyName
 @onready var synergyValue = $HBoxContainer/VBoxContainer/SynergyValue
 
-func setup(name: String, current: int, max: int, active: bool):
+var _name: String = ""
+var _data: SynergyData = null
+var _tier: int = -1
+var _stylebox: StyleBoxFlat = null   # this row's own panel StyleBox (see setup)
+
+# tier: current active tier (-1 = not yet proc'd). data: SynergyData or null.
+func setup(name: String, current: int, tier: int, data) -> void:
+	_name = name
+	_data = data
+	_tier = tier
+
 	if bg != null:
-		var style = bg.get_theme_stylebox("panel");
-		if(style != null):
-			style.bg_color = Color("#F3B578") if active else Color("#4D4D4D");
+		# The scene's panel StyleBox is one shared sub-resource across every row
+		# instance (even with the .tscn's own theme override). Duplicate it once per
+		# instance so colouring one synergy row never recolours the others.
+		if _stylebox == null:
+			var base = bg.get_theme_stylebox("panel")
+			if base is StyleBoxFlat:
+				_stylebox = (base as StyleBoxFlat).duplicate()
+				bg.add_theme_stylebox_override("panel", _stylebox)
+		if _stylebox != null:
+			_stylebox.bg_color = Color(_tier_color(tier))
 
 	if synergyName != null:
 		synergyName.text = name
 
 	if synergyValue != null:
-		synergyValue.text = str(current) + "/" + str(max)
+		# current count - proc breakpoints, active one bracketed (e.g. "4 - 3 [4] 5").
+		synergyValue.text = "%d - %s" % [current, _breakpoints_text(tier)]
+
+	# Rich tooltip is built in _make_custom_tooltip; tooltip_text just needs to be
+	# non-empty so the tooltip triggers (delay lowered globally in project.godot).
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	tooltip_text = name
+
+func _tier_color(tier: int) -> String:
+	if tier < 0:
+		return INACTIVE_COLOR
+	return TIER_COLORS[clampi(tier, 0, TIER_COLORS.size() - 1)]
+
+# "3 4 5" with the active tier's threshold bracketed.
+func _breakpoints_text(tier: int) -> String:
+	if _data == null or _data.thresholds.is_empty():
+		return ""
+	var parts: PackedStringArray = []
+	for i in _data.thresholds.size():
+		var t := str(int(_data.thresholds[i]))
+		parts.append("[" + t + "]" if i == tier else t)
+	return " ".join(parts)
+
+# Rich hover: flavour (scaling value highlighted) + a per-tier table with the
+# active tier marked + tier-coloured and the rest dimmed.
+func _make_custom_tooltip(_for_text: String) -> Object:
+	var panel := PanelContainer.new()
+	var rich := RichTextLabel.new()
+	rich.bbcode_enabled = true
+	rich.fit_content = true
+	rich.custom_minimum_size = Vector2(320, 0)
+	rich.text = _build_hover_bbcode()
+	panel.add_child(rich)
+	return panel
+
+func _build_hover_bbcode() -> String:
+	if _data == null:
+		return _name
+
+	var lines: PackedStringArray = []
+	lines.append("[b]" + _data.display_name + "[/b]")
+
+	# Flavour preview the lowest tier's value when not yet proc'd (maxi(tier,0)).
+	var flavor := _data.flavor(maxi(_tier, 0), SCALING_COLOR)
+	if flavor != "":
+		lines.append(flavor)
+
+	# Per-tier table (only when the synergy defines effect lines).
+	if not _data.tier_effects.is_empty():
+		lines.append("")
+		for i in _data.tier_count():
+			var row := "(" + str(_data.threshold_at(i)) + ")  " + _data.tier_effect(i)
+			if i == _tier:
+				row = "[color=" + ACTIVE_HIGHLIGHT + "]> " + row + "[/color]"   # active tier (single gold)
+			else:
+				row = "[color=" + DIM_COLOR + "]" + row + "[/color]"
+			lines.append(row)
+	return "\n".join(lines)

--- a/scripts/ui/tower_select/tower_select_button.gd
+++ b/scripts/ui/tower_select/tower_select_button.gd
@@ -30,11 +30,8 @@ func Setup(name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: To
 		if(portrait):
 			towerPortrait.texture = portrait
 	var tClassName = TowerTrait.TOWER_CLASS_NAMES.get(towerClass, "default").to_lower();
-	var tGenName = TowerTrait.TOWER_GENERATION_NAMES.get(towerGen, "default").to_lower();
 	var classSprite = ResourceManager.getSprite("synergy", tClassName);
 	var genSprite = ResourceManager.getSprite("synergy", TowerTrait.TOWER_GENERATION_NAMES.get(towerGen, "default").to_lower());
-	print("synergy class for ", tClassName, " :", classSprite);
-	print("synergy generation for ", tGenName, " :", genSprite);
 	if(towerClassImage):
 		towerClassImage.texture = classSprite
 


### PR DESCRIPTION
**Summary:** Data-driven synergy (TFT-style trait) framework: thresholds and per-tier values move from hardcoded GDScript to YAML (review R6). Myth is wired as the working reference; other synergies ship as declared placeholders.

**How it works:** Per-synergy YAML (`resources/database/synergy/` manifest + `<id>.yaml`) -> `SynergyDataLoader` -> `ResourceManager` cache. `TowerTrait` counts traits and emits `synergy_updated(id, count, tier)`; `SynergyController` holds one active tier per synergy (REPLACE, ratchets up) and drives `SynergyEffect` objects (factory by `effect` key, mirroring `SkillAction` / passive). Myth's effect (`energy_on_skill_cast`) listens to a new `Tower.skill_cast_succeeded` signal: any Myth cast restores Energy to all Myth units (team battery). The synergy panel shows the real current tier, a stepped tier colour, and a rich hover (flavour + per-tier table) with the scaling value highlighted.

**Implementation Notes:**
- Removes dead/broken synergy code: `SYNERGY_BUFFS`, `Tower.processActiveBuff`, `processGen0Buff`, and the never-called `executeModifier` path.
- Adding a synergy that reuses an existing effect is YAML-only; a new effect kind = one `SynergyEffect` subclass + one `create` arm.
- Per-instance `StyleBox` duplication fixes shared-StyleBox colour bleed across panel rows.
- `gui/timers/tooltip_delay_sec` lowered to 0.15 (global) for responsive hover.
- Design intent + invariants live in `tower_synergy.md`; copy/voice convention in `game_copy.md`.
