### PR TITLE
Clean up GDScript shadow warnings (rename shadowing identifiers)

### DIFF
--- a/scripts/area/circle_effect_area.gd
+++ b/scripts/area/circle_effect_area.gd
@@ -8,15 +8,15 @@ extends EffectArea
 
 var elapsedTime: float = 0.0;
 
-func setup(radius: float = 2.0, duration: float = 5.0, callback: EffectAreaCallback = null, drawColor: Color = Color(0, 0, 1, 0.2)):
+func setup(p_radius: float = 2.0, p_duration: float = 5.0, callback: EffectAreaCallback = null, p_drawColor: Color = Color(0, 0, 1, 0.2)):
 	var circle_shape = CircleShape2D.new()
-	circle_shape.radius = radius
+	circle_shape.radius = p_radius
 	_base_setup(circle_shape, callback);
-	collisionShape.scale = Vector2.ONE * radius;
+	collisionShape.scale = Vector2.ONE * p_radius;
 	elapsedTime = 0.0
-	self.drawColor = drawColor
-	self.radius = radius
-	self.duration = duration
+	self.drawColor = p_drawColor
+	self.radius = p_radius
+	self.duration = p_duration
 
 func _process(delta: float) -> void:
 	elapsedTime += delta

--- a/scripts/area/effect_area_callback.gd
+++ b/scripts/area/effect_area_callback.gd
@@ -4,6 +4,6 @@ extends RefCounted
 var onEnter: Callable = Callable()
 var onExit: Callable = Callable()
 
-func _init(onEnter: Callable = Callable(), onExit: Callable = Callable()):
-	self.onEnter = onEnter
-	self.onExit = onExit
+func _init(p_onEnter: Callable = Callable(), p_onExit: Callable = Callable()):
+	self.onEnter = p_onEnter
+	self.onExit = p_onExit

--- a/scripts/area/frame_area.gd
+++ b/scripts/area/frame_area.gd
@@ -11,9 +11,9 @@ var tickTime: float = 0.0;
 func _ready():
 	setup(radius, EffectAreaCallback.new(Callable(self, "enemyEntered"), Callable(self, "enemyExited")))
 
-func setup(radius: float = 2.0, callback: EffectAreaCallback = EffectAreaCallback.new(Callable(), Callable())):
+func setup(p_radius: float = 2.0, callback: EffectAreaCallback = EffectAreaCallback.new(Callable(), Callable())):
 	var circle_shape = CircleShape2D.new()
-	circle_shape.radius = radius * GridHelper.CELL_SIZE
+	circle_shape.radius = p_radius * GridHelper.CELL_SIZE
 
 	_base_setup(circle_shape, callback)
 

--- a/scripts/boss/boss_db_data.gd
+++ b/scripts/boss/boss_db_data.gd
@@ -7,10 +7,10 @@ var stats: Dictionary
 var wave: Array = [];
 var skills: Array[Skill] = []
 
-func _init(boss_name: String, wave: Array, boss_texture: Texture2D, boss_scale: float, boss_stats: Dictionary, boss_skills: Array[Skill] = []):
+func _init(boss_name: String, p_wave: Array, boss_texture: Texture2D, boss_scale: float, boss_stats: Dictionary, boss_skills: Array[Skill] = []):
 	self.name = boss_name
 	self.texture = boss_texture
 	self.scale = boss_scale
 	self.stats = boss_stats
 	self.skills = boss_skills
-	self.wave = wave
+	self.wave = p_wave

--- a/scripts/combat/attack_modifier.gd
+++ b/scripts/combat/attack_modifier.gd
@@ -2,8 +2,8 @@ class_name AttackModifier
 
 var damage: int = 0
 
-func _init(damage: int = 10):
-	self.damage = damage
+func _init(p_damage: int = 10):
+	self.damage = p_damage
 
 func active(target):
 	if(target != null && target.has_method("recvDamage")):

--- a/scripts/combat/damage.gd
+++ b/scripts/combat/damage.gd
@@ -11,8 +11,8 @@ var damage: int;
 var type: DamageType
 var isCritical: bool = false;
 
-func _init(source: Node2D, amount: int, type: DamageType, isCritical: bool = false):
-	self.source = source;
+func _init(p_source: Node2D, amount: int, p_type: DamageType, p_isCritical: bool = false):
+	self.source = p_source;
 	self.damage = amount;
-	self.type = type;
-	self.isCritical = isCritical;
+	self.type = p_type;
+	self.isCritical = p_isCritical;

--- a/scripts/combat/projectile.gd
+++ b/scripts/combat/projectile.gd
@@ -39,44 +39,44 @@ enum ProjectileMoveType
 # New Modifier Callable
 var callback: ProjectileCallback = null
 
-func _base_setup(shooter: Tower, damage: Damage, lifetime: float = 5.0, callback: ProjectileCallback = null):
-	self.shooter = shooter
-	self.damage = damage
-	self.lifetime = lifetime
-	self.callback = callback if callback else ProjectileCallback.new(Callable(), Callable(), Callable())
+func _base_setup(p_shooter: Tower, p_damage: Damage, p_lifetime: float = 5.0, p_callback: ProjectileCallback = null):
+	self.shooter = p_shooter
+	self.damage = p_damage
+	self.lifetime = p_lifetime
+	self.callback = p_callback if p_callback else ProjectileCallback.new(Callable(), Callable(), Callable())
 
-func setupTarget(shooter: Tower, target: Enemy, damage: Damage, lifetime: float = 5.0, callback: ProjectileCallback = null):
-	_base_setup(shooter, damage, lifetime, callback)
-	self.target = target
+func setupTarget(p_shooter: Tower, p_target: Enemy, p_damage: Damage, p_lifetime: float = 5.0, p_callback: ProjectileCallback = null):
+	_base_setup(p_shooter, p_damage, p_lifetime, p_callback)
+	self.target = p_target
 	moveType = ProjectileMoveType.Target
-	rotation = Utility.get_angle_to_target(global_position, target.global_position)
+	rotation = Utility.get_angle_to_target(global_position, p_target.global_position)
 	connect("area_entered", Callable(self, "onAreaEntered"))
 
-func setupTargetPosition(shooter: Tower, target_position: Vector2, damage: Damage, lifetime: float = 5.0, callback: ProjectileCallback = null):
-	_base_setup(shooter, damage, lifetime, callback)
-	self.target_position = target_position
+func setupTargetPosition(p_shooter: Tower, p_target_position: Vector2, p_damage: Damage, p_lifetime: float = 5.0, p_callback: ProjectileCallback = null):
+	_base_setup(p_shooter, p_damage, p_lifetime, p_callback)
+	self.target_position = p_target_position
 	moveType = ProjectileMoveType.Position
-	rotation = Utility.get_angle_to_target(global_position, target_position)
+	rotation = Utility.get_angle_to_target(global_position, p_target_position)
 
-func setup_direction(shooter: Tower, direction: Vector2, damage: Damage, lifetime: float = 5.0, callback: ProjectileCallback = null):
-	_base_setup(shooter, damage, lifetime, callback)
+func setup_direction(p_shooter: Tower, direction: Vector2, p_damage: Damage, p_lifetime: float = 5.0, p_callback: ProjectileCallback = null):
+	_base_setup(p_shooter, p_damage, p_lifetime, p_callback)
 	self.move_direction = direction.normalized()
 	moveType = ProjectileMoveType.Direction
 	rotation = Utility.get_angle_to_target(global_position, global_position + direction)
 	connect("area_entered", Callable(self, "onAreaEntered"))
 
