### PR TITLE
Skill-VFX template set: copy-ready controller/shader/preview harness

### DIFF
--- a/test/vfx_template/lane_effect_template.gd
+++ b/test/vfx_template/lane_effect_template.gd
@@ -1,0 +1,84 @@
+extends Node2D
+# ================================================================
+# LANE SKILL-VFX CONTROLLER TEMPLATE (copy me) - godot-2dfx skill
+#
+# COPY, do not edit in place:
+#   1. Copy this .gd + lane_effect_template.gdshader into
+#      test/<effect>_preview/ (iteration) or the tower's skill_effect/
+#      folder (production), rename both to the effect's name.
+#   2. Point SHADER_PATH at the copied shader, tune the consts, replace
+#      the shader's placeholder layers with the real effect.
+#   3. Production spawn path: SkillActionPlayEffect creates a bare
+#      Node2D at the caster, attaches this script, then calls
+#      setup(tower, context). YAML: action type "play_effect" ->
+#      data.effect_script = this file's res:// path.
+#
+# Anchor files (SKILL.md intake - read before designing):
+#   benchmark  resources/tower/hololive/en_branch/myth_gen/kiara/
+#              skill_effect/kiara_evo_skill_effect.gd + .gdshader
+#              (Hinotori - the project quality bar)
+#   this shape kiara_skill_effect.gd + .gdshader (Flame Slash)
+#
+# OTHER FAMILIES (docs/shader.md "Skill-VFX families"):
+#   centered/aura  - drop setup()'s aim/rotation and the lane include;
+#                    keep the rect + tweens. See amelia_skill_effect.gd.
+#   lingering tail - a second, longer clock ("life_t") owns queue_free.
+#                    See shinri_evo_skill_effect.gd.
+#   bullet         - visual rides the projectile via the tower YAML
+#                    `attack:` block, not a controller like this one.
+#                    See amelia/normal_effect/amelia_bullet.gdshader.
+# ================================================================
+
+const SHADER_PATH := "res://test/vfx_template/lane_effect_template.gdshader"
+
+const LANE_LEN_CELLS := 3.0   # gameplay lane length (tiles) - match the skill's range/AOE
+const VISUAL_W_CELLS := 1.6   # visual rect height (tiles) - may exceed the damage width
+const LANE_PAD       := 0.25  # frame padding in lane units - MUST match the shader's lane_pad
+const ROT_OFFSET     := 0.0   # shader motion runs along +X; flip (+-PI/2, PI) if it faces wrong
+const DURATION       := 0.9   # progress 0->1 seconds
+const POP_FRAC       := 0.22  # scale_p elastic pop length (fraction of DURATION)
+
+# Preview-only: the harness injects per-variant uniforms here before setup().
+# Production leaves it empty - bake the final look into the shader defaults.
+var uniform_overrides: Dictionary = {}
+
+# Called by SkillActionPlayEffect after the node is in the tree (or by the
+# preview harness with tower = null, which keeps the default RIGHT facing).
+func setup(tower, context = null) -> void:
+	var forward := Vector2.RIGHT
+	var aim := SkillVfx.resolve_aim(tower, context)  # live target -> aim snapshot -> ZERO
+	if aim.length() > 0.001:
+		forward = aim.normalized()
+		rotation = forward.angle() + ROT_OFFSET
+	# Centre the padded rect so lane-x 0 (the caster) sits on this node.
+	# Production may also add Utility.MUZZLE_OFFSET_TILES * cell so the bolt
+	# leaves the sprite edge, not its belly (see kiara_evo_skill_effect.gd).
+	var lane_px := LANE_LEN_CELLS * GridHelper.CELL_SIZE
+	global_position += forward * (lane_px * 0.5)
+	_spawn_effect(lane_px)
+
+func _spawn_effect(lane_px: float) -> void:
+	var size := Vector2(lane_px * (1.0 + 2.0 * LANE_PAD), VISUAL_W_CELLS * GridHelper.CELL_SIZE)
+	var rect := SkillVfx.make_lane_rect(self, size, SHADER_PATH)
+	var mat := rect.material as ShaderMaterial
+	mat.set_shader_parameter("progress", 0.0)
+	mat.set_shader_parameter("scale_p", 0.0)
+	mat.set_shader_parameter("aspect", size.x / size.y)
+	mat.set_shader_parameter("lane_pad", LANE_PAD)
+	for key in uniform_overrides:
+		mat.set_shader_parameter(key, uniform_overrides[key])
+
+	var pop := create_tween()
+	pop.set_ease(Tween.EASE_OUT)
+	pop.set_trans(Tween.TRANS_ELASTIC)
+	pop.tween_method(
+		func(v: float): mat.set_shader_parameter("scale_p", v),
+		0.0, 1.0, DURATION * POP_FRAC
+	)
+
+	var run := create_tween()
+	run.tween_method(
+		func(v: float): mat.set_shader_parameter("progress", v),
+		0.0, 1.0, DURATION
+	)
+	run.tween_callback(queue_free)

