### PR TITLE
Skill-authored status-icon title

### DIFF
--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -86,6 +86,7 @@ skills:
           target: "self"
           value_param: "attackSpeedBuff"
           duration: 4.0
+          title: "Time Traveler"
       - type: "play_animation"
         data:
           animation: "idle"
@@ -151,12 +152,14 @@ evolution_skills:
           value_param: "attackSpeedBuff"
           duration: 4.0
           range: 1
+          title: "Elementary My Dear - Attack Speed"
       - type: "apply_effect"
         data:
           effect: "crit_chance_up"
           target: "self"
           value_param: "critChanceBuff"
           duration: 4.0
+          title: "Elementary My Dear - Critical Chance"
       - type: "play_animation"
         data:
           animation: "idle"

--- a/scripts/effect/effect_instance.gd
+++ b/scripts/effect/effect_instance.gd
@@ -22,6 +22,10 @@ var params: Dictionary = {}
 # Caster-dependent data captured at apply time (e.g. DOT attack snapshot);
 # effects must never hold a live caster reference past apply.
 var snapshot: Dictionary = {}
+# Skill-authored display title for the overhead status icon (YAML `title:`).
+# Empty = fall back to the registry name (def.display_name). A static label
+# only; the {value} number lives in the desc line, never here.
+var authored_title: String = ""
 
 func param(name: String, default_value):
 	return params.get(name, def.params.get(name, default_value))
@@ -35,6 +39,12 @@ func effective_value() -> float:
 func set_applier(applier: Node) -> void:
 	if behavior != null:
 		behavior.capture(applier, self)
+
+# Overhead status-icon title: the skill-authored title when set, else the
+# registry name. Single-source with the icon tooltip - the UI never hand-builds
+# a title (game_copy.md).
+func display_title() -> String:
+	return authored_title if authored_title != "" else def.display_name
 
 # Player-facing tooltip line: def.desc with the {value} token resolved to the
 # REAL applied magnitude (stacks included) - numbers are never hand-typed.

--- a/scripts/effect/effect_spec.gd
+++ b/scripts/effect/effect_spec.gd
@@ -12,9 +12,10 @@ var source_id: String = ""
 var value: float = 0.0        # authored positive magnitude
 var duration: float = 0.0
 var extra_params: Dictionary = {}   # per-application def.params overrides
+var authored_title: String = ""     # skill-authored status-icon title (else registry name)
 
 func instantiate(applier: Node = null) -> EffectInstance:
-	var inst := EffectUtility.make_instance(def.id, source_id, value, duration, null)
+	var inst := EffectUtility.make_instance(def.id, source_id, value, duration, null, authored_title)
 	if inst == null:
 		return null
 	inst.params = extra_params

--- a/scripts/effect/effect_utility.gd
+++ b/scripts/effect/effect_utility.gd
@@ -6,7 +6,7 @@ class_name EffectUtility
 
 # Build one instance from a registry def. `value` is the authored (positive)
 # magnitude; "_down" defs negate it here. duration <= 0 = no self-expiry.
-static func make_instance(effect_id: String, source_id: String, value: float, duration: float, applier: Node = null) -> EffectInstance:
+static func make_instance(effect_id: String, source_id: String, value: float, duration: float, applier: Node = null, authored_title: String = "") -> EffectInstance:
 	var def := EffectRegistry.get_def(effect_id)
 	if def == null:
 		return null