-func setup_circle(shooter: Tower, damage: Damage, circle_radius: float = 100.0, angular_speed: float = 180.0, initial_angle: float = 0.0, lifetime: float = 5.0, callback: ProjectileCallback = null):
-	_base_setup(shooter, damage, lifetime, callback)
+func setup_circle(p_shooter: Tower, p_damage: Damage, p_circle_radius: float = 100.0, angular_speed: float = 180.0, initial_angle: float = 0.0, p_lifetime: float = 5.0, p_callback: ProjectileCallback = null):
+	_base_setup(p_shooter, p_damage, p_lifetime, p_callback)
 	spawn_position = global_position
-	self.circle_radius = circle_radius * GridHelper.CELL_SIZE
+	self.circle_radius = p_circle_radius * GridHelper.CELL_SIZE
 	self.circle_angle = initial_angle
 	self.circle_angular_speed = angular_speed
 	moveType = ProjectileMoveType.Circle
 	connect("area_entered", Callable(self, "onAreaEntered"))
 
-func setupStatusEffects(statusEffects: Array[StatusEffect]):
-	if statusEffects:
-		self.statusEffects = statusEffects
+func setupStatusEffects(p_statusEffects: Array[StatusEffect]):
+	if p_statusEffects:
+		self.statusEffects = p_statusEffects
 
 func _process(delta: float) -> void:
 	match moveType:

--- a/scripts/combat/projectile_callback.gd
+++ b/scripts/combat/projectile_callback.gd
@@ -5,7 +5,7 @@ var onHit: Callable = Callable()
 var onExpire: Callable = Callable()
 var onMove: Callable = Callable()
 
-func _init(onHit: Callable = Callable(), onExpire: Callable = Callable(), onMoving: Callable = Callable()):
-	self.onHit = onHit
-	self.onExpire = onExpire
+func _init(p_onHit: Callable = Callable(), p_onExpire: Callable = Callable(), onMoving: Callable = Callable()):
+	self.onHit = p_onHit
+	self.onExpire = p_onExpire
 	self.onMove = onMoving

--- a/scripts/enemy_detector.gd
+++ b/scripts/enemy_detector.gd
@@ -11,8 +11,8 @@ var enableDrawRange: bool = false
 signal onEnemyDetected(enemy: Enemy)
 signal onRemoveTarget()
 
-func setup(radius: float):
-	self.radius = radius + 0.5
+func setup(p_radius: float):
+	self.radius = p_radius + 0.5
 
 	# 🔥 Make shape unique so it won't affect other towers
 	if collision and collision.shape:

--- a/scripts/entity/attack_controller.gd
+++ b/scripts/entity/attack_controller.gd
@@ -10,9 +10,9 @@ var tower: Tower;
 
 var modifier: Dictionary = {}
 
-func setup(tower: Tower, getCooldown: Callable):
+func setup(p_tower: Tower, getCooldown: Callable):
 	getAttackCooldown = getCooldown;
-	self.tower = tower;
+	self.tower = p_tower;
 
 func addModifier(key: int, mod: Callable):
 	modifier[key] = mod

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -24,8 +24,8 @@ var _removed: bool = false;
 enum EnemyType {Normal, Elite, Boss}
 const FACING_X_EPSILON: float = 0.01
 
-func setup(enemyType: EnemyType, hp: int, armor: int, mArmor: int, moveSpeed: int, texture: Texture2D, skills: Array[Skill] = [], damageReduction: float = 0.0):
-	self.enemyType = enemyType;
+func setup(p_enemyType: EnemyType, hp: int, armor: int, mArmor: int, moveSpeed: int, texture: Texture2D, skills: Array[Skill] = [], damageReduction: float = 0.0):
+	self.enemyType = p_enemyType;
 	setTexture(texture);
 	stats = EnemyStat.new(hp, armor, mArmor, moveSpeed, damageReduction);
 	originalModulate = sprite.modulate

--- a/scripts/entity/enemy/enemy_reward.gd
+++ b/scripts/entity/enemy/enemy_reward.gd
@@ -4,6 +4,6 @@ extends RefCounted
 var gold: int = 0
 var evoToken: int = 0
 
-func _init(gold: int, evoToken: int):
-	self.gold = gold
-	self.evoToken = evoToken
+func _init(p_gold: int, p_evoToken: int):
+	self.gold = p_gold
+	self.evoToken = p_evoToken

--- a/scripts/entity/enemy_stats.gd
+++ b/scripts/entity/enemy_stats.gd
@@ -17,13 +17,13 @@ var blockCount: int = 0; # Number of damage blocks available
 
 var buffs: Dictionary = {};
 
-func _init(hp: int, armor: int, mArmor: int, moveSpeed: float, damageReduction: float = 0.0):
+func _init(hp: int, p_armor: int, p_mArmor: int, p_moveSpeed: float, p_damageReduction: float = 0.0):
 	maxHp = hp;
 	currentHp = hp;
-	self.armor = armor;
-	self.mArmor = mArmor;
-	self.moveSpeed = moveSpeed;
-	self.damageReduction = damageReduction;
+	self.armor = p_armor;
+	self.mArmor = p_mArmor;
+	self.moveSpeed = p_moveSpeed;
+	self.damageReduction = p_damageReduction;
 
 func updateHealth(amount: int):
 	currentHp = clamp(currentHp + amount, 0, maxHp);

--- a/scripts/entity/health_controller.gd
+++ b/scripts/entity/health_controller.gd
@@ -4,8 +4,8 @@ class_name HealthController
 var maxHealth: int = 0
 var currHealth: int = 0
 
-func setup(max: int, current: int):
-	maxHealth = max
+func setup(p_max: int, current: int):
+	maxHealth = p_max
 	currHealth = current
 
 func _ready():

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -128,17 +128,17 @@ func _process(delta):
 	if enableAttack && !attacking && !usingSkill && !skillReady:
 		attackEnemy();
 
-func setup(id: String, onPlace: Callable, onRemove: Callable):
-	self.id = id;
-	self.name = id;
-	towerName = id;
-	self.onPlace = onPlace;
-	self.onRemove = onRemove;
+func setup(p_id: String, p_onPlace: Callable, p_onRemove: Callable):
+	self.id = p_id;
+	self.name = p_id;
+	towerName = p_id;
+	self.onPlace = p_onPlace;
+	self.onRemove = p_onRemove;
 
-	var towerData = TowerCenter._towers_data.get(id.to_lower(), null);
+	var towerData = TowerCenter._towers_data.get(p_id.to_lower(), null);
 
 	if towerData == null:
-		printerr("tower data not found: " + id + ", exists: " + str(TowerCenter._towers_data.keys()));
+		printerr("tower data not found: " + p_id + ", exists: " + str(TowerCenter._towers_data.keys()));
 		return;
 
 	self.data = towerData.data;
@@ -282,12 +282,12 @@ func updateSpriteColor(available: bool):
 	else:
 		spr.self_modulate = Color("#ff0000", 1);
 
-func _onEnemyDetected(enemy: Enemy):
+func _onEnemyDetected(p_enemy: Enemy):
 	if self.enemy != null:
 		clearEnemy(null, null, null);
 