--- a/test/vfx_template/lane_effect_template.gdshader
+++ b/test/vfx_template/lane_effect_template.gdshader
@@ -1,0 +1,93 @@
+shader_type canvas_item;
+// blend_add suits bright/warm palettes. If the palette has DARK bands
+// (violet/crimson/deep magenta), switch to blend_premul_alpha - blend_add
+// only ADDS luminance, so dark bands vanish over the lit map (Kiara
+// Hinotori lesson, docs/shader.md Section 3). Verify over the real map.
+render_mode blend_add;
+
+#include "res://resources/tower/shared/lane_fx.gdshaderinc"
+
+// ================================================================
+// LANE SKILL-VFX SHADER TEMPLATE (copy me) - godot-2dfx skill
+// Placeholder look: a bolt rushing down the lane with a bounded trail,
+// white-hot core, and spark scatter. Replace the LAYER blocks with the
+// real effect; keep the frame/envelope structure.
+//
+// Rules baked in (docs/shader.md Section 2 + lane checklist):
+//   - progress / scale_p uniforms drive ALL motion - never TIME
+//   - lane_coord / lane_origin_gate / lane_frame_mask come from the
+//     shared include - never hand-roll frame/origin math, never step()
+//     at the origin or a step()-bounded content fill
+//   - multi-layer: each element adds into col, coverage a = max(...)
+//   - bounded tail: clean cut behind the head, no long faded drag
+// ================================================================
+
+// REQUIRED on every skill effect (docs/shader.md Section 2):
+uniform float progress : hint_range(0.0, 1.0) = 0.0;   // whole sequence (controller tween)
+uniform float scale_p  : hint_range(0.01, 1.2) = 1.0;  // elastic pop-in
+uniform float aspect   : hint_range(1.0, 6.0)  = 2.8;  // rect width/height (controller passes)
+uniform float lane_pad : hint_range(0.0, 1.0)  = 0.25; // MUST match controller LANE_PAD
+
+// Effect-specific tunables - rename/replace for your effect, keep them uniforms:
+uniform vec4  core_color : source_color = vec4(1.0, 0.97, 0.82, 1.0);
+uniform vec4  rim_color  : source_color = vec4(1.0, 0.70, 0.22, 1.0);
+uniform float bolt_len   : hint_range(0.1, 1.2)  = 0.45; // trail length behind the head (lane units)
+uniform float bolt_hw    : hint_range(0.05, 0.5) = 0.16; // bolt half-width (lane-y units)
+
+float easeOut3(float t) { return 1.0 - pow(1.0 - t, 3.0); }
+float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453); }
+
+void fragment() {
+	// aspect-true author frame for the vignette (pop scales the frame)
+	vec2 uv = (UV - 0.5) * vec2(aspect, 1.0) / max(scale_p, 0.01);
+	// gameplay-true lane coords: x 0 = caster -> 1 = range end, y centred at 0
+	vec2 lane = lane_coord(UV, lane_pad);
+	// pop the THICKNESS only - the footprint along the lane stays true
+	float ly = lane.y / max(scale_p, 0.01);
+
+	// head rushes caster -> range end (all motion from progress, never TIME)
+	float head = easeOut3(progress) * (1.0 + lane_pad * 0.5);
+	float dx = lane.x - head;
+
+	// bolt body: bounded trail behind the head, soft origin, no step()
+	float across  = abs(ly) / max(bolt_hw, 1e-3);
+	float width_m = 1.0 - smoothstep(0.55, 1.0, across);
+	float front   = 1.0 - smoothstep(0.0, 0.04, dx);
+	float tail    = smoothstep(head - bolt_len, head - bolt_len + 0.14, lane.x);
+	float body    = width_m * front * tail * lane_origin_gate(lane.x, 0.15);
+
+	vec3 col = vec3(0.0);
+	float a = 0.0;
+
+	// LAYER 1 - coloured body
+	col += rim_color.rgb * body * 1.1;
+	a = max(a, body * 0.85);
+
+	// LAYER 2 - white-hot core + head flash (energy focal point)
+	float core = (1.0 - smoothstep(0.0, 0.45, across)) * body;
+	float head_glow = 1.0 - smoothstep(0.0, 0.20, length(vec2(dx * 0.8, ly)));
+	head_glow *= lane_origin_gate(lane.x, 0.1);
+	col += core_color.rgb * (core * 1.5 + head_glow * 2.2);
+	a = max(a, max(core, head_glow));
+
+	// LAYER 3 - spark scatter peeling off behind the head
+	vec2 sg = vec2(lane.x * 9.0, ly * 7.0);
+	vec2 cellv = floor(sg);
+	vec2 lp = fract(sg) - 0.5;
+	float seed = hash(cellv);
+	float behind = smoothstep(head, head - bolt_len * 1.7, lane.x) * (1.0 - smoothstep(0.0, 0.02, dx));
+	float tw = sin(progress * 12.6 + seed * 6.28) * 0.5 + 0.5;
+	float spread = 1.0 - smoothstep(1.2, 2.4, across);
+	float spark = step(0.88, seed) * (1.0 - smoothstep(0.0, 0.30, length(lp))) * behind * tw * spread;
+	spark *= lane_origin_gate(lane.x, 0.15);
+	col += rim_color.rgb * spark * 1.6;
+	a = max(a, spark);
+
+	// envelope: fade-in, fade-out, corner-free frame - applied to the stack
+	float life = smoothstep(0.0, 0.06, progress) * (1.0 - smoothstep(0.72, 1.0, progress));
+	float mask = lane_frame_mask(uv, aspect, 0.14, 0.10) * life;
+	col *= mask;
+	a *= mask;
+
+	COLOR = vec4(col, a);
+}

