### PR TITLE
fix(tower): rename intialMana typo to initialMana

### DIFF
--- a/resources/database/towers/axel_syrios.yaml
+++ b/resources/database/towers/axel_syrios.yaml
@@ -14,7 +14,7 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 30
-    intialMana: 0
+    initialMana: 0
     critChance: 0
     critMultiplier: 1.5
 
@@ -22,7 +22,7 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 30
-    intialMana: 0
+    initialMana: 0
     critChance: 0
     critMultiplier: 1.5
 
@@ -30,7 +30,7 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 30
-    intialMana: 0
+    initialMana: 0
     critChance: 0
     critMultiplier: 1.5
 
@@ -58,7 +58,7 @@ evolutionStat:
   attackRange: 1.0
   attackSpeed: 80
   mana: 30
-  intialMana: 0
+  initialMana: 0
   critChance: 50.0
   critMultiplier: 1.5
 
@@ -71,4 +71,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   intialMana: 20
+#   initialMana: 20

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -14,7 +14,7 @@ stats:
     attackRange: 2.0
     attackSpeed: 120.0
     mana: 80
-    intialMana: 20
+    initialMana: 20
     critChance: 0
     critMultiplier: 1.5
 
@@ -22,7 +22,7 @@ stats:
     attackRange: 2.0
     attackSpeed: 120.0
     mana: 80
-    intialMana: 20
+    initialMana: 20
     critChance: 0
     critMultiplier: 1.5
 
@@ -30,7 +30,7 @@ stats:
     attackRange: 2.0
     attackSpeed: 120.0
     mana: 80
-    intialMana: 20
+    initialMana: 20
     critChance: 0
     critMultiplier: 1.5
 
@@ -58,7 +58,7 @@ evolutionStat:
   attackRange: 2.0
   attackSpeed: 120
   mana: 80
-  intialMana: 20
+  initialMana: 20
   critChance: 50.0
   critMultiplier: 1.5
 
@@ -71,4 +71,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   intialMana: 20
+#   initialMana: 20

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -16,7 +16,7 @@ stats:
     critChance: 15.0
     critMultiplier: 1.5
     mana: 120 # ค่า mana สูงสุด
-    intialMana: 60 # ค่า mana เริ่มต้น
+    initialMana: 60 # ค่า mana เริ่มต้น
 
   - damage: 120
     attackRange: 2.0
@@ -24,7 +24,7 @@ stats:
     critChance: 15.0
     critMultiplier: 1.5
     mana: 120
-    intialMana: 60
+    initialMana: 60
 
   - damage: 180
     attackRange: 2.0
@@ -32,7 +32,7 @@ stats:
     critChance: 15.0
     critMultiplier: 1.5
     mana: 120
-    intialMana: 60
+    initialMana: 60
 
 # ── Skill slots (ทรงใหม่) ────────────────────────────────────────────
 # skills.active = Active Skill (auto-cast ตอน Energy เต็ม)
@@ -166,7 +166,7 @@ evolutionStat:
   critChance: 50.0
   critMultiplier: 1.5
   mana: 120
-  intialMana: 80
+  initialMana: 80
 
 # evolution_skills = สกิลร่างวิวัฒน์ (ทรงเดียวกับ skills) — optional
 evolution_skills:

--- a/resources/database/towers/gavis_bettel.yaml
+++ b/resources/database/towers/gavis_bettel.yaml
@@ -14,7 +14,7 @@ stats:
     attackRange: 3.0
     attackSpeed: 95
     mana: 140
-    intialMana: 100
+    initialMana: 100
     critChance: 0
     critMultiplier: 1.5
 
@@ -22,7 +22,7 @@ stats:
     attackRange: 3.0
     attackSpeed: 95
     mana: 140
-    intialMana: 100
+    initialMana: 100
     critChance: 0
     critMultiplier: 1.5
 
@@ -30,7 +30,7 @@ stats:
     attackRange: 3.0
     attackSpeed: 95
     mana: 140
-    intialMana: 100
+    initialMana: 100
     critChance: 0
     critMultiplier: 1.5
 
@@ -58,7 +58,7 @@ evolutionStat:
   attackRange: 3.0
   attackSpeed: 95
   mana: 140
-  intialMana: 100
+  initialMana: 100
   critChance: 50.0
   critMultiplier: 1.5
 
@@ -71,4 +71,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   intialMana: 20
+#   initialMana: 20

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -14,7 +14,7 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 120
-    intialMana: 60
+    initialMana: 60
     critChance: 0
     critMultiplier: 1.5
 
@@ -22,7 +22,7 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 120
-    intialMana: 60
+    initialMana: 60
     critChance: 0
     critMultiplier: 1.5
 
@@ -30,7 +30,7 @@ stats:
     attackRange: 1.0
     attackSpeed: 80
     mana: 120
-    intialMana: 60
+    initialMana: 60
     critChance: 0
     critMultiplier: 1.5
 
@@ -98,7 +98,7 @@ evolutionStat:
   attackRange: 1.0
   attackSpeed: 100
   mana: 120
