### PR TITLE
chore: ignore exported build artifacts (*.pck, /build/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ mono_crash.*.json
 # Build results
 *.translation
 
+# Build / export artifacts (exported game builds must never be committed)
+*.pck
+/build/
+
 # Temporaries
 *.tmp
 *.log


### PR DESCRIPTION
**Summary:** Add `.gitignore` rules so exported game builds never re-enter git history.

**How it works:** `*.pck` ignores the root export pack (`index.pck`); `/build/` ignores the build output dir (`build/index.exe`, `build/index.console.exe`, `build/app.zip`).

**Implementation Notes:** These build artifacts were committed in the past (213 versions, the dominant share of `.git` history bloat). They are already gone from HEAD - this change only prevents recurrence. Scoped to `*.pck` + `/build/`: verified every historical `.exe`/`.zip` lives under `build/`, so broader `*.exe`/`*.zip` patterns were intentionally omitted to avoid shadowing legitimate future binaries (e.g. under `addons/`). No tracked file at HEAD matches the new patterns.