-	self.enemy = enemy;
-	if(enemy != null):
+	self.enemy = p_enemy;
+	if(p_enemy != null):
 		Utility.ConnectSignal(self.enemy, "onDead", Callable(self, "clearEnemy"));
 		Utility.ConnectSignal(self.enemy, "onReachEndPoint", Callable(self, "clearEnemy"));
 

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -306,32 +306,32 @@ func clearEnemy(_enemy = null, _cause = null, _reward = null):
 	enemy = null;
 	attacking = false;
 
-func play_animation(name: String, speed: float = 1):
+func play_animation(p_name: String, speed: float = 1):
 	if(anim != null):
-		return anim.play(name, speed);
+		return anim.play(p_name, speed);
 	return false;
 
-func get_animation_duration(name: String) -> float:
+func get_animation_duration(p_name: String) -> float:
 	if(anim != null):
-		return anim.get_native_duration(name);
+		return anim.get_native_duration(p_name);
 	return 0.0;
 
-func has_animation(name: String) -> bool:
+func has_animation(p_name: String) -> bool:
 	if(anim != null):
-		return anim.has_animation(name);
+		return anim.has_animation(p_name);
 	return false;
 
 func play_animation_default():
 	if(anim != null):
 		anim.playDefault();
 
-func animation_finished(name: String):
-	match name:
+func animation_finished(p_name: String):
+	match p_name:
 		_:
 			pass;
 			# play_animation_default();
 
-	on_animation_finished.emit(name);
+	on_animation_finished.emit(p_name);
 
 func update_mana_bar(current: float):
 	if(manaBar == null):
@@ -376,9 +376,9 @@ func resetForWave():
 
 	play_animation_default()
 
-func showAttackRange(show: bool):
+func showAttackRange(p_show: bool):
 	if enemyDetector != null:
-		enemyDetector.setEnabledDrawRange(show);
+		enemyDetector.setEnabledDrawRange(p_show);
 
 func setTowerStar(tier: int):
 	if(towerStar != null):

--- a/scripts/entity/tower/tower_factory.gd
+++ b/scripts/entity/tower/tower_factory.gd
@@ -25,8 +25,8 @@ func setup(p_onPlace: Callable, p_onRemove: Callable):
 	synergyController.setup(self)
 	Utility.ConnectSignal(towerTrait, "synergy_updated", Callable(self, "_on_synergy_updated"));
 
-func getTower(name: String, evoToken: int = 0) -> GetTowerResult:
-	var resource = ResourceManager.getTower(name);
+func getTower(p_name: String, evoToken: int = 0) -> GetTowerResult:
+	var resource = ResourceManager.getTower(p_name);
 
 	if(resource == null && towerTemplate != null):
 		resource = towerTemplate
@@ -36,8 +36,8 @@ func getTower(name: String, evoToken: int = 0) -> GetTowerResult:
 
 	var result: GetTowerResult = GetTowerResult.new()
 
-	if (towersByName.has(name)):
-		var t = towersByName.get(name, null);
+	if (towersByName.has(p_name)):
+		var t = towersByName.get(p_name, null);
 		if (t != null):
 			if(t.data.level >= t.data.maxLevel && !t.isEvolved() && t.data.evolutionCost >= evoToken):
 				result.state = GetTowerResult.State.Evolve;
@@ -49,7 +49,7 @@ func getTower(name: String, evoToken: int = 0) -> GetTowerResult:
 			result.state = GetTowerResult.State.Upgrade;
 
 			if(t.canEvolve() && not t.isEvolved()):
-				_evolutionList[name] = t.data;
+				_evolutionList[p_name] = t.data;
 
 			return result;
 
@@ -62,13 +62,13 @@ func getTower(name: String, evoToken: int = 0) -> GetTowerResult:
 
 	result.state = GetTowerResult.State.New
 	result.tower = tower;
-	tower.setup(name, onPlace, onRemove)
+	tower.setup(p_name, onPlace, onRemove)
 	Utility.ConnectSignal(tower, "onReceiveMission", Callable(self, "towerReceiveMission"));
 	Utility.ConnectSignal(tower, "skill_cast_succeeded", Callable(synergyController, "on_tower_cast"));
 	# Register traits in the keyed list BEFORE add_tower_traits so a synergy that
 	# activates on this placement already counts the new tower.
 	for towerSyn in [tower.data.towerClass, tower.data.generation]:
-		addTowerToDict(name, tower, towerSyn)
+		addTowerToDict(p_name, tower, towerSyn)
 	towerTrait.add_tower_traits([tower.data.towerClass, tower.data.generation])
 	synergyController.on_tower_added(tower)
 	return result
@@ -89,12 +89,12 @@ func returnTower(tower: Tower):
 	towerTrait.remove_tower_traits(traits)
 	tower.queue_free()
 
-func addTowerToDict(name: String, tower: Tower, key: int):
+func addTowerToDict(p_name: String, tower: Tower, key: int):
 	if key <= 0:  # Skip invalid keys
 		return
 
-	if not towersByName.has(name):
-		towersByName[name] = tower
+	if not towersByName.has(p_name):
+		towersByName[p_name] = tower
 
 	var list: Array = towers.get(key, [])
 	if(list.find(tower) >= 0):
@@ -115,10 +115,10 @@ func removeTowerFromDict(tower: Tower, key: int):
 	list.remove_at(index)
 	towers[key] = list
 
-func evolutionTower(name: String):
-	var towerData = TowerCenter.getTowerDataByName(name);
+func evolutionTower(p_name: String):
+	var towerData = TowerCenter.getTowerDataByName(p_name);
 	if towerData == null:
-		print("Error: Tower data not found for evolution:", name)
+		print("Error: Tower data not found for evolution:", p_name)
 		return;
 
 	var dataName = towerData.data_name;

--- a/scripts/entity/tower/tower_factory.gd
+++ b/scripts/entity/tower/tower_factory.gd
@@ -17,9 +17,9 @@ enum TowerId {
 	Test
 }
 
-func setup(onPlace: Callable, onRemove: Callable):
-	self.onPlace = onPlace
-	self.onRemove = onRemove
+func setup(p_onPlace: Callable, p_onRemove: Callable):
+	self.onPlace = p_onPlace
+	self.onRemove = p_onRemove
 
 	synergyController = SynergyController.new()
 	synergyController.setup(self)

--- a/scripts/game_camera.gd
+++ b/scripts/game_camera.gd
@@ -32,7 +32,7 @@ func _ready():
 	
 	position = Vector2(center.x * cell_size, center.y * cell_size)
 
-func get_tilemap_center(tilemap: TileMap) -> Vector2:
-	var used_rect = tilemap.get_used_rect()
+func get_tilemap_center(p_tilemap: TileMap) -> Vector2:
+	var used_rect = p_tilemap.get_used_rect()
 	var center_cell = used_rect.position + (used_rect.size / 2)
 	return center_cell

--- a/scripts/inventory/inventory_item.gd
+++ b/scripts/inventory/inventory_item.gd
@@ -8,10 +8,10 @@ var stack: int = 1
 var maxStack: int = 64;
 var icon: Texture2D = null
 