-  intialMana: 80
+  initialMana: 80
   critChance: 50.0
   critMultiplier: 1.5
 

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -25,7 +25,7 @@ attack:
   mid_color: [0.90, 0.94, 1.0]
 
 # Josuiji Shinri has no Active skill and no Energy — her kit is a pure Passive.
-# Stats omit mana/intialMana on purpose: with no active skill the tower builds
+# Stats omit mana/initialMana on purpose: with no active skill the tower builds
 # no Energy bar (see Tower._hasActiveSkill / _setupPassive).
 stats:
   - damage: 80

--- a/resources/database/towers/machina_x_flayon.yaml
+++ b/resources/database/towers/machina_x_flayon.yaml
@@ -14,7 +14,7 @@ stats:
     attackRange: 2.0
     attackSpeed: 100
     mana: 100
-    intialMana: 60
+    initialMana: 60
     critChance: 0
     critMultiplier: 1.5
 
@@ -22,7 +22,7 @@ stats:
     attackRange: 2.0
     attackSpeed: 100
     mana: 100
-    intialMana: 60
+    initialMana: 60
     critChance: 0
     critMultiplier: 1.5
 
@@ -30,7 +30,7 @@ stats:
     attackRange: 2.0
     attackSpeed: 100
     mana: 100
-    intialMana: 60
+    initialMana: 60
     critChance: 0
     critMultiplier: 1.5
 
@@ -58,7 +58,7 @@ evolutionStat:
   attackRange: 4.0
   attackSpeed: 20
   mana: 100
-  intialMana: 80
+  initialMana: 80
   critChance: 50.0
   critMultiplier: 1.5
 
@@ -71,4 +71,4 @@ evolutionStat:
 #   critChance: 25.0
 #   critMultiplier: 2.0
 #   mana: 80
-#   intialMana: 20
+#   initialMana: 20

--- a/resources/database/towers/mori_calliope.yaml
+++ b/resources/database/towers/mori_calliope.yaml
@@ -14,7 +14,7 @@ stats:
     attackRange: 2.0
     attackSpeed: 100
     mana: 40
-    intialMana: 10
+    initialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -22,7 +22,7 @@ stats:
     attackRange: 2.0
     attackSpeed: 100
     mana: 40
-    intialMana: 10
+    initialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -30,7 +30,7 @@ stats:
     attackRange: 2.0
     attackSpeed: 100
     mana: 40
-    intialMana: 10
+    initialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -58,6 +58,6 @@ evolutionStat:
   attackRange: 2.0
   attackSpeed: 120
   mana: 80
-  intialMana: 40
+  initialMana: 40
   critChance: 50.0
   critMultiplier: 1.5

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -14,7 +14,7 @@ stats:
     attackRange: 4.0
     attackSpeed: 60
     mana: 100
-    intialMana: 60
+    initialMana: 60
     critChance: 0
     critMultiplier: 1.5
 
@@ -22,7 +22,7 @@ stats:
     attackRange: 4.0
     attackSpeed: 60
     mana: 100
-    intialMana: 60
+    initialMana: 60
     critChance: 0
     critMultiplier: 1.5
 
@@ -30,7 +30,7 @@ stats:
     attackRange: 4.0
     attackSpeed: 60
     mana: 100
-    intialMana: 60
+    initialMana: 60
     critChance: 0
     critMultiplier: 1.5
 
@@ -55,6 +55,6 @@ evolutionStat:
   attackRange: 4.0
   attackSpeed: 80
   mana: 100
-  intialMana: 60
+  initialMana: 60
   critChance: 50.0
   critMultiplier: 1.5

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -15,7 +15,7 @@ stats:
     critChance: 0
     critMultiplier: 1.5
     mana: 120
-    intialMana: 40
+    initialMana: 40
 
   - damage: 140
     attackRange: 1.0
@@ -23,7 +23,7 @@ stats:
     critChance: 0
     critMultiplier: 1.5
     mana: 120
-    intialMana: 40
+    initialMana: 40
 
   - damage: 200
     attackRange: 1.0
@@ -31,7 +31,7 @@ stats:
     critChance: 0
     critMultiplier: 1.5
     mana: 120
-    intialMana: 40
+    initialMana: 40
 
 # Active Skill — "Gun and Blade" combo (2 beats, both physic).
 # Reference example for: combo beat model + armor-shred debuff + guaranteed crit.
@@ -123,7 +123,7 @@ evolutionStat:
   critChance: 50.0
   critMultiplier: 1.5
   mana: 120
-  intialMana: 40
+  initialMana: 40
 
 # Evolved Active Skill — "Heroic Requiem" (same combo, stronger + longer gun line).
 evolution_skills:

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -13,7 +13,7 @@ stats:
     attackRange: 1.0
     attackSpeed: 90.0
     mana: 50
-    intialMana: 10
+    initialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -21,7 +21,7 @@ stats:
     attackRange: 1.0
     attackSpeed: 90.0
     mana: 50
-    intialMana: 10
+    initialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -29,7 +29,7 @@ stats:
     attackRange: 1.0
     attackSpeed: 90.0
     mana: 50