--- a/test/vfx_template/vfx_preview_harness.gd
+++ b/test/vfx_template/vfx_preview_harness.gd
@@ -1,0 +1,98 @@
+extends Node2D
+# ================================================================
+# VFX PREVIEW HARNESS TEMPLATE (copy me) - godot-2dfx skill
+#
+# Purpose (Director 2026-07-02): watch a VFX at true gameplay scale and
+# compare up to 3 variants. Nothing else - keep it this light.
+#
+# Copy to test/<effect>_preview/, point EFFECT_SCRIPT at your controller
+# copy, fill _variants (max 3, each differing on >= 2 macro axes - see
+# skills/godot-2dfx/references/vfx-craft.md). F6 runs it: the effect
+# auto-replays; keys 1/2/3 switch variants. Scratch only - DELETE the
+# copied folder at handoff (this template folder itself stays).
+#
+# This dark background hides blend_add washout: verify additive or
+# dark-band effects over the real lit map before calling a look final
+# (docs/shader.md Section 3, Kiara Hinotori lesson).
+# ================================================================
+
+const EFFECT_SCRIPT := "res://test/vfx_template/lane_effect_template.gd"
+const LANE_CELLS := 3    # target cells drawn in front of the caster (match the controller)
+const REPLAY_GAP := 0.7  # seconds between auto-replays
+
+# Max 3 variants. name = short label, intent = one-line artistic intent
+# (never a parameter diff), params = shader uniform overrides.
+var _variants := {
+	1: {
+		"name": "Clean bolt",
+		"intent": "Graceful register: thin core, warm gold, reads calm.",
+		"params": {},
+	},
+	2: {
+		"name": "Wide sweep",
+		"intent": "Powerful register: broad body and longer trail, reads heavy.",
+		"params": {"bolt_hw": 0.30, "bolt_len": 0.75},
+	},
+	3: {
+		"name": "Cold flicker",
+		"intent": "Element swap: icy palette, tight body - identity check.",
+		"params": {
+			"core_color": Color(0.88, 0.97, 1.0),
+			"rim_color": Color(0.35, 0.62, 1.0),
+			"bolt_hw": 0.12,
+		},
+	},
+}
+
+var _current := 1
+var _label: Label
+var _timer: Timer
+
+func _ready() -> void:
+	_label = $HUD/Label
+	_timer = Timer.new()
+	_timer.one_shot = true
+	_timer.timeout.connect(_fire)
+	add_child(_timer)
+	_fire()
+
+func _unhandled_key_input(event: InputEvent) -> void:
+	var key := event as InputEventKey
+	if key == null or not key.pressed or key.echo:
+		return
+	var idx := int(key.keycode) - int(KEY_1) + 1
+	if _variants.has(idx):
+		_current = idx
+		_fire()
+
+func _fire() -> void:
+	_timer.stop()
+	var v: Dictionary = _variants[_current]
+	_label.text = "[%d/%d] %s - %s   (1/2/3 = switch variant)" % [
+		_current, _variants.size(), v["name"], v["intent"]
+	]
+	# Same spawn shape as SkillActionPlayEffect: bare Node2D + script + setup().
+	var effect := Node2D.new()
+	effect.set_script(load(EFFECT_SCRIPT))
+	effect.global_position = Vector2.ZERO  # caster cell centre
+	effect.set("uniform_overrides", v["params"])
+	add_child(effect)
+	if effect.has_method("setup"):
+		effect.setup(null)  # null caster -> effect faces RIGHT
+	effect.tree_exited.connect(_on_effect_done)
+
+func _on_effect_done() -> void:
+	if is_inside_tree() and is_instance_valid(_timer):
+		_timer.start(REPLAY_GAP)
+
+func _draw() -> void:
+	# caster cell + target lane cells at true grid scale - the footprint check
+	var cell := float(GridHelper.CELL_SIZE)
+	_draw_cell(Vector2.ZERO, cell, Color(0.35, 0.9, 0.5))
+	for i in LANE_CELLS:
+		_draw_cell(Vector2((i + 1) * cell, 0.0), cell, Color(0.95, 0.45, 0.35))
+
+func _draw_cell(centre: Vector2, cell: float, tint: Color) -> void:
+	var r := Rect2(centre - Vector2(cell, cell) * 0.5, Vector2(cell, cell))
+	draw_rect(r, Color(tint, 0.12), true)
+	draw_rect(r, tint, false, 6.0)

