### PR TITLE
Clear INTEGER_DIVISION debugger noise via float-cast

### DIFF
--- a/scripts/combat/evo_token_drop.gd
+++ b/scripts/combat/evo_token_drop.gd
@@ -97,7 +97,7 @@ static func _get_sparkle_texture() -> ImageTexture:
 		var size := 8
 		var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
 		img.fill(Color(0, 0, 0, 0))
-		var c := size / 2
+		var c := int(size / 2.0)
 		for i in range(size):
 			img.set_pixel(i, c, Color.WHITE)
 			img.set_pixel(c, i, Color.WHITE)

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -292,7 +292,7 @@ func _stopCountdown():
 
 func _format_time(sec: float) -> String:
 	var total: int = int(ceil(sec))
-	return "%d:%02d" % [total / 60, total % 60]
+	return "%d:%02d" % [int(total / 60.0), total % 60]
 
 func testSpawnBoss(index: int = -1):
 	if(bossList.size() == 0):

--- a/scripts/skill/metheor.gd
+++ b/scripts/skill/metheor.gd
@@ -3,7 +3,7 @@ class_name Metheor
 
 var spawn_position: Vector2
 var delay_explode: float
-var max_radius: float = GridHelper.CELL_SIZE / 2
+var max_radius: float = GridHelper.CELL_SIZE / 2.0
 var elapsed_time: float = 0.0
 var damage: Damage;
 

--- a/scripts/utility/grid_helper.gd
+++ b/scripts/utility/grid_helper.gd
@@ -4,14 +4,14 @@ const CELL_SIZE: int = 512
 
 static func WorldToCell(world_position: Vector2) -> Vector2i:
 	# Subtract half cell size before flooring to center-align
-	return Vector2i(floor((world_position.x - CELL_SIZE / 2) / CELL_SIZE), floor((world_position.y - CELL_SIZE / 2) / CELL_SIZE))
+	return Vector2i(floor((world_position.x - CELL_SIZE / 2.0) / CELL_SIZE), floor((world_position.y - CELL_SIZE / 2.0) / CELL_SIZE))
 
 static func CellToWorld(cell_position: Vector2i) -> Vector2:
 	# Add half cell size to center the position in the world
-	return Vector2(cell_position.x * CELL_SIZE + CELL_SIZE / 2, cell_position.y * CELL_SIZE + CELL_SIZE / 2)
+	return Vector2(cell_position.x * CELL_SIZE + CELL_SIZE / 2.0, cell_position.y * CELL_SIZE + CELL_SIZE / 2.0)
 
 
 static func snapToGrid(_screenSize, position):
-	var gridX = floor(position.x / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2
-	var gridY = floor(position.y / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2
+	var gridX = floor(position.x / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2.0
+	var gridY = floor(position.y / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2.0
 	return Vector2(gridX, gridY)

--- a/scripts/utility/yaml_parser.gd
+++ b/scripts/utility/yaml_parser.gd
@@ -42,7 +42,7 @@ static func load_data(file_path: String) -> Variant:
 			_fail(i, "Indentation is not consistent.")
 		var level := 0
 		if indent_unit > 0:
-			level = indent_spaces / indent_unit
+			level = int(indent_spaces / float(indent_unit))
 
 		# Unwind stack to correct parent
 		while stack.size() > 0 and level <= stack[-1]["indent"]:


### PR DESCRIPTION
**Problem:** The Godot analyzer raised `INTEGER_DIVISION` ("decimal part will be discarded") on divisions that are intentionally integer. Hot-path callers (grid world<->cell conversion, wave timer MM:SS format) fired these every frame, flooding the debugger and burying real warnings.
**Impact:** Debugger noise only - no player-facing behavior change.
**Fix:** Silence via float-cast - `x / 2.0` where the result flows into float, `int(x / float(y))` where an int result is needed - matching the project's existing `float()`-cast convention (no `@warning_ignore`, no project-setting toggle). Touches `grid_helper`, `wave_controller`, `yaml_parser`, `evo_token_drop`, and the analyzed-but-dead `metheor` scaffolding. Next umbrella slice: runtime print/printerr sweep.
