### PR TITLE
Wrap skill projectile damage in int() to clear NARROWING_CONVERSION

### DIFF
--- a/scripts/skill/skillActions/skill_create_circle_projectile.gd
+++ b/scripts/skill/skillActions/skill_create_circle_projectile.gd
@@ -14,5 +14,5 @@ func setupProjectile(projectile: Projectile, i: int, context: SkillContext):
 	var tower: Tower = context.user as Tower;
 	var multi = getDamageMultiplier(context)
 	projectile.scale = Vector2(projectile_size_w, projectile_size_h)
-	projectile.setup_circle(tower, Damage.new(tower, multi * tower.data.getDamage(null, null).damage, damageType), circle_radius, angular_speed, initial_angle + (angle_offset * i), lifetime, ProjectileCallback.new(Callable(self, "onHit"), Callable(), Callable()))
+	projectile.setup_circle(tower, Damage.new(tower, int(multi * tower.data.getDamage(null, null).damage), damageType), circle_radius, angular_speed, initial_angle + (angle_offset * i), lifetime, ProjectileCallback.new(Callable(self, "onHit"), Callable(), Callable()))
 	super.setupProjectile(projectile, i, context)

--- a/scripts/skill/skillActions/skill_create_directional_projectile.gd
+++ b/scripts/skill/skillActions/skill_create_directional_projectile.gd
@@ -19,7 +19,7 @@ extends SkillActionProjectile
 func setupProjectile(projectile: Projectile, i: int, context: SkillContext):
 	var tower: Tower = context.user as Tower
 	var multi: float = getDamageMultiplier(context)
-	var damage: Damage = Damage.new(tower, multi * tower.data.getDamage(null, null).damage, damageType)
+	var damage: Damage = Damage.new(tower, int(multi * tower.data.getDamage(null, null).damage), damageType)
 
 	# Direction = from tower toward primary target. Prefer the first target
 	# picked by find_multi_enemy (closest-to-path-end after sorting). Fall


### PR DESCRIPTION
**Problem:** GDScript analyzer warning `NARROWING_CONVERSION` (float converted to int, loses precision) at `skill_create_directional_projectile.gd:22`. The identical expression at `skill_create_circle_projectile.gd:17` truncates the same way but silently (its `multi` is untyped, so the analyzer cannot prove the narrowing).

**Impact:** No gameplay change. Damage is integer by design (`Damage.amount: int`); the float `multi * baseDamage` product was already truncated implicitly. This is purely dev-side debugger noise that buries real warnings.

**Fix:** Wrap the float damage product in explicit `int(...)` at both skill-projectile `Damage.new` sites, matching the existing idiom used elsewhere (`tower_data.gd:96`, `skill_action_attack.gd:89`). Zero behavior change (the implicit conversion already truncated toward zero); the cast just makes the intent explicit and clears the warning.
