### PR TITLE
fix(enemy): single cast-pacing gate - stop boss skill spam

### DIFF
--- a/resources/database/enemy/forest01/boss/king_salam.yaml
+++ b/resources/database/enemy/forest01/boss/king_salam.yaml
@@ -14,23 +14,23 @@ stats:
   moveSpeed: 30
 skill:
   - name: Adaptation
-    cooldown: 20
+    cooldown: 12
     recovery: 0.2
     tags:
       - defense
       - self
-    desc: "King Salam adapts his royal hide, reducing all damage he takes by 10% for 5 seconds."
+    desc: "King Salam adapts his royal hide, reducing all damage he takes by 20% for 5 seconds."
     action:
       - type: target_self
       - type: apply_effect
         data:
           effect: damage_reduction_up
           target: targets
-          value: 0.1
+          value: 0.2
           duration: 5
           title: "Adaptation"
   - name: Slime Fluid
-    cooldown: 30
+    cooldown: 15
     cast_time: 0.5
     recovery: 0.2
     tags:
@@ -47,7 +47,7 @@ skill:
           value: 0.1
           duration: 10
   - name: King's Command
-    cooldown: 40
+    cooldown: 30
     cast_time: 0.5
     recovery: 0.2
     tags:

--- a/resources/database/enemy/forest01/elite/armored_boar.yaml
+++ b/resources/database/enemy/forest01/elite/armored_boar.yaml
@@ -5,9 +5,7 @@ stats:
   moveSpeed: 50
 skill:
   - name: Protector Aura
-    cooldown: 0
-    oneTime: true
-    recovery: 0 # instant aura pop - no post-cast hold (keep 0: a hold would freeze walking on cast)
+    type: passive # aura up from spawn - a buff that must exist at engagement cannot be an Active under the cast gate
     desc: สร้างออร่าเพิ่ม Defense 2.5% ให้กับฝ่ายเดียวกันในระยะ 1*1 ช่อง
     action:
       - type: target_self

--- a/resources/database/enemy/forest01/elite/flying_flower.yaml
+++ b/resources/database/enemy/forest01/elite/flying_flower.yaml
@@ -5,9 +5,7 @@ stats:
   moveSpeed: 40
 skill:
   - name: Sweat Spore
-    cooldown: 0
-    oneTime: true
-    recovery: 0 # instant aura pop - no post-cast hold (keep 0: a hold would freeze walking on cast)
+    type: passive # aura up from spawn - a buff that must exist at engagement cannot be an Active under the cast gate
     desc: เพิ่ม def ให้ตนเอง 5%
     action:
       - type: target_self

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -29,8 +29,8 @@ var usingSkill: bool = false;
 # A sleeping boss (out of coverage / towers busy elsewhere) is intended, not a
 # bug. Do NOT restore instant-cast-on-wake: with skills ready at spawn it
 # chain-casts the whole kit on first engagement (enemy_skill.md).
-@export var inCombatWindow: float = 2.0
-@export var castWait: float = 3.0
+@export var inCombatWindow: float = 4.0
+@export var castWait: float = 4.0
 var inCombatRemaining: float = 0.0
 var castWaitRemaining: float = 0.0
 

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -21,12 +21,18 @@ var enableMove: bool = true;
 # a cast ending can't free a stunned one).
 var castLocked: bool = false;
 var usingSkill: bool = false;
-# In-combat gate (hybrid, Director 2026-07-07): a hit wakes the enemy and
-# ready skills cast immediately; inCombatWindow seconds without damage puts it
-# back to sleep, looping. A sleeping boss (out of coverage / towers busy
-# elsewhere) is intended, not a bug.
+# In-combat gate, single pacing timer (Director 2026-07-08): a hit wakes the
+# enemy AND arms the castWait timer; the timer ticks only while awake, and a
+# cast is allowed when it reaches 0 - hit = wait -> cast, never instant and
+# never back-to-back (it re-arms on wake and after each completed cast).
+# inCombatWindow seconds without damage puts the enemy back to sleep, looping.
+# A sleeping boss (out of coverage / towers busy elsewhere) is intended, not a
+# bug. Do NOT restore instant-cast-on-wake: with skills ready at spawn it
+# chain-casts the whole kit on first engagement (enemy_skill.md).
 @export var inCombatWindow: float = 2.0
+@export var castWait: float = 3.0
 var inCombatRemaining: float = 0.0
+var castWaitRemaining: float = 0.0
 
 var initialized: bool = false;
 # Mutex flag: ensures exactly ONE removal signal fires per enemy (onDead OR
@@ -65,6 +71,7 @@ func _process(_delta):
 		effects.tick(_delta)
 
 	if inCombatRemaining > 0.0:
+		castWaitRemaining = maxf(0.0, castWaitRemaining - _delta)
 		inCombatRemaining = maxf(0.0, inCombatRemaining - _delta)
 		if inCombatRemaining <= 0.0 and EnemySkillController.DEBUG_LOG:
 			print("[EnemySkill] asleep: ", self)