--- a/test/vfx_template/vfx_preview_harness.gd
+++ b/test/vfx_template/vfx_preview_harness.gd
@@ -20,6 +20,11 @@ const EFFECT_SCRIPT := "res://test/vfx_template/lane_effect_template.gd"
 const LANE_CELLS := 3    # target cells drawn in front of the caster (match the controller)
 const REPLAY_GAP := 0.7  # seconds between auto-replays
 
+# Static caster sprite for scale/overview context (Director 2026-07-02) -
+# first frame only, no animation. Swap the path for the tower being built.
+const CASTER_SPRITE := "res://resources/tower/hololive/en_branch/myth_gen/kiara/sprite/kiara_stand001.png"
+const CASTER_SHEET_GRID := 3  # kiara_stand001.png is a 3x3 sheet of 512px frames
+
 # Max 3 variants. name = short label, intent = one-line artistic intent
 # (never a parameter diff), params = shader uniform overrides.
 var _variants := {
@@ -50,6 +55,12 @@ var _timer: Timer
 
 func _ready() -> void:
 	_label = $HUD/Label
+	var caster := Sprite2D.new()
+	caster.texture = load(CASTER_SPRITE)
+	caster.hframes = CASTER_SHEET_GRID
+	caster.vframes = CASTER_SHEET_GRID
+	caster.frame = 0
+	add_child(caster)  # added before the effect -> effect draws on top
 	_timer = Timer.new()
 	_timer.one_shot = true
 	_timer.timeout.connect(_fire)

--- a/test/vfx_template/vfx_preview_harness.tscn
+++ b/test/vfx_template/vfx_preview_harness.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=2 format=3 uid="uid://pupqu6ucrmh2"]
 
 [ext_resource type="Script" path="res://test/vfx_template/vfx_preview_harness.gd" id="1_harness"]
 