-func _init(id: int, name: String, desc: String, stack: int, maxStack: int, icon: Texture2D) -> void:
-	self.id = id
-	self.name = name
-	self.desc = desc
-	self.stack = stack
-	self.maxStack = maxStack
-	self.icon = icon
+func _init(p_id: int, p_name: String, p_desc: String, p_stack: int, p_maxStack: int, p_icon: Texture2D) -> void:
+	self.id = p_id
+	self.name = p_name
+	self.desc = p_desc
+	self.stack = p_stack
+	self.maxStack = p_maxStack
+	self.icon = p_icon

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -63,8 +63,8 @@ func _input(event):
 		elif event.keycode == KEY_3:
 			testSpawnBoss(2);
 
-func setup(data: WaveControllerData):
-	self.data = data;
+func setup(p_data: WaveControllerData):
+	self.data = p_data;
 	enemyTextures = ResourceManager.getSpriteGroup("enemy");
 
 func setBossList(list: Array[BossDBData]):

--- a/scripts/map/enemy_wave/wave_enemy_group.gd
+++ b/scripts/map/enemy_wave/wave_enemy_group.gd
@@ -13,7 +13,7 @@ var startAt: float = 0
 # which still calls the legacy 6-arg setup(). Maps the old `texture` column to the
 # new `enemy` id and ignores the inline stat args (stats now live in the enemy DB).
 # Remove together with that dead tool (pending Lead - see coding log).
-func setup(texture: String, _health: int = 0, _def: float = 0, _mDef: float = 0, _moveSpeed: float = 0, count: int = 20, spawnInterval: float = 1):
+func setup(texture: String, _health: int = 0, _def: float = 0, _mDef: float = 0, _moveSpeed: float = 0, p_count: int = 20, p_spawnInterval: float = 1):
 	self.enemy = texture
-	self.count = count
-	self.spawnInterval = spawnInterval
+	self.count = p_count
+	self.spawnInterval = p_spawnInterval

--- a/scripts/map/map.gd
+++ b/scripts/map/map.gd
@@ -11,10 +11,10 @@ static var startY: int = 3;
 
 static var availableCells: Array[Vector2i];
 
-func toggle_grid(is_visible: bool):
+func toggle_grid(p_is_visible: bool):
 	if drawer:
-		drawer.visible = is_visible
-		if is_visible:
+		drawer.visible = p_is_visible
+		if p_is_visible:
 			drawer.queue_redraw()
 
 # Internal helper to refresh when data changes

--- a/scripts/map/map_data.gd
+++ b/scripts/map/map_data.gd
@@ -9,5 +9,5 @@ var waves: Array[WaveData] = []
 # tuning tool. Each entry: { stat, op, value } - validated by EnemyModifier.
 var stageModifiers: Array = []
 
-func setWave(waves: Array[WaveData]):
-	self.waves = waves;
+func setWave(p_waves: Array[WaveData]):
+	self.waves = p_waves;

--- a/scripts/map/map_grid_data.gd
+++ b/scripts/map/map_grid_data.gd
@@ -4,6 +4,6 @@ class_name MapGridData
 var cell: Vector2;
 var placable: bool;
 
-func _init(x: int, y: int, placable: bool = true):
+func _init(x: int, y: int, p_placable: bool = true):
 	cell = Vector2(x, y);
-	self.placable = placable;
+	self.placable = p_placable;

--- a/scripts/map/path_bake_auto.gd
+++ b/scripts/map/path_bake_auto.gd
@@ -28,7 +28,7 @@ func bake():
 	print("Path set with %d points." % path.size())
 	return path
 
-func get_marked_points(layer: int) -> Array[Vector2i]:
+func get_marked_points(p_layer: int) -> Array[Vector2i]:
 	var marked: Array[Vector2i] = []
 	var allowed_atlas_coords: Array[Vector2i] = [
 		Vector2i(0, 0), Vector2i(0, 1), Vector2i(0, 2),
@@ -37,19 +37,19 @@ func get_marked_points(layer: int) -> Array[Vector2i]:
 	]
 
 	# Step 1: Collect from the base layer (layer 0)
-	for pos in tilemap.get_used_cells(layer):
-		var source_id: int = tilemap.get_cell_source_id(layer, pos)
+	for pos in tilemap.get_used_cells(p_layer):
+		var source_id: int = tilemap.get_cell_source_id(p_layer, pos)
 		if source_id != target_source_id:
 			continue
 
-		var atlas_coord: Vector2i = tilemap.get_cell_atlas_coords(layer, pos)
+		var atlas_coord: Vector2i = tilemap.get_cell_atlas_coords(p_layer, pos)
 		if allowed_atlas_coords.has(atlas_coord):
 			marked.append(pos)
 
 	# Step 2: Check other layers and remove positions if they exist there
 	var final_marked := marked.duplicate()
 	for check_layer in range(2):
-		if check_layer == layer:
+		if check_layer == p_layer:
 			continue
 		for pos in marked:
 			if tilemap.get_used_cells(check_layer).has(pos):

--- a/scripts/map/path_tile.gd
+++ b/scripts/map/path_tile.gd
@@ -3,6 +3,6 @@ class_name PathTile
 var index: int;
 var position: Vector2i;
 
-func _init(index: int, x: int, y: int):
-	self.index = index;
+func _init(p_index: int, x: int, y: int):
+	self.index = p_index;
 	self.position = Vector2i(x, y);

--- a/scripts/map_data_object.gd
+++ b/scripts/map_data_object.gd
@@ -5,7 +5,7 @@ var name: String;
 var key: String;
 var wave: int;
 
-func _init(name: String, key: String, wave: int):
-	self.name = name;
-	self.key = key;
-	self.wave = wave;
+func _init(p_name: String, p_key: String, p_wave: int):
+	self.name = p_name;
+	self.key = p_key;
+	self.wave = p_wave;

--- a/scripts/mission/mission_detail.gd
+++ b/scripts/mission/mission_detail.gd
@@ -3,7 +3,7 @@ class_name MissionDetail
 var id: int;
 var keyword: String;
 var progress: int;
-var max: int;
+var maxProgress: int;
 var description: String;
 var onComplete: Callable;
 var completed: bool