-    intialMana: 10
+    initialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
@@ -108,7 +108,7 @@ evolutionStat:
   attackRange: 1.0
   attackSpeed: 110
   mana: 80
-  intialMana: 40
+  initialMana: 40
   critChance: 50.0
   critMultiplier: 1.5
 

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -24,7 +24,7 @@ stats:
     attackRange: 5.0
     attackSpeed: 120
     mana: 100
-    intialMana: 80
+    initialMana: 80
     critChance: 0
     critMultiplier: 1.5
 
@@ -32,7 +32,7 @@ stats:
     attackRange: 5.0
     attackSpeed: 120
     mana: 100
-    intialMana: 80
+    initialMana: 80
     critChance: 0
     critMultiplier: 1.5
 
@@ -40,7 +40,7 @@ stats:
     attackRange: 5.0
     attackSpeed: 120
     mana: 100
-    intialMana: 80
+    initialMana: 80
     critChance: 0
     critMultiplier: 1.5
 
@@ -96,7 +96,7 @@ evolutionStat:
   attackRange: 5.0
   attackSpeed: 140
   mana: 120
-  intialMana: 80
+  initialMana: 80
   critChance: 50.0
   critMultiplier: 1.5
 

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -56,7 +56,7 @@ func _ready():
 	var stat = data.getStat();
 
 	var maxMana = stat.mana;
-	var initMana = stat.intialMana;
+	var initMana = stat.initialMana;
 
 	if _hasActiveSkill():
 		if(manaBar != null):
@@ -193,7 +193,7 @@ func evolve():
 				skillController.cancel()
 			usingSkill = false
 			var stat = data.getStat()
-			skillController = SkillController.new(self, stat.mana, stat.intialMana, data.evolutionSkill)
+			skillController = SkillController.new(self, stat.mana, stat.initialMana, data.evolutionSkill)
 			Utility.ConnectSignal(skillController, "on_mana_updated", Callable(self, "update_mana_bar"))
 			Utility.ConnectSignal(skillController, "cast_succeeded", Callable(self, "_on_cast_succeeded"))
 			# Refresh manaBar visual to match the new evolved stat:
@@ -203,7 +203,7 @@ func evolve():
 			#   immediately; no on_mana_updated signal fires from the constructor.
 			if manaBar != null:
 				manaBar.setup(stat.mana, false)
-				manaBar.updateValue(stat.intialMana)
+				manaBar.updateValue(stat.initialMana)
 
 		_setupPassive()
 	return success
@@ -371,7 +371,7 @@ func resetForWave():
 
 	if skillController != null:
 		skillController.cancel()
-		var initMana: float = data.getStat().intialMana
+		var initMana: float = data.getStat().initialMana
 		skillController.currentMana = initMana
 		skillController.on_mana_updated.emit(initMana)
 

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -45,7 +45,7 @@ static func load_data(prefix: String, name: String) -> TowerData:
 		stat.critChance = stat_dict.get("critChance", 0.0)
 		stat.critMultiplier = stat_dict.get("critMultiplier", 1.0)
 		stat.mana = stat_dict.get("mana", 0)
-		stat.intialMana = stat_dict.get("intialMana", 0)
+		stat.initialMana = stat_dict.get("initialMana", 0)
 
 		stat_list.append(stat)
 
@@ -61,7 +61,7 @@ static func load_data(prefix: String, name: String) -> TowerData:
 		evo.critChance = evo_dict.get("critChance", 0.0)
 		evo.critMultiplier = evo_dict.get("critMultiplier", 1.0)
 		evo.mana = evo_dict.get("mana", 0)
-		evo.intialMana = evo_dict.get("intialMana", 0)
+		evo.initialMana = evo_dict.get("initialMana", 0)
 
 		tower.evolutionStat = evo
 

--- a/scripts/entity/tower/tower_stat.gd
+++ b/scripts/entity/tower/tower_stat.gd
@@ -7,7 +7,7 @@ extends Resource
 @export var critChance: float = 15.0
 @export var critMultiplier: float = 1.5
 @export var mana: int = 100
-@export var intialMana: int = 10
+@export var initialMana: int = 10
 
 func getAttackAnimationSpeed(anim: AnimatedSprite2D, name: String, attack_delay: float) -> float:
 	var total_frames: int = anim.sprite_frames.get_frame_count(name)


### PR DESCRIPTION
**Problem:** The tower start-energy field was misspelled `intialMana` across the whole tower data pipeline (`TowerStat`, the loader string keys, `tower.gd` reads, and all 12 tower YAML files). Every new tower copied the misspelled key, so the cost of fixing grew with each added tower.
**Impact:** No visible in-game change; maintenance/readability debt only.
**Fix:** Lockstep rename `intialMana` -> `initialMana` in the 3 code files plus the 12 tower YAML (live keys + commented copy-source examples), so the loader keeps reading the right key. `skill_controller.gd` already used the correct spelling (no change). Two dead, unreferenced `.tres` under `resources/tower/data/` still carry the old key and are intentionally left untouched (flagged separately as dead content).
