### PR TITLE
Clear UNUSED_SIGNAL debugger noise (dead onAttack + typed emits)

### DIFF
--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -168,5 +168,3 @@ func evolve():
 	_isEvolved = true;
 	print("evolve success");
 	return true;
-
-signal onAttack(target);

--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -35,7 +35,7 @@ func _apply_setup(cards: Array, max_refresh: int, evoTokenForRefresh: int, title
 	self.maxRefresh = max_refresh;
 
 	if cards.is_empty():
-		emit_signal("tower_select_skipped")
+		tower_select_skipped.emit()
 		queue_free()
 		return
 
@@ -84,7 +84,7 @@ func refreshList(evoToken: int = 0):
 
 	var cards = _build_card_list(evoToken)
 	if cards.is_empty():
-		emit_signal("tower_select_skipped")
+		tower_select_skipped.emit()
 		queue_free()
 		return
 
@@ -161,7 +161,7 @@ func _apply_cards_to_buttons(cards: Array) -> void:
 
 func _on_select_tower_button(p_name):
 	print("signal: tower_select,"+str(p_name))
-	emit_signal("tower_select", p_name)
+	tower_select.emit(p_name)
 	# emit_signal("tower_select", "gawr_gura") #temp
 	queue_free()
 	#get_tree().quit()


### PR DESCRIPTION
**Problem:** Godot's debugger floods with `UNUSED_SIGNAL` warnings at startup (4 flagged), burying real analyzer warnings/errors. Part of the debugger-noise cleanup umbrella.

**Impact:** Dev-only noise (no player-facing change); real warnings get lost in the flood.

**Fix:** Handled case-by-case after tracing each signal across `.gd` + `.tscn`:
- `onAttack` (`tower_data.gd`): fully dead (no emit, no listener anywhere) - removed.
- `tower_select` / `tower_select_skipped` (`UI_tower_select.gd`): false positives - they ARE emitted, but via string `emit_signal("...")` which the analyzer does not count. Converted to typed `.emit()` (behavior-identical); listeners in `game_scene.gd` unchanged.
- `onReceiveMission` (`tower.gd`): intentionally left untouched. It is a dormant hook for the not-yet-built Mission system - wired through `TowerFactory` but never emitted yet. Its warning is expected until the Mission feature ships; deleting it would break the connect in `tower_factory.gd`.

Net: startup `UNUSED_SIGNAL` 4 -> 1 (the intentional `onReceiveMission`).