@@ -12,7 +12,7 @@ func _init(p_id: int,p_keyword: String, p_progress: int, p_max: int, desc: Strin
 	self.id = p_id;
 	self.keyword = p_keyword;
 	self.progress = p_progress;
-	self.max = p_max;
+	self.maxProgress = p_max;
 	description = desc;
 	self.onComplete = p_onComplete;
 	completed = p_progress == p_max;
@@ -21,7 +21,7 @@ func updateProgress(updateAmount: int):
 	if (completed):
 		return;
 	
-	progress = clamp(progress + updateAmount, 0, max);
-	if(progress == max):
+	progress = clamp(progress + updateAmount, 0, maxProgress);
+	if(progress == maxProgress):
 		completed = true;
 		onComplete.call(id);

--- a/scripts/mission/mission_detail.gd
+++ b/scripts/mission/mission_detail.gd
@@ -8,14 +8,14 @@ var description: String;
 var onComplete: Callable;
 var completed: bool
 
-func _init(id: int,keyword: String, progress: int, max: int, desc: String, onComplete: Callable):
-	self.id = id;
-	self.keyword = keyword;
-	self.progress = progress;
-	self.max = max;
+func _init(p_id: int,p_keyword: String, p_progress: int, p_max: int, desc: String, p_onComplete: Callable):
+	self.id = p_id;
+	self.keyword = p_keyword;
+	self.progress = p_progress;
+	self.max = p_max;
 	description = desc;
-	self.onComplete = onComplete;
-	completed = progress == max;
+	self.onComplete = p_onComplete;
+	completed = p_progress == p_max;
 
 func updateProgress(updateAmount: int):
 	if (completed):

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -231,9 +231,9 @@ func _commit_staff_skill_cast():
 		return
 	# Snap mouse to grid cell center (same logic as the indicator) and execute.
 	var cell: Vector2i = GridHelper.WorldToCell(get_global_mouse_position())
-	var snapped: Vector2 = GridHelper.CellToWorld(cell)
+	var snapped_pos: Vector2 = GridHelper.CellToWorld(cell)
 	_exit_skill_cast_state()
-	staff.executeSkillAtPosition(snapped)
+	staff.executeSkillAtPosition(snapped_pos)
 
 func _cancel_staff_skill_cast():
 	_exit_skill_cast_state()

--- a/scripts/skill/base_skill_controller.gd
+++ b/scripts/skill/base_skill_controller.gd
@@ -11,9 +11,9 @@ var cancelled = false;
 # emit it but nothing listens on the enemy side.
 signal cast_succeeded(skill)
 
-func _init(user: Node, skills: Array[Skill]):
-	self.skills = skills;
-	self.user = user;
+func _init(p_user: Node, p_skills: Array[Skill]):
+	self.skills = p_skills;
+	self.user = p_user;
 
 func useSkill():
 	if(!canUseSkill()):
@@ -82,8 +82,8 @@ func canUseSkill() -> bool:
 
 	return true;
 
-func addModifier(key: int, modifier: Callable):
-	self.modifier[key] = modifier
+func addModifier(key: int, p_modifier: Callable):
+	self.modifier[key] = p_modifier
 
 func removeModifier(key: int):
 	if(!modifier.has(key)):

--- a/scripts/skill/enemy_skill.gd
+++ b/scripts/skill/enemy_skill.gd
@@ -4,9 +4,9 @@ extends Skill
 @export var cooldown: float = 3
 var cooldownRemaining: float = 0.0;
 
-func _init(name:String="EnemySkill", desc:String="Just an enemy skill", actions:Array[SkillAction]=[], parameters:Dictionary={}, oneTimeUse: bool = false, cooldown:float=3.0):
-	super(name, desc, actions, parameters, oneTimeUse);
-	self.cooldown = cooldown;
+func _init(p_name:String="EnemySkill", p_desc:String="Just an enemy skill", p_actions:Array[SkillAction]=[], p_parameters:Dictionary={}, p_oneTimeUse: bool = false, p_cooldown:float=3.0):
+	super(p_name, p_desc, p_actions, p_parameters, p_oneTimeUse);
+	self.cooldown = p_cooldown;
 
 func isReady():
 	return super.isReady() and cooldownRemaining <= 0.0

--- a/scripts/skill/enemy_skill_controller.gd
+++ b/scripts/skill/enemy_skill_controller.gd
@@ -1,9 +1,9 @@
 class_name EnemySkillController
 extends BaseSkillController
 
-func _init(user: Node, skills: Array[Skill]):
-	super._init(user, skills);
-	for s in skills:
+func _init(p_user: Node, p_skills: Array[Skill]):
+	super._init(p_user, p_skills);
+	for s in p_skills:
 		(s as EnemySkill).initCooldown();
 
 func process(delta: float):

--- a/scripts/skill/metheor.gd
+++ b/scripts/skill/metheor.gd
@@ -7,12 +7,12 @@ var max_radius: float = GridHelper.CELL_SIZE / 2
 var elapsed_time: float = 0.0
 var damage: Damage;
 
-func _init(damage: Damage, position: Vector2, delay_explode: float) -> void:
-	spawn_position = position
-	self.delay_explode = delay_explode;
+func _init(p_damage: Damage, p_position: Vector2, p_delay_explode: float) -> void:
+	spawn_position = p_position
+	self.delay_explode = p_delay_explode;
 
-	self.position = position;
-	self.damage = damage;
+	self.position = p_position;
+	self.damage = p_damage;
 	
 func _process(delta: float) -> void:
 	elapsed_time += delta

--- a/scripts/skill/skill.gd
+++ b/scripts/skill/skill.gd
@@ -19,13 +19,13 @@ enum TARGET_TYPE {ENEMY, FRIENDLY}
 var using = false;
 var disable = false;
 
-func _init(name:String="Skill", desc:String="Just a skill", actions:Array[SkillAction]=[], parameters:Dictionary={}, oneTimeUse: bool = false, castTime: float = 0.0):
-	self.name = name;
-	self.desc = desc;
-	self.actions = actions;
-	self.parameters = parameters;
-	self.oneTimeUse = oneTimeUse;
-	self.castTime = castTime;
+func _init(p_name:String="Skill", p_desc:String="Just a skill", p_actions:Array[SkillAction]=[], p_parameters:Dictionary={}, p_oneTimeUse: bool = false, p_castTime: float = 0.0):
+	self.name = p_name;
+	self.desc = p_desc;
+	self.actions = p_actions;
+	self.parameters = p_parameters;
+	self.oneTimeUse = p_oneTimeUse;
+	self.castTime = p_castTime;
 
 func get_display_name(level: int) -> String:
 	if names.size() > 0:

--- a/scripts/skill/skillActions/decrease_atk_spd_area.gd
+++ b/scripts/skill/skillActions/decrease_atk_spd_area.gd
@@ -34,8 +34,8 @@ func enemyExited(area: Area2D):
 
 	effectedTargets.erase(area);
 
-func isEnemy(user: Node, target: Node):
-	return (user is Enemy and target is Tower) || (user is Tower and (target is Enemy or target is EnemyArea))
+func isEnemy(p_user: Node, target: Node):
+	return (p_user is Enemy and target is Tower) || (p_user is Tower and (target is Enemy or target is EnemyArea))
 
 func getDebuffKey():
 	return "skill_" + str(get_instance_id());

--- a/scripts/skill/skillActions/decrease_dmg_all_area.gd
+++ b/scripts/skill/skillActions/decrease_dmg_all_area.gd
@@ -34,8 +34,8 @@ func enemyExited(area: Area2D):
 
 	effectedTargets.erase(area);
 
-func isEnemy(user: Node, target: Node):
-	return (user is Enemy and target is Tower) || (user is Tower and (target is Enemy or target is EnemyArea))
+func isEnemy(p_user: Node, target: Node):
+	return (p_user is Enemy and target is Tower) || (p_user is Tower and (target is Enemy or target is EnemyArea))
 
 func getDebuffKey():
 	return "skill_" + str(get_instance_id());

--- a/scripts/skill/skillActions/increase_def_area.gd
+++ b/scripts/skill/skillActions/increase_def_area.gd
@@ -34,8 +34,8 @@ func enemyExited(area: Area2D):
 
 	effectedTargets.erase(area);
 
-func isEnemy(user: Node, target: Node):
-	return (user is Enemy and target is Tower) || (user is Tower and (target is Enemy or target is EnemyArea))
+func isEnemy(p_user: Node, target: Node):
+	return (p_user is Enemy and target is Tower) || (p_user is Tower and (target is Enemy or target is EnemyArea))
 
 func getDebuffKey():
 	return "skill_" + str(get_instance_id());

--- a/scripts/skill/skillActions/increase_move_spd_area.gd
+++ b/scripts/skill/skillActions/increase_move_spd_area.gd
@@ -34,8 +34,8 @@ func enemyExited(area: Area2D):
 
 	effectedTargets.erase(area);
 
-func isEnemy(user: Node, target: Node):
-	return (user is Enemy and target is Tower) || (user is Tower and (target is Enemy or target is EnemyArea))
+func isEnemy(p_user: Node, target: Node):
+	return (p_user is Enemy and target is Tower) || (p_user is Tower and (target is Enemy or target is EnemyArea))
 
 func getDebuffKey():
 	return "skill_" + str(get_instance_id());

--- a/scripts/skill/skillActions/skill_action_atk_speed_buff_aoe.gd
+++ b/scripts/skill/skillActions/skill_action_atk_speed_buff_aoe.gd
@@ -5,7 +5,7 @@ extends SkillAction
 # ATTACK_SPEED is decimal scale (0.5 = +50%) — see tower_data.getAttackSpeed.
 @export var percent: float = 0.5
 @export var paramName: String = ""
-@export var range: int = 1
+@export var range_cells: int = 1
 @export var displayName: String = "Attack Speed Up"
 @export var iconPath: String = ""
 
@@ -25,7 +25,7 @@ func execute(context: SkillContext) -> void:
 		if tower == null:
 			continue
 		var cell: Vector2 = GridHelper.WorldToCell(tower.global_position)
-		if abs(cell.x - source_cell.x) <= range and abs(cell.y - source_cell.y) <= range:
+		if abs(cell.x - source_cell.x) <= range_cells and abs(cell.y - source_cell.y) <= range_cells:
 			var buff := BuffInstance.new(
 				BUFF_KEY,
 				BuffInstance.StatType.ATTACK_SPEED,

--- a/scripts/skill/skill_controller.gd
+++ b/scripts/skill/skill_controller.gd
@@ -4,9 +4,9 @@ extends BaseSkillController
 var maxMana := 0.0;
 var currentMana := 0.0;
 
-func _init(user: Node, maxMana: float, initialMana: float, skill: Skill):
-	super._init(user, [skill]);
-	self.maxMana = maxMana;
+func _init(p_user: Node, p_maxMana: float, initialMana: float, skill: Skill):
+	super._init(p_user, [skill]);
+	self.maxMana = p_maxMana;
 	currentMana = initialMana;
 
 func updateMana(amount: float):

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -109,7 +109,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			# ATTACK_SPEED is decimal scale (0.5 = +50%) — see tower_data.getAttackSpeed.
 			skill.percent = skillData.get("percent", 0.5)
 			skill.paramName = skillData.get("param_name", "")
-			skill.range = skillData.get("range", 1)
+			skill.range_cells = skillData.get("range", 1)
 		"crit_chance_buff":
 			skill = SkillActionCritChanceBuff.new()
 			var skillData = data.get("data", {})

--- a/scripts/status_effect/dmg_reduction_buff.gd
+++ b/scripts/status_effect/dmg_reduction_buff.gd
@@ -5,9 +5,9 @@ extends StatusEffect
 var elapsedTime: float = 0.0
 var originColor: Color
 
-func _init(duration: float = 5.0, reductionAmount: float = 0.1):
-	super._init(duration, 1, "DamageReductionBuff")
-	self.reductionAmount = reductionAmount
+func _init(p_duration: float = 5.0, p_reductionAmount: float = 0.1):
+	super._init(p_duration, 1, "DamageReductionBuff")
+	self.reductionAmount = p_reductionAmount
 
 func _process_effect(delta: float, target: Node) -> void:
 	elapsedTime += delta

--- a/scripts/status_effect/increase_armor_flat_buff.gd
+++ b/scripts/status_effect/increase_armor_flat_buff.gd
@@ -4,9 +4,9 @@ extends StatusEffect
 @export var increaseAmount: int = 1 # Flat armor amount
 var elapsedTime: float = 0.0
 
-func _init(duration: float = 5.0, increaseAmount: int = 1):
-	super._init(duration, 1, "IncreaseArmorFlatBuff")
-	self.increaseAmount = increaseAmount
+func _init(p_duration: float = 5.0, p_increaseAmount: int = 1):
+	super._init(p_duration, 1, "IncreaseArmorFlatBuff")
+	self.increaseAmount = p_increaseAmount
 
 func _process_effect(delta: float, target: Node) -> void:
 	elapsedTime += delta

--- a/scripts/status_effect/increase_def_buff.gd
+++ b/scripts/status_effect/increase_def_buff.gd
@@ -6,20 +6,20 @@ var elapsedTime: float = 0.0
 var originColor: Color
 var buffKey: String = ""
 
-func _init(duration: float = 5.0, increaseAmount: float = 0.1):
-	super._init(duration, 1, "IncreaseDefBuff")
-	self.increaseAmount = increaseAmount
+func _init(p_duration: float = 5.0, p_increaseAmount: float = 0.1):
+	super._init(p_duration, 1, "IncreaseDefBuff")
+	self.increaseAmount = p_increaseAmount
 
 func _process_effect(delta: float, target: Node) -> void:
 	elapsedTime += delta
 	if elapsedTime >= duration:
 		_on_expire(target)
 
-func _on_apply(target: Node, buffKey: String = "") -> void:
-	self.buffKey = buffKey if buffKey != "" else ""
+func _on_apply(target: Node, p_buffKey: String = "") -> void:
+	self.buffKey = p_buffKey if p_buffKey != "" else ""
 	if target.stats != null && target.stats is EnemyStat:
 		var stats := target.stats as EnemyStat
-		stats.addDefPercent(increaseAmount, buffKey);
+		stats.addDefPercent(increaseAmount, p_buffKey);
 
 func _on_expire(target: Node) -> void:
 	if(!is_instance_valid(target)):

--- a/scripts/status_effect/increase_marmor_flat_buff.gd
+++ b/scripts/status_effect/increase_marmor_flat_buff.gd
@@ -4,9 +4,9 @@ extends StatusEffect
 @export var increaseAmount: int = 1 # Flat magic resist amount
 var elapsedTime: float = 0.0
 
-func _init(duration: float = 5.0, increaseAmount: int = 1):
-	super._init(duration, 1, "IncreaseMArmorFlatBuff")
-	self.increaseAmount = increaseAmount
+func _init(p_duration: float = 5.0, p_increaseAmount: int = 1):
+	super._init(p_duration, 1, "IncreaseMArmorFlatBuff")
+	self.increaseAmount = p_increaseAmount
 
 func _process_effect(delta: float, target: Node) -> void:
 	elapsedTime += delta

--- a/scripts/status_effect/increase_marmor_percent_buff.gd
+++ b/scripts/status_effect/increase_marmor_percent_buff.gd
@@ -4,9 +4,9 @@ extends StatusEffect
 @export var increaseAmount: float = 0.1 # Percentage (0.0 to 1.0)
 var elapsedTime: float = 0.0
 
-func _init(duration: float = 5.0, increaseAmount: float = 0.1):
-	super._init(duration, 1, "IncreaseMArmorPercentBuff")
-	self.increaseAmount = increaseAmount
+func _init(p_duration: float = 5.0, p_increaseAmount: float = 0.1):
+	super._init(p_duration, 1, "IncreaseMArmorPercentBuff")
+	self.increaseAmount = p_increaseAmount
 
 func _process_effect(delta: float, target: Node) -> void:
 	elapsedTime += delta

--- a/scripts/status_effect/move_speed_multiplier_buff.gd
+++ b/scripts/status_effect/move_speed_multiplier_buff.gd
@@ -4,9 +4,9 @@ extends StatusEffect
 @export var multiplierValue: float = 0.5 # Decimal: +0.5 = +50% haste, -0.5 = 50% slow
 var elapsedTime: float = 0.0
 
-func _init(duration: float = 5.0, multiplierValue: float = 0.5):
-	super._init(duration, 1, "MoveSpeedMultiplierBuff")
-	self.multiplierValue = multiplierValue
+func _init(p_duration: float = 5.0, p_multiplierValue: float = 0.5):
+	super._init(p_duration, 1, "MoveSpeedMultiplierBuff")
+	self.multiplierValue = p_multiplierValue
 
 func _process_effect(delta: float, target: Node) -> void:
 	elapsedTime += delta

--- a/scripts/status_effect/status_effect.gd
+++ b/scripts/status_effect/status_effect.gd
@@ -16,10 +16,10 @@ var applied: bool = false;
 var expired: bool = false;
 var appliedTarget: Node = null
 
-func _init(duration: float = 5.0, level: int = 1, effectType: String = ""):
-	self.duration = duration
-	self.level = level
-	self.effectType = effectType
+func _init(p_duration: float = 5.0, p_level: int = 1, p_effectType: String = ""):
+	self.duration = p_duration
+	self.level = p_level
+	self.effectType = p_effectType
 
 func _process_effect(delta: float, target: Node) -> void:
 	if not applied:

--- a/scripts/status_effect/status_effect_container.gd
+++ b/scripts/status_effect/status_effect_container.gd
@@ -4,8 +4,8 @@ var effects: Dictionary = {}  # key = effect_type, value = Array[StatusEffect]
 
 var host: Node = null
 
-func _init(host: Node):
-	self.host = host
+func _init(p_host: Node):
+	self.host = p_host
 
 func addEffect(effect: StatusEffect) -> void:
 	if not effects.has(effect.effectType):

--- a/scripts/tower_center.gd
+++ b/scripts/tower_center.gd
@@ -93,8 +93,8 @@ func setTowerData(datas: Dictionary):
 func setDefaultTowerData(data):
 	_default_tower_data = data
 
-func preloadPortrait(name: String):
-	return ResourceManager.loadImage("portrait", name, "tower/portrait/" + name + ".png")
+func preloadPortrait(p_name: String):
+	return ResourceManager.loadImage("portrait", p_name, "tower/portrait/" + p_name + ".png")
 
 func getTowerData(key: String):
 	if(key == "default"):
@@ -105,14 +105,14 @@ func getTowerData(key: String):
 
 	return _towers_data.get(key, null)
 
-func getTowerDataByName(name: String):
-	if(name == "default"):
+func getTowerDataByName(p_name: String):
+	if(p_name == "default"):
 		return _default_tower_data;
 
 	if _towers_data_by_name == null:
 		return null
 
-	return _towers_data_by_name.get(name.to_lower(), null)
+	return _towers_data_by_name.get(p_name.to_lower(), null)
 
 func getTowerNames():
 	var names = []
@@ -123,25 +123,25 @@ func getTowerNames():
 
 	return names
 
-func getTowerSelectDataByName(name: String):
+func getTowerSelectDataByName(p_name: String):
 	if _own_towers == null:
 		return null
 
-	var data = _own_towers.get(name.to_lower(), null);
+	var data = _own_towers.get(p_name.to_lower(), null);
 	if(data != null):
 		var maxed: bool = data.level >= data.maxLevel and not data.isEvolved
 		return {"level": data.level, "evoCost": data.evoCost if maxed else 0}
 
 	return {"level":0, "evoCost":0}
 
-func validateSelectTower(name: String, evoToken: int):
-	if(_evolvedList.find(name) >= 0):
+func validateSelectTower(p_name: String, evoToken: int):
+	if(_evolvedList.find(p_name) >= 0):
 		return false
 
 	if _own_towers == null:
 		return false
 
-	var data = _own_towers.get(name.to_lower(), null);
+	var data = _own_towers.get(p_name.to_lower(), null);
 	if(data != null):
 		var maxed: bool = data.level >= data.maxLevel and not data.isEvolved
 		if(data.isEvolved or (maxed and data.evoCost > evoToken)):
@@ -151,11 +151,11 @@ func validateSelectTower(name: String, evoToken: int):
 
 	return true
 
-func getTowerEvolutionCostByName(name: String):
+func getTowerEvolutionCostByName(p_name: String):
 	if _own_towers == null:
 		return null
 
-	var data = _own_towers.get(name.to_lower(), null);
+	var data = _own_towers.get(p_name.to_lower(), null);
 	if(data != null):
 		if(data.level >= data.maxLevel):
 			return data.evoCost
@@ -164,34 +164,34 @@ func getTowerEvolutionCostByName(name: String):
 
 	return 0
 
-func upgradeTowerLevelByName(name: String):
+func upgradeTowerLevelByName(p_name: String):
 	if _own_towers == null:
 		return null
 
-	var data = _own_towers.get(name.to_lower(), null);
+	var data = _own_towers.get(p_name.to_lower(), null);
 	if(data != null):
 		if(data.isEvolved):
 			return
 		if(data.level >= data.maxLevel):
 			data.isEvolved = true;
-			_canEvoList.erase(name);
+			_canEvoList.erase(p_name);
 		else:
 			data.level += 1
 			if(data.level >= data.maxLevel):
-				_canEvoList.append(name);
+				_canEvoList.append(p_name);
 	else:
-		var tData = getTowerDataByName(name);
+		var tData = getTowerDataByName(p_name);
 		if(tData == null):
 			return
 		var d = tData.data;
 		var evoCost = d.evolutionCost;
 		var maxLevel = d.maxLevel;
-		_own_towers[name.to_lower()] = {"level": 1, "maxLevel": maxLevel, "evoCost": evoCost, "isEvolved": false};
+		_own_towers[p_name.to_lower()] = {"level": 1, "maxLevel": maxLevel, "evoCost": evoCost, "isEvolved": false};
 
-func getTowerPortraitByName(name: String):
+func getTowerPortraitByName(p_name: String):
 	if _tower_portrait_by_name == null:
 		return null
-	var portrait = _tower_portrait_by_name.get(name.to_lower(), null);
+	var portrait = _tower_portrait_by_name.get(p_name.to_lower(), null);
 	if(portrait != null):
 		return portrait
 

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -19,8 +19,8 @@ var _tier: int = -1
 var _stylebox: StyleBoxFlat = null   # this row's own panel StyleBox (see setup)
 
 # tier: current active tier (-1 = not yet proc'd). data: SynergyData or null.
-func setup(name: String, current: int, tier: int, data) -> void:
-	_name = name
+func setup(p_name: String, current: int, tier: int, data) -> void:
+	_name = p_name
 	_data = data
 	_tier = tier
 
@@ -37,7 +37,7 @@ func setup(name: String, current: int, tier: int, data) -> void:
 			_stylebox.bg_color = Color(_tier_color(tier))
 
 	if synergyName != null:
-		synergyName.text = name
+		synergyName.text = p_name
 
 	if synergyValue != null:
 		# current count - proc breakpoints, active one bracketed (e.g. "4 - 3 [4] 5").

--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -159,9 +159,9 @@ func _apply_cards_to_buttons(cards: Array) -> void:
 		else:
 			buttons[index].visible = false
 
-func _on_select_tower_button(name):
-	print("signal: tower_select,"+str(name))
-	emit_signal("tower_select", name)
+func _on_select_tower_button(p_name):
+	print("signal: tower_select,"+str(p_name))
+	emit_signal("tower_select", p_name)
 	# emit_signal("tower_select", "gawr_gura") #temp
 	queue_free()
 	#get_tree().quit()

--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -21,14 +21,14 @@ var _title_label: Label = null
 func _ready() -> void:
 	setupRefreshText(refreshLeft, maxRefresh);
 
-func setup(evoToken: int = 0, maxRefresh: int = 0, title: String = ""):
+func setup(evoToken: int = 0, p_maxRefresh: int = 0, title: String = ""):
 	var cards = _build_card_list(evoToken)
-	_apply_setup(cards, maxRefresh, evoToken, title)
+	_apply_setup(cards, p_maxRefresh, evoToken, title)
 
 # Entry point for callers that already have a card list (e.g. deck-add popup at wave-5 end).
 # Bypasses _build_card_list so the popup is not tied to TowerCenter tower pool.
-func setup_with_cards(cards: Array, maxRefresh: int = 0, title: String = ""):
-	_apply_setup(cards, maxRefresh, 0, title)
+func setup_with_cards(cards: Array, p_maxRefresh: int = 0, title: String = ""):
+	_apply_setup(cards, p_maxRefresh, 0, title)
 
 func _apply_setup(cards: Array, max_refresh: int, evoTokenForRefresh: int, title: String = ""):
 	self.refreshLeft = max_refresh;
@@ -73,9 +73,9 @@ func _ensure_title_label(title: String) -> void:
 		panel.add_child(_title_label)
 	_title_label.text = title
 
-func setupRefreshText(refreshCount: int, maxRefresh: int):
+func setupRefreshText(refreshCount: int, p_maxRefresh: int):
 	if(refreshText):
-		refreshText.text = str(refreshCount) + "/" + str(maxRefresh)
+		refreshText.text = str(refreshCount) + "/" + str(p_maxRefresh)
 
 func refreshList(evoToken: int = 0):
 	if(refreshLeft <= 0):

--- a/scripts/ui/tower_select/tower_select_button.gd
+++ b/scripts/ui/tower_select/tower_select_button.gd
@@ -12,7 +12,7 @@ var towerGenImage: TextureRect;
 func _ready():
 	add_to_group("tower_buttons")  # Ensures buttons register correctly
 
-func Setup(name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: TowerTrait.TowerGeneration, level: int, evolutionCost: int):
+func Setup(p_name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: TowerTrait.TowerGeneration, level: int, evolutionCost: int):
 	towerNameText = $TowerName
 	evolutionCostText = $Evolution/EvolutionCost
 	evolutionNode = $Evolution
@@ -20,13 +20,13 @@ func Setup(name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: To
 	towerClassImage = $Synergies/Class
 	towerGenImage = $Synergies/Gen
 
-	towerNameText.text = name + ("\nLevel " + str(level) if level > 0 else "")
+	towerNameText.text = p_name + ("\nLevel " + str(level) if level > 0 else "")
 	evolutionNode.visible = evolutionCost > 0
 	evolutionCostText.text = " " + str(evolutionCost)
 	if sprite != null:
 		towerPortrait.texture = sprite
 	else:
-		var portrait = TowerCenter.getTowerPortraitByName(name.to_lower());
+		var portrait = TowerCenter.getTowerPortraitByName(p_name.to_lower());
 		if(portrait):
 			towerPortrait.texture = portrait
 	var tClassName = TowerTrait.TOWER_CLASS_NAMES.get(towerClass, "default").to_lower();

--- a/scripts/ui/tower_select/tower_select_data.gd
+++ b/scripts/ui/tower_select/tower_select_data.gd
@@ -6,7 +6,7 @@ var icon: Texture2D;
 var level: int;
 var evolutionCost: int;
 
-func _init(name: String, level: int, evolutionCost: int):
-	self.name = name;
-	self.level = level;
-	self.evolutionCost = evolutionCost;
+func _init(p_name: String, p_level: int, p_evolutionCost: int):
+	self.name = p_name;
+	self.level = p_level;
+	self.evolutionCost = p_evolutionCost;

--- a/scripts/ui_scenes/deck_selection.gd
+++ b/scripts/ui_scenes/deck_selection.gd
@@ -74,10 +74,10 @@ func _setup_branch_filter():
 		filter_button.pressed.connect(Callable(self, "_on_branch_filter_pressed").bind(filter_button.name.to_lower()))
 
 func _display_character():
-	var char = characters[current_character_index]
-	%CharacterImage.texture = load(char["image"])
-	%CharacterName.text = char["name"]
-	%CharacterDescription.text = char["description"]
+	var character = characters[current_character_index]
+	%CharacterImage.texture = load(character["image"])
+	%CharacterName.text = character["name"]
+	%CharacterDescription.text = character["description"]
 
 func _setup_buttons():
 	if is_instance_valid(startBtn):

--- a/scripts/wallet/currency.gd
+++ b/scripts/wallet/currency.gd
@@ -8,12 +8,12 @@ var value: int = 0
 
 var onUpdate: Dictionary; #key = String, value = Callable
 
-func _init(id: int, name: String, desc: String, icon: Texture2D, value: int) -> void:
-	self.id = id
-	self.name = name
-	self.desc = desc
-	self.icon = icon
-	self.value = value
+func _init(p_id: int, p_name: String, p_desc: String, p_icon: Texture2D, p_value: int) -> void:
+	self.id = p_id
+	self.name = p_name
+	self.desc = p_desc
+	self.icon = p_icon
+	self.value = p_value
 
 func update(updateAmount: int):
 	if updateAmount == 0:


### PR DESCRIPTION
**Summary:** Project-wide rename of GDScript identifiers that triggered shadow warnings flooding the Godot debugger. Pure renames, no behaviour change; the debugger now reports zero shadow warnings.

**How it works:** Three warning categories, each fixed by renaming:
- `SHADOWED_VARIABLE` - a param/local matching a same-file member -> `p_` prefix.
- `SHADOWED_VARIABLE_BASE_CLASS` - matching an inherited Godot member (`Node.name`, `CanvasItem.show()`/`is_visible()`) -> `p_` prefix; found by resolving each script's `extends` chain (a same-file grep cannot see these).
- `SHADOWED_GLOBAL_IDENTIFIER` - a var/member named like a `@GlobalScope` builtin (`max`/`range`/`snapped`/`char`) -> descriptive rename (e.g. `max` -> `maxProgress`).

All renames are caller-safe (GDScript calls are positional). Params forwarded through `super(...)`/`super._init(...)` had their super-call args renamed in lockstep. One YAML-bound member (`skill_action_atk_speed_buff_aoe` `range` -> `range_cells`) is renamed in code + the `skill_utility` parser assignment, keeping the YAML key `range` so designer authoring is untouched.

**Implementation Notes:** 4 commits, pure renames (255/255 symmetric diff across 55 scripts). The noise originated from the legacy Unity->Godot port + pre-convention code; newer code already used the `p_` convention. Verified by a static scan (0 remaining across all 3 categories) and in-engine Director test (gameplay unaffected). A scrutinize pass caught the `super()`-forward gotcha and a file the same-file scan missed (`enemy_skill_controller.gd`).
