### PR TITLE
Pre-wave start delay telegraph before enemy spawns

### DIFF
--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -6,6 +6,12 @@ var data: WaveControllerData = null;
 @onready var nextWaveTimer: Timer = $NextWaveDelayTimer
 
 @export var map: Map = null;
+
+# Breathing beat between the player starting a wave (managing-phase popup closed)
+# and the first enemy spawning - a short "wave incoming" telegraph. Applies to every
+# wave incl. the first and boss waves. Symmetric to game_scene.wave_end_popup_delay.
+# Inspector-editable feel knob; scales with game-speed time_scale like spawns.
+@export var pre_wave_start_delay: float = 1.0
 var spawnParent: Node2D = null;
 
 var enemyTextures: Dictionary = {};
@@ -71,7 +77,7 @@ func setBossList(list: Array[BossDBData]):
 	bossList = list;
 
 func start():
-	nextWaveTimer.wait_time = 0.001
+	nextWaveTimer.wait_time = max(pre_wave_start_delay, 0.001)
 	nextWaveTimer.start()
 
 	onWaveStart.emit();

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -11,7 +11,7 @@ var data: WaveControllerData = null;
 # and the first enemy spawning - a short "wave incoming" telegraph. Applies to every
 # wave incl. the first and boss waves. Symmetric to game_scene.wave_end_popup_delay.
 # Inspector-editable feel knob; scales with game-speed time_scale like spawns.
-@export var pre_wave_start_delay: float = 1.0
+@export var pre_wave_start_delay: float = 0.8
 var spawnParent: Node2D = null;
 
 var enemyTextures: Dictionary = {};


### PR DESCRIPTION
**Summary:** Adds a short "wave incoming" telegraph (~0.8s) before enemies spawn each wave, so the field does not instantly fill the moment the player closes the managing-phase popup. Symmetric to the existing wave-end popup pacing beat.

**How it works:** Re-enables the already-wired `NextWaveDelayTimer` on `WaveController`. `start()` previously overwrote its `wait_time` to a near-zero `0.001`; it now sets `max(pre_wave_start_delay, 0.001)`. The timer already sits on the once-per-wave path (`start()` -> timer timeout -> `startNextWave()`), so the delay applies uniformly to every wave including the first and boss waves, with no new await or generation guard. `pre_wave_start_delay` is an inspector-editable `@export` (default 0.8s) and scales with game-speed `time_scale` like spawns.

**Implementation Notes:**
- Default started at 1.0s; lowered to 0.8s after in-engine feel test (1.0s read as the game hanging).
- Knob lives on `WaveController` (where the timer is), not `game_scene` where `wave_end_popup_delay` lives (where its callback is) - each documented in place.
- `onWaveStart` still fires at the start of the telegraph (before spawns). It is a no-op stub today (`tower_factory.onWaveStart`); any future per-wave subscriber must account for this ~`pre_wave_start_delay` lead.
- No `.tscn`, data-class, YAML, or parser changes.