@@ -23,6 +23,7 @@ static func make_instance(effect_id: String, source_id: String, value: float, du
 	inst.duration = duration
 	inst.lifetime = def.lifetime
 	inst.behavior = _behavior_for(def)
+	inst.authored_title = authored_title
 	if applier != null:
 		inst.set_applier(applier)
 	return inst
@@ -32,7 +33,7 @@ static func make_instance(effect_id: String, source_id: String, value: float, du
 # binding, same rules as the legacy status_effect_utility parser. Any entry
 # key beyond effect/value/duration becomes a def.params override (literal, or
 # `<name>_param` binding), e.g. Kiara's max_hp_percent_param.
-const _SPEC_BASE_KEYS := ["effect", "value", "value_param", "duration", "duration_param"]
+const _SPEC_BASE_KEYS := ["effect", "value", "value_param", "duration", "duration_param", "title"]
 
 static func parse_effect_list(list: Array, parameters: Dictionary, source_id: String) -> Array[EffectSpec]:
 	var result: Array[EffectSpec] = []
@@ -46,6 +47,7 @@ static func parse_effect_list(list: Array, parameters: Dictionary, source_id: St
 		var spec := EffectSpec.new()
 		spec.def = def
 		spec.source_id = source_id
+		spec.authored_title = str(entry.get("title", ""))
 		spec.value = float(_resolve_field(entry, parameters, "value", "value_param", 0.0))
 		spec.duration = float(_resolve_field(entry, parameters, "duration", "duration_param", def.default_duration))
 		for key in entry.keys():

--- a/scripts/skill/skillActions/skill_action_apply_effect.gd
+++ b/scripts/skill/skillActions/skill_action_apply_effect.gd
@@ -23,6 +23,7 @@ extends SkillAction
 @export var duration: float = 0.0
 @export var durationParam: String = ""
 @export var range_cells: int = 1
+@export var authoredTitle: String = ""
 
 func execute(context: SkillContext) -> void:
 	var user := context.user
@@ -41,7 +42,7 @@ func execute(context: SkillContext) -> void:
 	for target in _resolve_targets(context, user):
 		if not is_instance_valid(target) or not target.has_method("apply_effect"):
 			continue
-		var inst := EffectUtility.make_instance(effectId, source_id, resolved_value, resolved_duration, user)
+		var inst := EffectUtility.make_instance(effectId, source_id, resolved_value, resolved_duration, user, authoredTitle)
 		if inst == null:
 			return
 		target.apply_effect(inst)

--- a/scripts/skill/skillActions/skill_action_effect_area.gd
+++ b/scripts/skill/skillActions/skill_action_effect_area.gd
@@ -29,6 +29,7 @@ extends SkillAction
 @export var duration: float = 3.0
 @export var radius: float = 1.0
 @export var affects: String = "enemies"
+@export var authoredTitle: String = ""
 
 var user: Node2D
 
@@ -48,7 +49,7 @@ func _on_enter(node: Area2D) -> void:
 	if node.has_method("apply_effect"):
 		# duration 0: aura-bound life - removed on exit / zone death only
 		# (wave clear catches any orphan).
-		var inst := EffectUtility.make_instance(effectId, _source_id(), value, 0.0, user)
+		var inst := EffectUtility.make_instance(effectId, _source_id(), value, 0.0, user, authoredTitle)
 		if inst != null:
 			node.apply_effect(inst)
 

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -46,6 +46,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill.duration = float(skillData.get("duration", 0.0));
 			skill.durationParam = skillData.get("duration_param", "");
 			skill.range_cells = skillData.get("range", 1);
+			skill.authoredTitle = skillData.get("title", "");
 		"effect_area":
 			# Aura zone applying a registry effect while hosts stay inside.
 			skill = SkillActionEffectArea.new();
@@ -55,6 +56,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill.duration = float(skillData.get("duration", 3.0));
 			skill.radius = float(skillData.get("radius", 1.0));
 			skill.affects = skillData.get("affects", "enemies");
+			skill.authoredTitle = skillData.get("title", "");
 		"delay":
 			skill = SkillActionDelay.new();
 			var skillData = data.get("data", {});

--- a/scripts/ui/effect/effect_icon_row.gd
+++ b/scripts/ui/effect/effect_icon_row.gd
@@ -108,7 +108,7 @@ func _make_icon(inst: EffectInstance) -> TextureRect:
 	return icon
 
 func _update_stack_label(icon: TextureRect, inst: EffectInstance) -> void:
-	var tooltip := inst.def.display_name
+	var tooltip := inst.display_title()
 	var desc := inst.display_desc()
 	if desc != "":
 		tooltip += "\n" + desc


### PR DESCRIPTION
**Summary:** The overhead status-icon tooltip title now shows a per-effect skill-authored `title:` (skill YAML), falling back to the registry effect name when unauthored. First adopters: Watson Amelia active + evolved.

**How it works:** `apply_effect`, `effect_area`, and on-hit effect entries accept an optional `title:` string. It is parsed onto the action/spec (`ParseAction`, `parse_effect_list`) and stored on the `EffectInstance` as `authored_title`, kept separate from `source_id` (which stays the identity/stacking key). `EffectInstance.display_title()` returns the authored title when set, else `def.display_name`; the icon row tooltip (`_update_stack_label`) uses it. desc, category/colour, stacking, and identity are unchanged - only the title line changes.

**Implementation Notes:**
- `effect_area` carries the title as an `@export`, so the no-context `_on_enter` aura callback can read it - auras get titles too without threading a SkillContext.
- Unauthored effects keep their registry name (passive Bull Eyes, on-hit Phoenix Flame, and any not-yet-authored tower). Synergy board buffs never reach the title path (hidden by `show_icon`).
- Amelia: active -> `Time Traveler`; evolved -> `Elementary My Dear - Attack Speed` / `Elementary My Dear - Critical Chance`.
- The dead skill-level `effects:` metadata block (per-effect names, unread by any code) is left in place - flagged for a separate cleanup/document decision.
