### PR TITLE
fix(map): remove dead excluded_layers filter from get_available_tiles

### DIFF
--- a/scripts/map/map.gd
+++ b/scripts/map/map.gd
@@ -44,6 +44,6 @@ func addAvailableCell(cell: Vector2i):
 
 func setup():
 	var path_data = path_bake.bake();
-	availableCells = path_bake.get_available_tiles(path_data, [6]);
+	availableCells = path_bake.get_available_tiles(path_data);
 	# Default to visible on setup, or call toggle_grid(false) if you want it off by default
 	toggle_grid(false)

--- a/scripts/map/path_bake_auto.gd
+++ b/scripts/map/path_bake_auto.gd
@@ -114,30 +114,14 @@ func draw_path_line(points: Array[Vector2i]) -> void:
 
 	path2d.add_child(line)
 
-func get_available_tiles(path_tiles: Array[Vector2i], _excluded_layers: Array[int] = []) -> Array[Vector2i]:
+func get_available_tiles(path_tiles: Array[Vector2i]) -> Array[Vector2i]:
 	var available_tiles: Array[Vector2i] = []
-
 	var target_layer := 1
-	var _target_source := 3
 	var used_cells := tilemap.get_used_cells(target_layer)
 
 	for pos in used_cells:
 		if path_tiles.has(pos):
 			continue
-
-		#var source_id := tilemap.get_cell_source_id(target_layer, pos)
-		#if source_id != target_source:
-			#continue
-#
-		#var is_used_elsewhere := false
-		#for check_layer in range(tilemap.get_layers_count()):
-			#if check_layer == target_layer or excluded_layers.has(check_layer):
-				#continue
-			#if tilemap.get_used_cells(check_layer).has(pos):
-				#is_used_elsewhere = true
-				#break
-
 		available_tiles.append(pos)
-		#if not is_used_elsewhere:
 
 	return available_tiles


### PR DESCRIPTION
**Problem:** `PathBakeAuto.get_available_tiles()` carried a fully commented-out obstacle filter plus a dead `_excluded_layers` param (called with `[6]`) and an unused `_target_source` local - half-ported leftovers from the Unity->Godot port. The commented block referenced undefined identifiers (would not even compile if re-enabled) and, logically, would test every buildable cell against base layer 0 (full-field grass) and leave zero placeable cells.
**Impact:** None today - the filter never ran, so buildability is already art-driven. This removes latent dead code that would break tower placement if anyone naively re-enabled it.
**Fix:** Delete the commented filter, the `_excluded_layers` param, and the `_target_source` local in `path_bake_auto.gd`; drop the no-op `[6]` argument at the single caller in `map.gd`. Buildability stays exactly as before: layer-1 cells minus path. The future dynamic destructible-obstacle direction (Director intent) is recorded in the game_stage system doc.
