### PR TITLE
fix(lint): clear UNUSED_PARAMETER + UNUSED_VARIABLE warnings

### DIFF
--- a/scripts/area/effect_area.gd
+++ b/scripts/area/effect_area.gd
@@ -12,5 +12,5 @@ func _base_setup(shape: Shape2D,callback: EffectAreaCallback = null):
 		collisionShape.shape = shape
 		add_child(collisionShape)
 
-func _process(delta):
+func _process(_delta):
 	queue_redraw()

--- a/scripts/combat/projectile_spawner.gd
+++ b/scripts/combat/projectile_spawner.gd
@@ -3,7 +3,7 @@ class_name ProjectileSpawner
 
 @export var projectile: PackedScene
 
-func _process(delta):
+func _process(_delta):
 	pass
 
 func attack(target: Node2D):

--- a/scripts/enemy_detector.gd
+++ b/scripts/enemy_detector.gd
@@ -42,7 +42,7 @@ func _draw():
 		var targetLocalPos = to_local(target.global_position)
 		draw_line(position, targetLocalPos, Color.RED, 2.0)
 
-func _process(delta):
+func _process(_delta):
 	queue_redraw();
 
 func onCollisionHit(area: Area2D):

--- a/scripts/entity/enemy/enemy_factory.gd
+++ b/scripts/entity/enemy/enemy_factory.gd
@@ -22,8 +22,8 @@ func createEnemy(type: Enemy.EnemyType, parent: Node2D, health: int, def: int, m
 
 	return enemy
 
-func addBuff(count: int):
+func addBuff(_count: int):
 	pass
 
-func addSkill(count: int):
+func addSkill(_count: int):
 	pass

--- a/scripts/entity/health_controller.gd
+++ b/scripts/entity/health_controller.gd
@@ -11,7 +11,7 @@ func setup(max: int, current: int):
 func _ready():
 	pass
 
-func _process(delta):
+func _process(_delta):
 	pass
 	
 func updateHealth(updateAmount: int):

--- a/scripts/map/path_bake_auto.gd
+++ b/scripts/map/path_bake_auto.gd
@@ -116,7 +116,7 @@ func draw_path_line(points: Array[Vector2i]) -> void:
 
 	path2d.add_child(line)
 
-func get_available_tiles(path_tiles: Array[Vector2i], excluded_layers: Array[int] = []) -> Array[Vector2i]:
+func get_available_tiles(path_tiles: Array[Vector2i], _excluded_layers: Array[int] = []) -> Array[Vector2i]:
 	var available_tiles: Array[Vector2i] = []
 
 	var target_layer := 1

--- a/scripts/map/path_bake_auto.gd
+++ b/scripts/map/path_bake_auto.gd
@@ -86,7 +86,6 @@ func find_path_from_marked_points(points: Array[Vector2i]) -> Array[Vector2i]:
 	return path
 
 func get_direction(from: Vector2i, to: Vector2i):
-	var cell_size = GridHelper.CELL_SIZE;
 	return (to - from)
 
 func get_adjacent_offsets() -> Array[Vector2i]:
@@ -120,7 +119,7 @@ func get_available_tiles(path_tiles: Array[Vector2i], _excluded_layers: Array[in
 	var available_tiles: Array[Vector2i] = []
 
 	var target_layer := 1
-	var target_source := 3
+	var _target_source := 3
 	var used_cells := tilemap.get_used_cells(target_layer)
 
 	for pos in used_cells:

--- a/scripts/map/path_follow.gd
+++ b/scripts/map/path_follow.gd
@@ -1,6 +1,6 @@
 extends PathFollow2D
 
-func _process(delta):
+func _process(_delta):
 	if(progress_ratio == 1):
 		queue_free()
 

--- a/scripts/status_effect/status_effect.gd
+++ b/scripts/status_effect/status_effect.gd
@@ -21,7 +21,7 @@ func _init(duration: float = 5.0, level: int = 1, effectType: String = ""):
 	self.level = level
 	self.effectType = effectType
 
-func _process_effect(delta: float, target: Node) -> void:
+func _process_effect(_delta: float, _target: Node) -> void:
 	if not applied:
 		triggeredTime = scaledAge
 		applied = true
@@ -38,7 +38,7 @@ func checkExpired(delta: float) -> bool:
 func _on_apply(target: Node) -> void:
 	appliedTarget = target
 
-func _on_expire(target: Node) -> void:
+func _on_expire(_target: Node) -> void:
 	pass
 
 # Optional hook for effects that need the casting tower at apply time

--- a/scripts/ui/currency.gd
+++ b/scripts/ui/currency.gd
@@ -8,5 +8,5 @@ func updateEssenceOfMem(amount: int):
 	essenceOfMem.visible = amount >= 1
 	essenceOfMemText.text = str(amount);
 
-func updateGold(value: int):
+func updateGold(_value: int):
 	pass

--- a/scripts/utility/grid_helper.gd
+++ b/scripts/utility/grid_helper.gd
@@ -11,7 +11,7 @@ static func CellToWorld(cell_position: Vector2i) -> Vector2:
 	return Vector2(cell_position.x * CELL_SIZE + CELL_SIZE / 2, cell_position.y * CELL_SIZE + CELL_SIZE / 2)
 
 
-static func snapToGrid(screenSize, position):
+static func snapToGrid(_screenSize, position):
 	var gridX = floor(position.x / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2
 	var gridY = floor(position.y / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2
 	return Vector2(gridX, gridY)


### PR DESCRIPTION
**Summary:** Clear `UNUSED_PARAMETER` + `UNUSED_VARIABLE` GDScript analyzer warnings (debugger noise), continuing PR #66's `SHADOWED_*` cleanup. 13 unused params underscore-prefixed across 10 files + 2 unused locals fixed in `path_bake_auto.gd`. Pure cleanup, no behaviour change.

**How it works:** Unused params get an `_` prefix (Godot's documented suppression). This is caller-safe (params are positional) and safe on base virtual hooks and signal callbacks too, since GDScript matches overrides by method name (not param name) and dispatches signals positionally - the project already follows this (e.g. `updateTarget(_enemy, _cause, _reward)`). Unused locals: dead `cell_size` removed; `_target_source` prefixed.

**Implementation Notes:**
- `get_available_tiles` `_excluded_layers` + `_target_source` belong to a commented-out layer filter. Prefixing only mutes the warning; the underlying gap (caller `map.gd` passes `[6]` to exclude layer 6, but the arg is never read) is flagged for separate triage, not fixed here.
- Sibling warning classes `UNUSED_SIGNAL` and `UNUSED_PRIVATE_CLASS_VARIABLE` are out of scope and remain for a future slice.
