### PR TITLE
Give towerClass/generation explicit enum defaults

### DIFF
--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -19,8 +19,8 @@ var _attackModifierBuff: Array[Callable] = []
 var buffs: TowerBuffContainer = TowerBuffContainer.new()
 
 @export var maxLevel: int = 3;
-@export var towerClass: TowerClass;
-@export var generation: TowerGeneration;
+@export var towerClass: TowerClass = TowerClass.Assassin;
+@export var generation: TowerGeneration = TowerGeneration.Myth;
 @export var attackType: Damage.DamageType = Damage.DamageType.PHYSIC;
 
 @export var stats: Array[TowerStat];


### PR DESCRIPTION
**Problem:** Godot's GDScript analyzer flagged `ENUM_VARIABLE_WITHOUT_DEFAULT` at `tower_data.gd:22-23`. The `towerClass`/`generation` fields are enum-typed with no explicit default; because `TowerClass`/`TowerGeneration` start at 100/200, Godot's implicit `0` default is not a named member.

**Impact:** Editor debugger noise only - two warnings at every game start. No runtime or player-facing effect: the loader is the only `TowerData` constructor and always overwrites both fields.

**Fix:** Default each field to its first real member (`TowerClass.Assassin` / `TowerGeneration.Myth`), matching the string default the loader already uses (`data.get("towerClass", "Assassin")`). A parse miss still returns `0` independently of the declared default, so the existing "unset / no trait" guards (`> 0` / `<= 0` in `TowerFactory` and `TowerTrait._update_synergy`) keep working unchanged.

Note: this flips the exported-field default from an unnamed `0` to Assassin/Myth. No `.tscn`/`.tres` stores a `TowerData` with these fields (they are built by the loader at runtime), so no scene/resource files change.