@@ -122,8 +129,11 @@ func setTexture(image: Texture2D):
 func recvDamage(damage: Damage) -> int:
 	# Refresh the awake window before ANY early-return so blocked hits
 	# (e.g. while invincible or shield-blocked) still count as engagement.
-	if inCombatRemaining <= 0.0 and EnemySkillController.DEBUG_LOG:
-		print("[EnemySkill] engaged: ", self)
+	if inCombatRemaining <= 0.0:
+		# Waking from sleep: arm the pacing timer - hit = wait -> cast.
+		castWaitRemaining = castWait
+		if EnemySkillController.DEBUG_LOG:
+			print("[EnemySkill] engaged: ", self)
 	inCombatRemaining = inCombatWindow
 
 	# Invincible: no damage, no flash, no floating text. Single choke point -
@@ -242,6 +252,11 @@ func setSpeed(value: float):
 
 func isInCombat() -> bool:
 	return inCombatRemaining > 0.0
+
+# Pacing gate for EnemySkillController.useSkill: awake AND the castWait timer
+# has elapsed (enemy_skill.md cast rules).
+func canCastNow() -> bool:
+	return isInCombat() and castWaitRemaining <= 0.0
 
 # Container state is the single source of truth (no bool flag to desync);
 # InvincibleBehavior pushes tower re-target on apply/expire.

--- a/scripts/skill/enemy_skill.gd
+++ b/scripts/skill/enemy_skill.gd
@@ -18,9 +18,10 @@ func tick(delta: float):
 	cooldownRemaining = maxf(0.0, cooldownRemaining - delta)
 
 func initCooldown():
-	# Ready at spawn: the first engagement must be answerable immediately
-	# (Director 2026-07-07; was cooldown/2, which muted King Salam for its
-	# first 10s no matter how hard it was hit). Cooldown starts per cast.
+	# Ready at spawn (Director 2026-07-07; was cooldown/2, which muted King
+	# Salam for its first 10s no matter how hard it was hit). First-cast
+	# TIMING is owned by Enemy's castWait pacing gate, not by cooldowns;
+	# cooldown starts per cast.
 	cooldownRemaining = 0.0
 
 func startCooldown():

--- a/scripts/skill/enemy_skill_controller.gd
+++ b/scripts/skill/enemy_skill_controller.gd
@@ -20,14 +20,15 @@ func process(delta: float):
 				print("[EnemySkill] ready: ", es.name, " (", user, ")")
 
 # Enemy cast rules (differ from towers): a hit wakes the enemy for
-# Enemy.inCombatWindow seconds (hybrid sleep loop), and ONE random ready skill
-# is cast per opportunity instead of every ready skill in order.
+# Enemy.inCombatWindow seconds (hybrid sleep loop) and arms its castWait
+# pacing timer; when the timer elapses ONE random ready skill is cast, then
+# the timer re-arms - hit = wait -> cast, never a back-to-back chain.
 func useSkill():
 	if(!canUseSkill()):
 		return;
 
 	var enemy := user as Enemy
-	if(enemy == null || !enemy.isInCombat()):
+	if(enemy == null || !enemy.canCastNow()):
 		return;
 
 	var ready: Array[Skill] = [];
@@ -52,6 +53,10 @@ func useSkill():
 	await execute_skill_actions(skill, context);
 	if(is_instance_valid(enemy)):
 		enemy.castLocked = false;
+		# Re-arm the pacing gap AFTER the full cast (incl. recovery). Also runs
+		# on a cancelled cast (wave-end teardown) - harmless, kept simpler than
+		# splitting it into onSuccess.
+		enemy.castWaitRemaining = enemy.castWait;
 
 func onSuccess(skill: Skill):
 	super.onSuccess(skill);


### PR DESCRIPTION
**Problem:** Leftover from the PR #85 "boss never casts" hunt: two stacked cast gates (instant-cast-on-wake + the sleep loop) plus the later skills-ready-at-spawn root fix (`2e2e92f`) meant a boss chain-cast its whole ready kit the moment towers first hit it, then re-fired every skill the instant its cooldown ended.
**Impact:** Bosses spam skills back-to-back on first engagement; skill usage unreadable.
**Fix:** Consolidated into ONE per-enemy pacing timer (`Enemy.castWait`, 4s): armed on wake and after each completed cast, ticks only while awake, cast allowed at 0 - hit = wait -> cast. Sleep loop stays (window tuned 2s -> 4s, equal to the wait, so one slow tower still keeps an enemy awake through it). The two aura elites (flying_flower, armored_boar) were the same PR #85 leftover shape (cooldown-0 oneTime Actives) - now `type: passive`, aura up from spawn. King Salam tune (Director): Adaptation CD 20->12 + reduction 10%->20%, Slime Fluid CD 30->15, King's Command CD 40->30. Files: `enemy.gd`, `enemy_skill_controller.gd`, `enemy_skill.gd`, 3 enemy YAMLs.
