### PR TITLE
Clear STATIC_CALLED_ON_INSTANCE + sweep stray print/printerr

### DIFF
--- a/scripts/audio/audio_manager.gd
+++ b/scripts/audio/audio_manager.gd
@@ -47,13 +47,11 @@ func preloadAudio():
 			sfx[key] = soundCache[fullPath]
 			continue;
 		var sound = ResourceLoader.load(fullPath)
-		print("Loaded SFX: ", fullPath, " for key: ", key)
 		if sound:
-			print("Successfully loaded SFX: ", key)
 			sfx[key] = sound
 			soundCache[fullPath] = sound
 		else:
-			print("Failed to load SFX: " + fullPath)
+			push_warning("Failed to load SFX: " + fullPath)
 
 	var bgmList = SoundDatabase.bgm.keys()
 	for key in bgmList:
@@ -63,13 +61,11 @@ func preloadAudio():
 			bgm[key] = soundCache[fullPath]
 			continue;
 		var sound = ResourceLoader.load(fullPath)
-		print("Loaded BGM: ", fullPath, " for key: ", key)
 		if sound:
-			print("Successfully loaded BGM: ", key)
 			bgm[key] = sound
 			soundCache[fullPath] = sound
 		else:
-			print("Failed to load BGM: " + fullPath)
+			push_warning("Failed to load BGM: " + fullPath)
 
 	var voiceList = SoundDatabase.voice.keys()
 	for key in voiceList:

--- a/scripts/boss/boss_library.gd
+++ b/scripts/boss/boss_library.gd
@@ -42,7 +42,7 @@ func _load_boss(mapName: String, id: String) -> BossDBData:
 	var texturePath := SPRITE_PREFIX + mapName + "/boss/" + id + "/" + id + ".png"
 	var texture = load(texturePath)
 	if texture == null:
-		print("Error: Failed to load texture at path:", texturePath)
+		push_error("Failed to load texture at path: ", texturePath)
 
 	var bossSkills: Array[Skill] = []
 	var skillRaw = bd.get("skill", [])

--- a/scripts/combat/projectile_spawner.gd
+++ b/scripts/combat/projectile_spawner.gd
@@ -8,7 +8,7 @@ func _process(_delta):
 
 func attack(target: Node2D):
 	if(projectile == null):
-		printerr("cannot shoot, projectile is null")
+		push_error("cannot shoot, projectile is null")
 		return;
 	var projectileInstance = projectile.instantiate();
 	get_tree().root.add_child(projectileInstance)

--- a/scripts/entity/enemy_stats.gd
+++ b/scripts/entity/enemy_stats.gd
@@ -54,7 +54,6 @@ func calculatePathfollowSpeed(path: Path2D) -> float:
 func getDamageReduction() -> float:
 	if(blockCount > 0):
 		blockCount -= 1
-		print("block remain:", blockCount);
 		return 1
 
 	return clamp(damageReduction, 0.0, 0.9);

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -138,7 +138,7 @@ func setup(p_id: String, p_onPlace: Callable, p_onRemove: Callable):
 	var towerData = TowerCenter._towers_data.get(p_id.to_lower(), null);
 
 	if towerData == null:
-		printerr("tower data not found: " + p_id + ", exists: " + str(TowerCenter._towers_data.keys()));
+		push_error("tower data not found: " + p_id + ", exists: " + str(TowerCenter._towers_data.keys()));
 		return;
 
 	self.data = towerData.data;

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -153,12 +153,10 @@ func _addBuffByStat(statType: int, value: float, key) -> void:
 	buffs.add(BuffInstance.new(keyStr, statType, value, category))
 
 func levelUp():
-	print("level up, current level ", _level, " max level ", maxLevel);
 	if _level >= stats.size():
 		return false;
 
 	_level = mini(_level + 1, maxLevel);
-	print("level up to ", _level);
 	return true;
 
 func evolve():
@@ -166,5 +164,4 @@ func evolve():
 		return false;
 
 	_isEvolved = true;
-	print("evolve success");
 	return true;

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -4,7 +4,7 @@ static func load_data(prefix: String, name: String) -> TowerData:
 	var path = prefix + name + ".yaml";
 	var file := FileAccess.open(path, FileAccess.READ)
 	if file == null:
-		print("Failed to open YAML: " + path + " try loading default.")
+		push_warning("Failed to open YAML: " + path + " try loading default.")
 		path = prefix + "default_tower.yaml";
 		file = FileAccess.open(path, FileAccess.READ);
 		if file == null:

--- a/scripts/entity/tower/tower_factory.gd
+++ b/scripts/entity/tower/tower_factory.gd
@@ -118,7 +118,7 @@ func removeTowerFromDict(tower: Tower, key: int):
 func evolutionTower(p_name: String):
 	var towerData = TowerCenter.getTowerDataByName(p_name);
 	if towerData == null:
-		print("Error: Tower data not found for evolution:", p_name)
+		push_error("Tower data not found for evolution: ", p_name)
 		return;
 
 	var dataName = towerData.data_name;

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -104,7 +104,6 @@ func startNextWave():
 	updateUI();
 
 func endWave():
-	print("End Wave ", currWave);
 	if endWaveCalled:
 		return;
 
@@ -113,7 +112,6 @@ func endWave():
 	deadList.clear();
 
 	if(currWave >= data.waveDatas.size()):
-		print("All waves completed!");
 		var ui = UIEndDemo.create();
 		if(ui):
 			get_tree().current_scene.add_child(ui);
@@ -121,7 +119,6 @@ func endWave():
 		data.onWaveEnd.call();
 
 func setupSpawnTask():
-	print("wave data: ", waveData, " wave index:", currWave);
 	# Initialize remaining counts early so end-wave checks don't trigger before all groups have been registered.
 	for group in range(0, waveData.groupList.size()):
 		var groupData = waveData.groupList[group]
@@ -231,14 +228,11 @@ func _tierToEnemyType(tier: String) -> Enemy.EnemyType:
 
 func spawnBoss():
 	var result = bossList.filter(func(b):
-		print("[test] checking boss wave: ", b.name, " wave: ", b.wave, " against current wave: ", currWave)
 		return b.wave.has(currWave);
 	)
 
 	if result.is_empty():
-		for b in bossList:
-			print("[test] Boss wave: ", b.name, " wave: ", b.wave, " current wave:", currWave, " has:", b.wave.has(currWave))
-		printerr("Error: No boss found for current wave ", currWave)
+		push_error("No boss found for current wave ", currWave)
 		return
 
 	var bossData: BossDBData;
@@ -296,14 +290,12 @@ func _format_time(sec: float) -> String:
 
 func testSpawnBoss(index: int = -1):
 	if(bossList.size() == 0):
-		print("No boss available to spawn.");
 		return;
 
 	if(index < 0):
 		index = randi_range(0, bossList.size() - 1);
 
 	if(index >= bossList.size()):
-		print("No boss at index ", index, " (bossList size: ", bossList.size(), ")");
 		return;
 
 	var boss = bossList[index]; # For testing, spawn the first boss in the list.
@@ -347,14 +339,11 @@ func _allGroupsSpawned() -> bool:
 	return true
 
 func checkEndWave():
-	print("check end wave called alive: " + str(enemyAliveCount) + " is spawn all: " + str(isSpawnAllEnemy));
-
 	if isBossWave:
 		if isSpawnAllEnemy && enemyAliveCount <= 0:
 			endWave()
 	else:
 		if isSpawnAllEnemy && enemyAliveCount <= 0 && _allGroupsSpawned():
-			print("end wave: " + str(isSpawnAllEnemy) + " alive: " + str(enemyAliveCount))
 			groupSpawnRemain.clear()
 			endWave()
 

--- a/scripts/map/map.gd
+++ b/scripts/map/map.gd
@@ -45,6 +45,5 @@ func addAvailableCell(cell: Vector2i):
 func setup():
 	var path_data = path_bake.bake();
 	availableCells = path_bake.get_available_tiles(path_data, [6]);
-	print("grid size:", availableCells.size());
 	# Default to visible on setup, or call toggle_grid(false) if you want it off by default
 	toggle_grid(false)

--- a/scripts/map/path_bake_auto.gd
+++ b/scripts/map/path_bake_auto.gd
@@ -9,12 +9,12 @@ class_name PathBakeAuto
 func bake():
 	var marked_points: Array[Vector2i] = get_marked_points(layer)
 	if marked_points.is_empty():