--- a/test/vfx_template/vfx_preview_harness.tscn
+++ b/test/vfx_template/vfx_preview_harness.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://test/vfx_template/vfx_preview_harness.gd" id="1_harness"]
+
+[node name="VfxPreviewHarness" type="Node2D"]
+script = ExtResource("1_harness")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(900, 0)
+zoom = Vector2(0.55, 0.55)
+
+[node name="HUD" type="CanvasLayer" parent="."]
+
+[node name="Label" type="Label" parent="HUD"]
+offset_left = 24.0
+offset_top = 16.0
+offset_right = 1896.0
+offset_bottom = 64.0
+theme_override_font_sizes/font_size = 26
+text = "loading..."


### PR DESCRIPTION
**Summary:** Copy-ready skill-VFX template set under `test/vfx_template/` (4 files, new folder only - zero existing code touched). Future agents copy these instead of guessing VFX file formats from prose docs, which caused recurring frame/origin/lifecycle bugs.

**How it works:**
- `lane_effect_template.gd` - controller skeleton extracted from the shipped Kiara conventions: `setup()` aim hook via `SkillVfx.resolve_aim`, rect via `SkillVfx.make_lane_rect`, `progress`/`scale_p` tween pair, `queue_free` lifecycle. Header comments route the other families (centered -> amelia, lingering dual-clock -> shinri evo, bullet -> YAML `attack:`).
- `lane_effect_template.gdshader` - lane shader skeleton on `lane_fx.gdshaderinc` helpers (`lane_coord` / `lane_origin_gate` / `lane_frame_mask`), multi-layer `col`/`a=max` stack, bounded tail, `blend_add` vs `blend_premul_alpha` note.
- `vfx_preview_harness.gd/.tscn` - minimal F6 preview: true grid scale, footprint cells, static Kiara stand sprite at the caster for overview, auto-replay, keys 1/2/3 switch up to 3 variants.
- Lifecycle rule (Director-approved): any PR that changes what the templates reference (`SkillVfx`, `lane_fx.gdshaderinc`, conventions) updates the templates in the same PR - no standalone template PRs.

**Implementation Notes:**
- For Lead: `export_presets.cfg` has empty `exclude_filter`, so `test/` currently ships in exports. Recommend adding `res://test/*` to `exclude_filter` (both presets) - left untouched here as a config decision.
- Scene uid was assigned by the Godot editor on first save (committed), not hand-written.
- Director tested in-engine: harness F6 pass (effect, 3 variants, caster sprite) + F5 regression pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
