### PR TITLE
fix(synergy): clear UNUSED_SIGNAL quest_progress_changed (owner emits)

### DIFF
--- a/scripts/synergy/synergy_controller.gd
+++ b/scripts/synergy/synergy_controller.gd
@@ -15,6 +15,12 @@ var _effects: Dictionary = {}      # synergy_id -> SynergyEffect
 # right panel row.
 signal quest_progress_changed(synergy_id: int, current: int)
 
+# Quest effects report progress through this method so the emit lives in the
+# declaring script (the UNUSED_SIGNAL check is per-script; cross-script emits
+# do not count - see agent_lessons.md).
+func report_quest_progress(synergy_id: int, current: int) -> void:
+	quest_progress_changed.emit(synergy_id, current)
+
 func setup(factory) -> void:
 	_factory = factory
 

--- a/scripts/synergy/synergy_effect_quest_tempus.gd
+++ b/scripts/synergy/synergy_effect_quest_tempus.gd
@@ -22,11 +22,11 @@ var _energy_timer: float = 0.0
 
 func activate() -> void:
 	# Guild formed (2 Tempus units): start the tracker at 0.
-	controller.quest_progress_changed.emit(data.synergy_id, _kills)
+	controller.report_quest_progress(data.synergy_id, _kills)
 
 func on_enemy_killed(_enemy, _cause, _reward) -> void:
 	_kills += 1
-	controller.quest_progress_changed.emit(data.synergy_id, _kills)
+	controller.report_quest_progress(data.synergy_id, _kills)
 	_check_rewards()
 
 func on_tier_changed(_new_tier: int) -> void:


### PR DESCRIPTION
**Problem:** Godot debugger flags UNUSED_SIGNAL for `quest_progress_changed` in `synergy_controller.gd`, although the signal is live (it drives the Tempus quest hover progress line). Both emits sit in `synergy_effect_quest_tempus.gd` through the controller reference, and the analyzer counts emits per script only.
**Impact:** Dev log noise only; no player-facing effect.
**Fix:** New `SynergyController.report_quest_progress()` wrapper so the declaring script emits its own signal; the Tempus quest effect calls it at both sites (activate + on_enemy_killed). No behavior change.