-		print("No marked tiles found!")
+		push_warning("No marked tiles found!")
 		return
 
 	var path: Array[Vector2i] = find_path_from_marked_points(marked_points)
 	if path.is_empty():
-		print("No valid path found.")
+		push_warning("No valid path found.")
 		return
 
 	# Clear existing path
@@ -25,7 +25,6 @@ func bake():
 		path2d.curve.add_point(point)
 
 	draw_path_line(path);
-	print("Path set with %d points." % path.size())
 	return path
 
 func get_marked_points(p_layer: int) -> Array[Vector2i]:

--- a/scripts/resource_manager/game_resources.gd
+++ b/scripts/resource_manager/game_resources.gd
@@ -12,7 +12,6 @@ func loadResource(prefix: String, resourceList: Array):
 			resource.to_lower()
 		]
 		
-		print("full path:", full_path)
 		if(ResourceLoader.exists(full_path)):
 			var key = resource.to_lower();
 			if(collection.has(key)):
@@ -24,8 +23,5 @@ func loadResource(prefix: String, resourceList: Array):
 		else:
 			push_warning("Missing resource: " + full_path)
 
-	print("Loaded resources. prefix: ", prefix, " count: ", collection.size(), " keys: ", collection.keys());
-
 func getResource(key: String):
-	print("get resource:", key);
 	return collection.get(key, null);

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -34,7 +34,6 @@ static func getTower(key: String):
 static func loadImage(group, key, path):
 	var fullPath = "%s%s" % [resourcePrefix, path]
 	var texture: Texture2D = load(fullPath)
-	print("Loaded image: ", fullPath, ", group: ", group, ", key: ", key, ", res:", texture);
 	if(texture):
 		if(_sprites.has(group) == false):
 			_sprites[group] = {}
@@ -94,12 +93,10 @@ static func preloadEnemy(mapName: String) -> void:
 		if ResourceLoader.exists(full_path):
 			var texture: Texture2D = load(full_path)
 			loaded[id] = texture
-			print("Loaded: ", full_path)
 		else:
 			push_warning("Missing texture: " + full_path)
 
 	_sprites["enemy"] = loaded
-	print("loaded: ", loaded)
 
 
 static func getSpriteGroup(group: String):

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -86,7 +86,6 @@ func _ready():
 	setup_staff()
 	var camera = get_node("Camera2D")
 	camera.make_current()
-	print("Camera forced to current:", camera.is_current())
 	if(map != null):
 		map.setup();
 
@@ -278,7 +277,6 @@ func show_deck_popup():
 	if state == "game_over":
 		return
 	if _popup_open:
-		print("show_deck_popup: popup already open, ignoring duplicate call")
 		return
 
 	var popup: UITowerSelect = PopupPanelScene.instantiate() as UITowerSelect
@@ -322,7 +320,6 @@ func show_popup_panel():
 		return
 	# Prevent opening multiple popups if this function is called repeatedly
 	if _popup_open:
-		print("show_popup_panel: popup already open, ignoring duplicate call")
 		return
 
 	var popup: UITowerSelect = PopupPanelScene.instantiate() as UITowerSelect;
@@ -348,16 +345,15 @@ func _on_popup_closed():
 	_active_popup = null
 
 func _on_tower_select_skipped():
-	print("Tower select skipped — no valid towers available")
+	push_warning("Tower select skipped - no valid towers available")
 	startWave()
 
 # Handle the selection from the popup
 func _on_option_selected(selection):
 	# selection = "gawr_gura"
-	print("Selected:", selection)
 	var tower = TowerCenter.getTowerDataByName(selection);
 	if(tower == null):
-		print("Error: Tower data not found for selection:", selection)
+		push_error("Tower data not found for selection: ", selection)
 		return
 
 	TowerCenter.upgradeTowerLevelByName(selection);

--- a/scripts/skill/enemy_skill_controller.gd
+++ b/scripts/skill/enemy_skill_controller.gd
@@ -13,6 +13,5 @@ func process(delta: float):
 
 func onSuccess(skill: Skill):
 	super.onSuccess(skill);
-	print("Enemy used skill: ", skill.name);
 	if skill is EnemySkill:
 		(skill as EnemySkill).startCooldown();

