### PR TITLE
Clear INCOMPATIBLE_TERNARY warning in shader-warm guard

### DIFF
--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -195,9 +195,10 @@ static func warmSkillEffectShaders(host: Node) -> void:
 		# Mark the resolved path warmed regardless of load result (a missing file
 		# must not retry every unlock); keep the Shader ref so its compiled
 		# pipeline survives scene changes and the skip stays valid next run.
-		_warmed_shaders[sp] = shader if shader != null else true
 		if shader == null:
+			_warmed_shaders[sp] = true
 			continue
+		_warmed_shaders[sp] = shader
 		var mat := ShaderMaterial.new()
 		mat.shader = shader
 		var rect := ColorRect.new()


### PR DESCRIPTION
**Problem:** Godot's GDScript analyzer flagged `INCOMPATIBLE_TERNARY` at `resource_manager.gd:198`. The shader-warm guard wrote `_warmed_shaders[sp]` with a ternary whose two branches had incompatible static types (a `Shader` resource on success vs bool `true` on a failed load).
**Impact:** Editor debugger noise only - a warning at every game start that buries real warnings. No runtime or player-facing effect; the guard reads only key presence, so the stored value type never mattered.
**Fix:** Replace the ternary in `warmSkillEffectShaders` with an explicit if/else, folding in the redundant `if shader == null: continue` that immediately followed it. Behavior is unchanged: a failed load still marks the path with a sentinel and skips, a successful load still stores the `Shader` ref so its compiled pipeline survives scene changes.
