### PR TITLE
Sort synergy panel rows by tier then count, active-first

### DIFF
--- a/scripts/ui/synergy/ui_synergy.gd
+++ b/scripts/ui/synergy/ui_synergy.gd
@@ -1,10 +1,12 @@
 extends Control
 class_name UISynergy
 
+const ROW_HEIGHT := 100
+
 @export var contentTemplate: PackedScene;
 
 var contentList: Dictionary = {};   # synergy name -> UISynergyContent
-var currentYPos := 0;
+var _nextOrder := 0;                 # creation order, frozen per row (stable-sort tie-break)
 
 # Create or update a synergy row from the single TowerTrait.synergy_updated signal:
 # count + tier drive the row (count, proc breakpoints, tier colour); synergy_id
@@ -16,6 +18,24 @@ func updateSynergy(synergyName: String, count: int, tier: int, synergy_id: int) 
 		content = contentTemplate.instantiate() as UISynergyContent
 		contentList[synergyName] = content
 		add_child(content)
-		content.position.y = currentYPos
-		currentYPos += 100
+		content.setOrder(_nextOrder)   # frozen once at creation; never rewritten
+		_nextOrder += 1
 	content.setup(synergyName, count, tier, ResourceManager.getSynergyData(synergy_id))
+	_reflow()
+
+# Re-order rows on every update: tier desc, then count desc, then creation order.
+# Active rows (tier >= 0) float above inactive (tier -1) because -1 sorts lowest.
+# sort_custom is NOT stable, so creation order is the final key to keep rows with
+# equal tier+count from swapping (and flickering) each reflow.
+func _reflow() -> void:
+	var rows: Array = contentList.values()
+	rows.sort_custom(_compare_rows)
+	for i in rows.size():
+		rows[i].position.y = i * ROW_HEIGHT
+
+func _compare_rows(a: UISynergyContent, b: UISynergyContent) -> bool:
+	if a.getTier() != b.getTier():
+		return a.getTier() > b.getTier()
+	if a.getCount() != b.getCount():
+		return a.getCount() > b.getCount()
+	return a.getOrder() < b.getOrder()

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -16,6 +16,8 @@ const ACTIVE_HIGHLIGHT := "#FFD15A"                       # active tier row in t
 var _name: String = ""
 var _data: SynergyData = null
 var _tier: int = -1
+var _count: int = 0                   # live unit count (sort key; drops when units removed)
+var _order: int = -1                  # creation order, frozen by UISynergy (stable-sort tie-break)
 var _stylebox: StyleBoxFlat = null   # this row's own panel StyleBox (see setup)
 
 # tier: current active tier (-1 = not yet proc'd). data: SynergyData or null.
@@ -23,6 +25,7 @@ func setup(p_name: String, current: int, tier: int, data) -> void:
 	_name = p_name
 	_data = data
 	_tier = tier
+	_count = current
 
 	if bg != null:
 		# The scene's panel StyleBox is one shared sub-resource across every row
@@ -47,6 +50,13 @@ func setup(p_name: String, current: int, tier: int, data) -> void:
 	# non-empty so the tooltip triggers (delay lowered globally in project.godot).
 	mouse_filter = Control.MOUSE_FILTER_STOP
 	tooltip_text = name
+
+# Sort keys read by UISynergy._reflow - kept on the row so its sort state has a
+# single source of truth (mirrors how _tier is already threaded via setup).
+func getTier() -> int: return _tier
+func getCount() -> int: return _count
+func getOrder() -> int: return _order
+func setOrder(value: int) -> void: _order = value
 
 func _tier_color(tier: int) -> String:
 	if tier < 0:


### PR DESCRIPTION
**Problem:** The synergy panel placed each row by insertion order via absolute `position.y` and never re-sorted on update, so active synergies did not float above inactive ones and rows ignored tier order.
**Impact:** The player could not read the synergy panel at a glance - the strongest / active traits were not at the top, breaking the TFT / Auto-Chess reading convention.
**Fix:** Re-sort rows on every `updateSynergy` - tier descending, then unit-count descending (active rows sort above inactive since tier -1 is lowest), with a frozen per-row creation index as the stable-sort tie-break (`Array.sort_custom` is not stable). Sort keys live on the row node as the single source of truth; `position.y` stays the layout mechanism (the root `Container` does not reflow children). Files: `ui_synergy.gd`, `ui_synergy_content.gd`.