--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -164,8 +164,7 @@ func debug_draw(canvas_item: CanvasItem, context: SkillContext, color: Color = C
 		return
 
 	var tower := context.user as Tower
-	var grid_helper_script = preload("res://scripts/utility/grid_helper.gd")
-	var user_position = grid_helper_script.WorldToCell(context.user.global_position)
+	var user_position = GridHelper.WorldToCell(context.user.global_position)
 	if tower.enemy == null:
 		return
 

--- a/scripts/skill/skillActions/skill_action_play_effect.gd
+++ b/scripts/skill/skillActions/skill_action_play_effect.gd
@@ -10,7 +10,7 @@ func execute(context: SkillContext) -> void:
 
 	var script = load(effectScriptPath)
 	if script == null:
-		printerr("SkillActionPlayEffect: script not found at ", effectScriptPath)
+		push_error("SkillActionPlayEffect: script not found at ", effectScriptPath)
 		return
 
 	var effect := Node2D.new()

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -18,13 +18,13 @@ static func ParseSkill(skillDataList: Array) -> Array[Skill]:
 			if action != null:
 				actions.append(action);
 			else:
-				print("Warning: Failed to parse action in skill", skillName);
+				push_warning("Failed to parse action in skill ", skillName);
 
 		var s = EnemySkill.new(skillName, desc, actions, {}, oneTime, cooldown);
 		if s != null:
 			result.append(s);
 		else:
-			print("Warning: Skill", s, "not found");
+			push_warning("Skill ", s, " not found");
 	return result
 
 static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillAction:
@@ -247,7 +247,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 				skill.statusEffects = dirStatusEffects;
 			skill.projectileTemplate = load(skillData.get("projectile", "res://resources/combat/bullets/gawr_gura_skill_projectile.tscn"));
 		_:
-			print("Warning: Unknown skill type:", skillType);
+			push_warning("Unknown skill type: ", skillType);
 			return null;
 
 	return skill;

--- a/scripts/status_effect/status_effect.gd
+++ b/scripts/status_effect/status_effect.gd
@@ -32,7 +32,6 @@ func checkExpired(delta: float) -> bool:
 		return false;
 	_on_expire(appliedTarget)
 	expired = true
-	print("effect expired: ", effectType, " time used: ", scaledAge - triggeredTime)
 	return expired
 
 func _on_apply(target: Node) -> void:

--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -114,7 +114,6 @@ func _build_card_list(evoToken: int) -> Array:
 		if (!available_towers.has(t) && !evoList.has(t)):
 			available_towers.append(t)
 
-	print("available towers: ", available_towers);
 	if remain > 0:
 		finalList.append_array(_dealer.get_random_cards(available_towers, remain, evoToken))
 
@@ -160,7 +159,6 @@ func _apply_cards_to_buttons(cards: Array) -> void:
 			buttons[index].visible = false
 
 func _on_select_tower_button(p_name):
-	print("signal: tower_select,"+str(p_name))
 	tower_select.emit(p_name)
 	# emit_signal("tower_select", "gawr_gura") #temp
 	queue_free()

--- a/scripts/ui_scenes/deck_selection.gd
+++ b/scripts/ui_scenes/deck_selection.gd
@@ -40,7 +40,6 @@ func _ready():
 
 func _load_deck():
 	_data = YamlParser.load_data("res://resources/database/towers/decks/decks.yaml")
-	print("Loaded JSON Data: ", _data.keys())
 
 	if !is_instance_valid(deckContainer):
 		push_error("DeckContainer node is not valid. Please check the scene hierarchy.");
@@ -59,9 +58,7 @@ func _load_deck():
 func _setup_gen_filter():
 	var genGroupBtn = genGroupContainer.get_children();
 
-	print("Setting up generation filters. Found buttons:", genGroupBtn.size())
 	for filter_button in genGroupBtn:
-		print("btn: ", filter_button.name, " is button: ", (filter_button is Button));
 		filter_button.pressed.connect(Callable(self, "_on_gen_filter_pressed").bind(filter_button.name))
 
 	if(genGroupBtn.size() > 0): # Set default filter to first button's group
@@ -141,7 +138,6 @@ func _on_deck_selected(deck_name: String, toggle: UIToggle):
 		selectingDeckToggle = toggle
 
 	_selected_deck = _data[deck_name]
-	print("Selected Deck:", _selected_deck)
 	setActiveStartBtn(true)
 
 func setActiveStartBtn(isActive: bool):
@@ -153,7 +149,6 @@ func setActiveStartBtn(isActive: bool):
 			startToggle.toggleActive(isActive);
 
 func _on_confirm():
-	print("Deck selected:", _selected_deck)
 	TowerCenter.selected_deck = _selected_deck["name"]
 	TowerCenter.selected_data_file = _selected_deck["data_file"]
 	# Staff selection: persisted via StaffCenter.selected_staff (already set by _refresh_staff_card on bullet/arrow).

--- a/scripts/ui_scenes/main_menu.gd
+++ b/scripts/ui_scenes/main_menu.gd
@@ -26,7 +26,7 @@ func _on_start_pressed():
 	#get_tree().change_scene_to_file("res://scenes/tower_select_tmp_scene.tscn")  # Change to your actual game scene
 	get_tree().change_scene_to_file("res://resources/ui_component/deck_selection.tscn")  # Change to your actual game scene
 func _on_options_pressed():
-	print("Options menu (To be implemented)")
+	pass # Options menu not implemented yet
 
 func _on_exit_pressed():
 	get_tree().quit()

--- a/scripts/utility/grid_helper.gd
+++ b/scripts/utility/grid_helper.gd
@@ -2,16 +2,16 @@ extends Node
 
 const CELL_SIZE: int = 512
 
-static func WorldToCell(world_position: Vector2) -> Vector2i:
+func WorldToCell(world_position: Vector2) -> Vector2i:
 	# Subtract half cell size before flooring to center-align
 	return Vector2i(floor((world_position.x - CELL_SIZE / 2.0) / CELL_SIZE), floor((world_position.y - CELL_SIZE / 2.0) / CELL_SIZE))
 
-static func CellToWorld(cell_position: Vector2i) -> Vector2:
+func CellToWorld(cell_position: Vector2i) -> Vector2:
 	# Add half cell size to center the position in the world
 	return Vector2(cell_position.x * CELL_SIZE + CELL_SIZE / 2.0, cell_position.y * CELL_SIZE + CELL_SIZE / 2.0)
 
 
-static func snapToGrid(_screenSize, position):
+func snapToGrid(_screenSize, position):
 	var gridX = floor(position.x / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2.0
 	var gridY = floor(position.y / CELL_SIZE) * CELL_SIZE + CELL_SIZE / 2.0
 	return Vector2(gridX, gridY)

--- a/scripts/wallet/wallet.gd
+++ b/scripts/wallet/wallet.gd
@@ -10,7 +10,6 @@ func _init(onGoldUpdate: Callable, onEvoTokenUpdate: Callable):
 func updateGold(value: int):
 	if value == 0:
 		return
-	print("update gold", value);
 	gold.update(value);
 
 func getGold() -> int:
@@ -19,7 +18,6 @@ func getGold() -> int:
 func updateEvoToken(amount: int):
 	if amount == 0:
 		return
-	print("update evo token", amount);
 	evoToken.update(amount);
 
 func getEvoToken() -> int:


### PR DESCRIPTION
**Summary:** Final debugger-noise slice - clear the last analyzer warning family (`STATIC_CALLED_ON_INSTANCE`) and sweep leftover runtime `print`/`printerr` across `scripts/`.

**How it works:** `grid_helper.gd` is the `GridHelper` autoload but declared its funcs `static`, so every `GridHelper.xxx()` call warned. Dropping `static` makes them instance methods on the singleton (consistent with the other 6 autoloads) - the 10 call sites need no change; one preload-and-call site was rewired to call `GridHelper` directly. Stray debug `print`/`printerr` are removed; real diagnostics are routed to `push_warning`/`push_error`. Go-forward rule: no raw `print`/`printerr` in committed code.

**Implementation Notes:** Kept `skill_action_shout.gd` (the `print` IS the SkillAction's behavior) and `map_generator.gd` (dead tool, pending removal). Existing `push_error`/`push_warning` guards are untouched. Two commits: static-call fix, then the print sweep.
