### PR TITLE
Staff skill hover + fix fake UIDs in staff/bullet scenes

### DIFF
--- a/resources/combat/bullets/bullet.tscn
+++ b/resources/combat/bullets/bullet.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://bm6ibfiqh7uvc"]
 
 [ext_resource type="Script" path="res://scripts/combat/projectile.gd" id="1_m51ds"]
-[ext_resource type="Texture2D" uid="uid://cjniiq3h7lrk0" path="res://resources/combat/bullets/bullet.png" id="2_pqj8l"]
+[ext_resource type="Texture2D" uid="uid://b1wb2pvc0ly7f" path="res://resources/combat/bullets/bullet.png" id="2_pqj8l"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_38r1k"]
 

--- a/resources/combat/bullets/gawr_gura_skill_projectile.tscn
+++ b/resources/combat/bullets/gawr_gura_skill_projectile.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://bgbx57ye0s2ww"]
 
 [ext_resource type="Script" path="res://scripts/combat/projectile.gd" id="1_5nyku"]
-[ext_resource type="Texture2D" uid="uid://cjniiq3h7lrk0" path="res://resources/combat/bullets/bullet.png" id="2_xvyqq"]
+[ext_resource type="Texture2D" uid="uid://b1wb2pvc0ly7f" path="res://resources/combat/bullets/bullet.png" id="2_xvyqq"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_ev5gm"]
 radius = 10.0045

--- a/resources/staffs/a_chan/sprite/staff_a_chan_sprite.tscn
+++ b/resources/staffs/a_chan/sprite/staff_a_chan_sprite.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=17 format=3 uid="uid://cbvsli7h2xgda"]
+[gd_scene load_steps=10 format=3 uid="uid://cbvsli7h2xgda"]
 
-[ext_resource type="Texture2D" uid="uid://ctoggex1gqn4" path="res://resources/staffs/a_chan/sprite/manestand.png" id="1_sa5fc"]
-[ext_resource type="Texture2D" uid="uid://ckv1mcuwniogb" path="res://resources/tower/hololive/en_branch/myth_gen/kiara/sprite/test_character_idle.png" id="2_gh881"]
+[ext_resource type="Texture2D" uid="uid://b7yaocdpffwaa" path="res://resources/staffs/a_chan/sprite/manestand.png" id="1_sa5fc"]
 [ext_resource type="Script" path="res://scripts/entity/staff/staff_sprite.gd" id="3_e3kds"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_cmnq7"]
@@ -28,30 +27,6 @@ region = Rect2(512, 512, 512, 512)
 atlas = ExtResource("1_sa5fc")
 region = Rect2(1024, 512, 512, 512)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_hsakj"]
-atlas = ExtResource("2_gh881")
-region = Rect2(0, 0, 512, 512)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_5cab7"]
-atlas = ExtResource("2_gh881")
-region = Rect2(512, 0, 512, 512)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_lh4qf"]
-atlas = ExtResource("2_gh881")
-region = Rect2(1024, 0, 512, 512)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6koqb"]
-atlas = ExtResource("2_gh881")
-region = Rect2(0, 512, 512, 512)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_vepo6"]
-atlas = ExtResource("2_gh881")
-region = Rect2(512, 512, 512, 512)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_2sq5h"]
-atlas = ExtResource("2_gh881")
-region = Rect2(1024, 512, 512, 512)
-
 [sub_resource type="SpriteFrames" id="SpriteFrames_e7eyb"]
 animations = [{
 "frames": [{
@@ -74,36 +49,13 @@ animations = [{
 "texture": SubResource("AtlasTexture_egg1y")
 }],
 "loop": true,
-"name": &"a_chan",
-"speed": 12.0
-}, {
-"frames": [{
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_hsakj")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_5cab7")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_lh4qf")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_6koqb")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_vepo6")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_2sq5h")
-}],
-"loop": true,
-"name": &"idel",
+"name": &"idle",
 "speed": 12.0
 }]
 
 [node name="AnimatedSprite2D_a_chan" type="AnimatedSprite2D"]
 sprite_frames = SubResource("SpriteFrames_e7eyb")
-animation = &"a_chan"
+animation = &"idle"
 frame_progress = 0.667521
 script = ExtResource("3_e3kds")
-animationName = "a_chan"
+animationName = "idle"

--- a/resources/ui_component/staff_widget.tscn
+++ b/resources/ui_component/staff_widget.tscn
@@ -1,13 +1,14 @@
-[gd_scene load_steps=9 format=3 uid="uid://omnglvjm0xyi"]
+[gd_scene load_steps=10 format=3 uid="uid://omnglvjm0xyi"]
 
 [ext_resource type="Script" path="res://scripts/ui/staff_widget.gd" id="1_script"]
-[ext_resource type="Texture2D" uid="uid://dirflpewxylbn" path="res://resources/ui_asset/staff/bg.png" id="2_bg"]
-[ext_resource type="Texture2D" uid="uid://bsvnv5u67vlrv" path="res://resources/staffs/a_chan/hud/portrait.png" id="3_portrait"]
-[ext_resource type="Texture2D" uid="uid://b1qmtl8ktewvf" path="res://resources/ui_asset/staff/border.png" id="4_border"]
-[ext_resource type="Texture2D" uid="uid://b0cs1do08aqpk" path="res://resources/ui_asset/staff/hp_border.png" id="5_hp_border"]
-[ext_resource type="Texture2D" uid="uid://dl086p0jt33jj" path="res://resources/ui_asset/staff/hp_gauge.png" id="6_hp_gauge"]
-[ext_resource type="Texture2D" uid="uid://cdtc4uurl8x5m" path="res://resources/ui_asset/staff/skill_border.png" id="7_skill_border"]
-[ext_resource type="Texture2D" uid="uid://cc27qry4n02k2" path="res://resources/staffs/a_chan/hud/skill_icon.png" id="8_skill_icon"]
+[ext_resource type="Texture2D" uid="uid://cadkh62jlagwi" path="res://resources/ui_asset/staff/bg.png" id="2_bg"]
+[ext_resource type="Texture2D" uid="uid://bjdctlxpbwr4r" path="res://resources/staffs/a_chan/hud/portrait.png" id="3_portrait"]
+[ext_resource type="Texture2D" uid="uid://cj0f7j184vjoi" path="res://resources/ui_asset/staff/border.png" id="4_border"]
+[ext_resource type="Texture2D" uid="uid://c66wy6ms1ur6k" path="res://resources/ui_asset/staff/hp_border.png" id="5_hp_border"]
+[ext_resource type="Texture2D" uid="uid://bx74hpdw3wr5a" path="res://resources/ui_asset/staff/hp_gauge.png" id="6_hp_gauge"]
+[ext_resource type="Texture2D" uid="uid://bxcvwa5v0c2dc" path="res://resources/ui_asset/staff/skill_border.png" id="7_skill_border"]
+[ext_resource type="Texture2D" uid="uid://31qqqswybwhs" path="res://resources/staffs/a_chan/hud/skill_icon.png" id="8_skill_icon"]
+[ext_resource type="Script" path="res://scripts/ui/staff_skill_tooltip.gd" id="9_tooltip"]
 
 [node name="StaffWidget" type="Control"]
 custom_minimum_size = Vector2(520, 236)
@@ -126,6 +127,7 @@ grow_vertical = 2
 texture_normal = ExtResource("8_skill_icon")
 ignore_texture_size = true
 stretch_mode = 0
+script = ExtResource("9_tooltip")
 
 [node name="SkillBorder" type="TextureRect" parent="."]
 layout_mode = 1

--- a/scripts/ui/staff_skill_tooltip.gd
+++ b/scripts/ui/staff_skill_tooltip.gd
@@ -1,0 +1,32 @@
+class_name StaffSkillTooltip
+extends TextureButton
+
+# Placeholder skill-info hover for the Staff skill button (StaffWidget).
+# Shows skill name + description as a rich tooltip, mirroring the synergy hover
+# pattern (ui_synergy_content.gd _make_custom_tooltip). Guideline only — the final
+# skill UI surface is tracked in coding log "Tower UI surface" / staff hover task.
+#
+# StaffWidget.setup() assigns `skill` and a non-empty tooltip_text so the custom
+# tooltip triggers (tooltip delay is lowered globally in project.godot).
+
+var skill: Skill = null
+
+func _make_custom_tooltip(_for_text: String) -> Object:
+	var panel := PanelContainer.new()
+	var rich := RichTextLabel.new()
+	rich.bbcode_enabled = true
+	rich.fit_content = true
+	rich.custom_minimum_size = Vector2(320, 0)
+	rich.text = _build_hover_bbcode()
+	panel.add_child(rich)
+	return panel
+
+func _build_hover_bbcode() -> String:
+	if skill == null:
+		return ""
+	var lines: PackedStringArray = []
+	lines.append("[b]" + skill.get_display_name(1) + "[/b]")
+	var desc := skill.get_display_desc(1)
+	if desc != "":
+		lines.append(desc)
+	return "\n".join(lines)

--- a/scripts/ui/staff_skill_tooltip.gd
+++ b/scripts/ui/staff_skill_tooltip.gd
@@ -10,6 +10,7 @@ extends TextureButton
 # tooltip triggers (tooltip delay is lowered globally in project.godot).
 
 var skill: Skill = null
+var max_charges: int = -1  # StaffData.skill_max_charges: -1 = unlimited, N = N uses per game
 
 func _make_custom_tooltip(_for_text: String) -> Object:
 	var panel := PanelContainer.new()
@@ -26,7 +27,9 @@ func _build_hover_bbcode() -> String:
 		return ""
 	var lines: PackedStringArray = []
 	lines.append("[b]" + skill.get_display_name(1) + "[/b]")
+	lines.append("Limit: " + ("Unlimited" if max_charges < 0 else str(max_charges)))
 	var desc := skill.get_display_desc(1)
 	if desc != "":
+		lines.append("")
 		lines.append(desc)
 	return "\n".join(lines)

--- a/scripts/ui/staff_widget.gd
+++ b/scripts/ui/staff_widget.gd
@@ -12,7 +12,7 @@ signal skill_pressed  # forwarded by GameScene → Staff.requestCastSkill (Phase
 @onready var _hp_gauge: TextureProgressBar = $HpGauge
 @onready var _hp_label: Label = $HpLabel
 @onready var _skill_mask: TextureRect = $SkillMask
-@onready var _skill_icon: TextureButton = $SkillMask/SkillButton
+@onready var _skill_icon: StaffSkillTooltip = $SkillMask/SkillButton
 @onready var _skill_border: TextureRect = $SkillBorder
 
 # Hover effect — subtle scale tween on the skill area when mouse enters / leaves the button.
@@ -32,6 +32,7 @@ func setup(staff: Staff) -> void:
 		return
 	_staff = staff
 	_apply_staff_textures(staff.data)
+	_apply_skill_hover(staff.data)
 	_apply_hp(staff.getCurrentHp(), staff.getMaxHp())
 	if not staff.is_connected("hp_changed", Callable(self, "_on_hp_changed")):
 		staff.hp_changed.connect(_on_hp_changed)
@@ -53,6 +54,15 @@ func _apply_staff_textures(data: StaffData) -> void:
 		_portrait.texture = load("res://resources/" + data.hud_portrait)
 	if data.hud_skill_icon != "":
 		_skill_icon.texture_normal = load("res://resources/" + data.hud_skill_icon)
+
+func _apply_skill_hover(data: StaffData) -> void:
+	# Placeholder skill-info hover (name + desc) on the skill button. The rich tooltip
+	# is built by StaffSkillTooltip._make_custom_tooltip; tooltip_text just needs to be
+	# non-empty so the tooltip triggers (delay lowered globally in project.godot).
+	if _skill_icon == null or data == null or data.skill == null:
+		return
+	_skill_icon.skill = data.skill
+	_skill_icon.tooltip_text = data.skill.get_display_name(1)
 
 func _apply_hp(current: int, max_hp: int) -> void:
 	_hp_gauge.max_value = float(max_hp)

--- a/scripts/ui/staff_widget.gd
+++ b/scripts/ui/staff_widget.gd
@@ -62,6 +62,7 @@ func _apply_skill_hover(data: StaffData) -> void:
 	if _skill_icon == null or data == null or data.skill == null:
 		return
 	_skill_icon.skill = data.skill
+	_skill_icon.max_charges = data.skill_max_charges
 	_skill_icon.tooltip_text = data.skill.get_display_name(1)
 
 func _apply_hp(current: int, max_hp: int) -> void:


### PR DESCRIPTION
**Summary:** Add a placeholder skill-info hover (name, use Limit, description) on the StaffWidget skill button, and fix Godot `invalid UID` load warnings in the staff and bullet scenes by pointing ext_resources at the assets' real `.import` uids.

**How it works:** `StaffSkillTooltip` (attached to the skill button) overrides `_make_custom_tooltip` to build a BBCode panel from the staff's `Skill` (name + `get_display_desc`) plus the use cap from `StaffData.skill_max_charges` (shown as `Limit:`, `Unlimited` when -1). Mirrors the synergy hover pattern; the tooltip triggers via a non-empty `tooltip_text`. The existing scale-tween hover is unchanged.

**Implementation Notes:**
- Fake UIDs are a project-wide issue (66 refs / 20 files); this PR fixes only the 4 staff/bullet-related files. The rest is tracked as a separate cleanup task (opening+saving each scene in Godot regenerates the uids).
- In `staff_a_chan_sprite.tscn`, removed an unused Kiara-borrowed "idel" animation + its ext_resource and renamed the played animation `a_chan` -> `idle` (matches the tower convention).
- The fake-UID lesson already lived in `ui.md` but recurred (including `staff_widget.tscn` itself); the lesson was strengthened with the recurrence + fix recipe.

**Touched scenes:** resources/staffs/a_chan/sprite/staff_a_chan_sprite.tscn, resources/ui_component/staff_widget.tscn, resources/combat/bullets/bullet.tscn, resources/combat/bullets/gawr_gura_skill_projectile.tscn
