### PR TITLE
Giant Boar real skill kit + enemy foundation mechanics (dash / triggered / heal)

### DIFF
--- a/resources/database/effect/effects.yaml
+++ b/resources/database/effect/effects.yaml
@@ -148,6 +148,14 @@ attack_mult_down:
   host: tower
   kind: attack_mult
 
+magic_mult_down:
+  name: "Magic Down"
+  desc: "Magic power reduced by {value}."
+  icon: "ui_asset/effects/debuff_generic.png"
+  category: debuff
+  host: tower
+  kind: magic_mult
+
 # Themed id (no _down suffix): negate: true keeps the authored magnitude
 # positive while applying as a reduction (effect_registry parse).
 slime_fluid:
@@ -229,6 +237,28 @@ royal_command:
   category: buff
   host: enemy
   kind: stun
+
+# Self-freeze rest state (Thick Skin) - same stun-kind pattern as royal_command.
+rest:
+  name: "Resting"
+  desc: "Resting soundly and unable to move."
+  icon: "ui_asset/effects/buff_generic.png"
+  category: buff
+  host: enemy
+  kind: stun
+
+# Heal-over-time (interval half of the heal pair; instant = heal_percent_maxhp
+# action). Magnitude comes from params like the phoenix_flame DOT, not {value}.
+rest_recovery:
+  name: "Recovering"
+  desc: "Recovering health every second while resting."
+  icon: "ui_asset/effects/buff_generic.png"
+  category: buff
+  host: enemy
+  kind: hot
+  params:
+    interval: 1.0
+    max_hp_percent: 0.05
 
 # ---- Enemy debuffs (tower skills) ----
 

--- a/resources/database/enemy/forest01/boss/giant_boar.yaml
+++ b/resources/database/enemy/forest01/boss/giant_boar.yaml
@@ -1,6 +1,9 @@
 # Boss. `name` is the display name; the sprite + id come from the file path
 # (resources/enemy/forest01/boss/giant_boar/giant_boar.png). `wave` lists the
-# waves this boss is eligible to spawn on. skill is inline (3 boss skills).
+# waves this boss is eligible to spawn on; `scale` is the visual/hitbox size
+# multiplier applied at spawn. Skills are inline (3 max by design); enemy
+# skills are single-level, so desc uses concrete numbers (see enemy_skill.md).
+# Design source: Director xlsx 2026-07-09 (boss.md Giant Boar).
 name: Giant Boar
 scale: 2
 wave:
@@ -9,53 +12,85 @@ stats:
   hp: 20000
   def: 5
   mDef: 5
-  moveSpeed: 100
-  skillCount: 3
-  buffCount: 3
+  moveSpeed: 60
 skill:
-  - name: Charge
-    cooldown: 20
+  - name: Super Charge
+    cooldown: 12
+    cast_time: 1.0
     recovery: 0.2
-    desc: charge_desc
+    tags:
+      - movement
+    desc: "The Giant Boar braces, then charges 2 tiles forward along the path."
     action:
-      - type: target_self
-      - type: set_speed
+      - type: dash
         data:
-          speed: 0
-      - type: delay
-        data:
-          delay: 2
-      - type: set_speed
-        data:
-          speed: 150
-      - type: delay
-        data:
-          delay: 2
-      - type: set_speed
-        data:
-          speed: 100
+          cells: 2
+          duration: 0.3
   - name: Thick Skin
-    cooldown: 45
+    type: triggered
+    trigger:
+      hp_below: 0.4
+    oneTime: true
+    cast_time: 0.5
     recovery: 0.2
-    desc: thick_skin_desc
+    tags:
+      - defense
+      - heal
+    desc: "When its health falls below 40%, the Giant Boar lies down to rest for 5 seconds - taking 50% less damage and recovering 5% of its max health every second. On waking it gains 50% movement speed for 5 seconds."
     action:
       - type: target_self
       - type: apply_effect
         data:
-          effect: armor_mult_up
+          effect: rest
           target: targets
-          value: 7.5
           duration: 5
-  - name: Scary Graze
-    cooldown: 30
+          title: "Thick Skin - Resting"
+      - type: apply_effect
+        data:
+          effect: damage_reduction_up
+          target: targets
+          value: 0.5
+          duration: 5
+          title: "Thick Skin - Hardened"
+      - type: apply_effect
+        data:
+          effect: rest_recovery
+          target: targets
+          duration: 5
+          title: "Thick Skin - Recovering"
+      - type: delay
+        data:
+          delay: 5
+      - type: apply_effect
+        data:
+          effect: move_speed_up
+          target: targets
+          value: 0.5
+          duration: 5
+          title: "Thick Skin - Haste"
+  - name: Bulldoze
+    cooldown: 20
+    cast_time: 0.5
     recovery: 0.2
-    desc: scary_graze_desc
+    tags:
+      - debuff
+      - aoe
+    desc: "The Giant Boar stomps the ground, shaking a 5x5 area - units caught inside deal 20% less damage for 8 seconds."
     action:
-      - type: target_self
-      - type: effect_area
+      - type: apply_effect
         data:
           effect: attack_mult_down
-          value: 10           # percent scale (10 = -10% damage); same result as legacy 0.10 decimal
-          duration: 3
-          radius: 1
-          affects: towers
+          target: towers_in_range
+          range: 2
+          value: 20
+          duration: 8
+          title: "Bulldoze - Damage Down"
+      - type: apply_effect
+        data:
+          effect: magic_mult_down
+          target: towers_in_range
+          range: 2
+          value: 20
+          duration: 8
+          show_area: false
+          title: "Bulldoze - Magic Down"

--- a/scripts/effect/behaviors/hot_behavior.gd
+++ b/scripts/effect/behaviors/hot_behavior.gd
@@ -1,0 +1,27 @@
+class_name HotBehavior
+extends EffectBehavior
+
+# Heal-over-time (first user: Giant Boar rest_recovery). Per-tick heal:
+#     heal = params.max_hp_percent * host.maxHp
+# Ticks every params.interval seconds; a duration of N*interval yields exactly
+# N ticks (t = interval .. duration). Unlike DotBehavior's `last_tick = elapsed`
+# the tick clock advances `last_tick += interval`, so timing never drifts and
+# the final tick still lands: the container runs behavior.process BEFORE the
+# expiry check in the same tick() pass, and elapsed/remaining accumulate the
+# same deltas, so the last tick and expiry share a frame with the tick first.
+
+func process(delta: float, host: Node, inst: EffectInstance) -> void:
+	var interval := float(inst.param("interval", 1.0))
+	var elapsed := float(inst.snapshot.get("elapsed", 0.0)) + delta
+	inst.snapshot["elapsed"] = elapsed
+	var last := float(inst.snapshot.get("last_tick", 0.0))
+	if elapsed - last < interval:
+		return
+	inst.snapshot["last_tick"] = last + interval
+	if not (host is Enemy) or not is_instance_valid(host):
+		return
+	var enemy := host as Enemy
+	if enemy.stats == null:
+		return
+	var hp_pct := float(inst.param("max_hp_percent", 0.0))
+	enemy.heal(int(hp_pct * float(enemy.stats.maxHp)))

--- a/scripts/effect/effect_types.gd
+++ b/scripts/effect/effect_types.gd
@@ -33,6 +33,7 @@ enum Kind {
 	DOT,
 	MARK_ONLY,
 	INVINCIBLE,
+	HOT,
 }
 
 enum Category { BUFF, DEBUFF, MARK }
@@ -70,6 +71,7 @@ const KIND_FROM_STRING := {
 	"dot": Kind.DOT,
 	"mark": Kind.MARK_ONLY,
 	"invincible": Kind.INVINCIBLE,
+	"hot": Kind.HOT,
 }
 
 const CATEGORY_FROM_STRING := {

--- a/scripts/effect/effect_utility.gd
+++ b/scripts/effect/effect_utility.gd
@@ -84,6 +84,8 @@ static func _behavior_for(def: EffectDef) -> EffectBehavior:
 			return StunBehavior.new()
 		EffectTypes.Kind.DOT:
 			return DotBehavior.new()
+		EffectTypes.Kind.HOT:
+			return HotBehavior.new()
 		EffectTypes.Kind.INVINCIBLE:
 			return InvincibleBehavior.new()
 		_:

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -78,6 +78,7 @@ func _process(_delta):
 
 	if skillController:
 		skillController.process(_delta)
+		skillController.useTriggeredSkill();
 		skillController.useSkill();
 
 	if(progress_ratio >= 1.0):
@@ -185,6 +186,11 @@ func recvDamage(damage: Damage) -> int:
 
 	if currentHp <= 0:
 		dead(damage)
+	elif skillController != null:
+		# HP%-trigger check at the single HP-loss site; a killing blow never
+		# triggers (dead() wins). Only flags pending - the cast fires from the
+		# _process hook (enemy_skill.md Triggered).
+		skillController.check_hp_triggers(float(currentHp) / float(stats.maxHp))
 
 	var dmgColor: Color
 	match damage.type:
@@ -210,9 +216,24 @@ func updateHealthBar(value: float):
 	if healthBar and enemyType != EnemyType.Boss:
 		healthBar.visible = true
 		healthBar.updateValue(value)
-	# recvDamage is the only HP mutation path, so this is the one emit site
-	# (data source for the top-center boss HP bar).
+	# recvDamage and heal() are the only HP mutation paths; both route through
+	# here, so this is the one emit site (data source for the boss HP bar).
 	onHpChanged.emit(value, float(stats.maxHp))
+
+# Single heal entry (instant heal_percent_maxhp action + hot effect ticks).
+# Returns the ACTUAL restored amount - updateHealth clamps at maxHp, so the
+# floating number reflects real healing, not the requested amount.
+func heal(amount: int) -> int:
+	if _removed or amount <= 0 or stats == null:
+		return 0
+	var before: int = stats.currentHp
+	var currentHp = stats.updateHealth(amount)
+	var healed: int = currentHp - before
+	if healed <= 0:
+		return 0
+	updateHealthBar(currentHp)
+	Utility.show_float_text(global_position, get_parent(), "+" + str(healed), Color(0.4, 1.0, 0.45))
+	return healed
 
 func dead(cause: Damage):
 	# Mutex guard (see _removed comment near top). If the reach-end branch

--- a/scripts/skill/base_skill_controller.gd
+++ b/scripts/skill/base_skill_controller.gd
@@ -81,7 +81,10 @@ func execute_skill_actions(skill: Skill, context: SkillContext):
 
 func resetUsingSkill(skill: Skill):
 	skill.using = false;
-	if(user is Tower || user is Enemy):
+	# Valid guard: a cancel can arrive after the host was freed (e.g. an enemy
+	# leaking/dying during a long mid-cast delay) - `user is Enemy` alone still
+	# passes on a freed instance.
+	if(user != null && is_instance_valid(user) && (user is Tower || user is Enemy)):
 		user.usingSkill = skills.any(Callable(self, "checkUsingSkill"));
 
 func onSuccess(skill: Skill):

--- a/scripts/skill/enemy_skill.gd
+++ b/scripts/skill/enemy_skill.gd
@@ -5,6 +5,14 @@ extends Skill
 # Passive: actions apply once at spawn (EnemySkillController.applyPassives);
 # never enters the in-combat/random cast pool, cooldown unused.
 @export var passive: bool = false
+# Triggered: fires itself when its trigger condition is met (first condition:
+# hp_below), bypassing the castWait pacing gate - the condition is its own
+# telegraph (Director 2026-07-09). Never in the random cast pool.
+@export var triggered: bool = false
+@export var trigger_hp_below: float = 0.0
+# Once the condition fires the skill never re-arms (set at queue time, so a
+# heal re-crossing the threshold cannot double-fire while the cast is pending).
+var triggerUsed: bool = false
 var cooldownRemaining: float = 0.0;
 
 func _init(p_name:String="EnemySkill", p_desc:String="Just an enemy skill", p_actions:Array[SkillAction]=[], p_parameters:Dictionary={}, p_oneTimeUse: bool = false, p_cooldown:float=3.0, p_castTime: float = 0.0):

--- a/scripts/skill/enemy_skill_controller.gd
+++ b/scripts/skill/enemy_skill_controller.gd
@@ -33,7 +33,7 @@ func useSkill():
 
 	var ready: Array[Skill] = [];
 	for skill in skills:
-		if(skill is EnemySkill && (skill as EnemySkill).passive):
+		if(skill is EnemySkill && ((skill as EnemySkill).passive || (skill as EnemySkill).triggered)):
 			continue;
 		if(skill != null && skill.isReady()):
 			ready.append(skill);
@@ -62,6 +62,50 @@ func onSuccess(skill: Skill):
 	super.onSuccess(skill);
 	if skill is EnemySkill:
 		(skill as EnemySkill).startCooldown();
+
+# Triggered skills (type: triggered): condition checked from Enemy.recvDamage
+# after the HP write; check_hp_triggers only flags PENDING - the cast fires
+# from useTriggeredSkill() in the Enemy._process hook once the busy flag frees,
+# bypassing the castWait pacing gate (the condition is its own telegraph; the
+# gate paces gate-driven Actives, not condition reactions - enemy_skill.md).
+var pendingTriggered: Array[Skill] = []
+
+func check_hp_triggers(hp_ratio: float):
+	for skill in skills:
+		if(!(skill is EnemySkill)):
+			continue;
+		var es := skill as EnemySkill
+		if(!es.triggered || es.triggerUsed):
+			continue;
+		if(es.trigger_hp_below > 0.0 && hp_ratio < es.trigger_hp_below):
+			es.triggerUsed = true;
+			pendingTriggered.append(es);
+			if DEBUG_LOG:
+				print("[EnemySkill] trigger pending: ", es.name, " (", user, ", hp ", hp_ratio, ")")
+
+func useTriggeredSkill():
+	if(pendingTriggered.is_empty() || !canUseSkill()):
+		return;
+	var enemy := user as Enemy
+	if(enemy == null):
+		return;
+
+	cancelled = false;
+	var skill: Skill = pendingTriggered.pop_front();
+	if DEBUG_LOG:
+		print("[EnemySkill] trigger cast: ", skill.name, " (", user, ")")
+	var context = SkillContext.new()
+	context.user = user
+	context.skillName = skill.name
+	context.extra["parameter"] = skill.parameters
+
+	enemy.castLocked = true;
+	await execute_skill_actions(skill, context);
+	if(is_instance_valid(enemy)):
+		enemy.castLocked = false;
+		# Same re-arm invariant as useSkill: without it a gate Active fires
+		# back-to-back right after a long triggered cast (e.g. Thick Skin ~5.5s).
+		enemy.castWaitRemaining = enemy.castWait;
 
 # Passive skills (type: passive): apply the action list once at spawn - no
 # in-combat gate, no cast_time/busy flag, no cooldown/onSuccess. Called from

--- a/scripts/skill/skillActions/skill_action_apply_effect.gd
+++ b/scripts/skill/skillActions/skill_action_apply_effect.gd
@@ -27,6 +27,9 @@ extends SkillAction
 @export var durationParam: String = ""
 @export var range_cells: int = 1
 @export var authoredTitle: String = ""
+# false = skip the red footprint flash; for the 2nd+ apply_effect of one skill
+# hitting the same box (e.g. Bulldoze) so the area doesn't double-flash.
+@export var showArea: bool = true
 
 func execute(context: SkillContext) -> void:
 	var user := context.user
@@ -44,7 +47,7 @@ func execute(context: SkillContext) -> void:
 
 	# Enemy-cast area debuff: flash the affected box in red so the player (and
 	# playtests) can see the real footprint - reuses the staff SkillCastIndicator.
-	if targetMode == "towers_in_range":
+	if targetMode == "towers_in_range" and showArea:
 		_spawn_area_flash(user)
 
 	for target in _resolve_targets(context, user):

--- a/scripts/skill/skillActions/skill_action_dash.gd
+++ b/scripts/skill/skillActions/skill_action_dash.gd
@@ -1,0 +1,46 @@
+class_name SkillActionDash
+extends SkillAction
+
+# Path dash (first user: Giant Boar Super Charge): slides the casting enemy
+# forward ALONG ITS PATH by `cells` path-cells over `duration` seconds. Runs
+# inside the cast while castLocked blocks normal walking - the action drives
+# progress_ratio directly. One curve segment = one cell, the same convention
+# as EnemyStat.calculatePathfollowSpeed. Reaching the endpoint mid-dash leaks
+# normally: Enemy._process runs its endpoint check outside the movement gate,
+# and the path curve does not loop, so overshoot clamps (design: a dash into
+# the base IS a leak). A stunned caster still completes the slide - cast rule
+# "a started skill always completes" (enemy_skill.md).
+
+@export var cells: float = 1.0
+@export var duration: float = 0.3
+
+func execute(context: SkillContext):
+	var enemy := context.user as Enemy
+	if enemy == null or not is_instance_valid(enemy):
+		return
+	var parent := enemy.get_parent() as Path2D
+	if parent == null or parent.curve == null:
+		return
+	var totalSegments: int = parent.curve.point_count - 3
+	if totalSegments <= 0:
+		return
+	var totalRatio: float = cells / float(totalSegments)
+	if duration <= 0.0:
+		enemy.progress_ratio += totalRatio
+		return
+	var remaining := duration
+	while remaining > 0.0:
+		await enemy.get_tree().process_frame
+		if not is_instance_valid(enemy):
+			context.cancel = true
+			return
+		if enemy.get_tree().paused:
+			continue
+		var delta: float = enemy.get_process_delta_time()
+		var step: float = minf(delta, remaining)
+		var previousRatio := enemy.progress_ratio
+		enemy.progress_ratio += totalRatio * (step / duration)
+		enemy.updateFacingFromDirection(enemy.getPathDirection(parent, previousRatio, enemy.progress_ratio))
+		remaining -= step
+		if enemy.progress_ratio >= 1.0:
+			return  # endpoint (leak) flow takes over in Enemy._process

--- a/scripts/skill/skillActions/skill_action_heal_percent_maxhp.gd
+++ b/scripts/skill/skillActions/skill_action_heal_percent_maxhp.gd
@@ -1,0 +1,25 @@
+extends SkillAction
+class_name SkillActionHealPercentMaxHp
+
+# Heals each target for stats.maxHp x percent (instant half of the heal pair;
+# the interval half is the `hot` effect kind - see rest_recovery). Enemy-only
+# hosts for now; mirrors SkillActionDamagePercentMaxHp's target normalize.
+
+@export var percent: float = 0.0
+
+func execute(context: SkillContext):
+	if context.target == null:
+		return
+	for target in context.target:
+		if not is_instance_valid(target):
+			continue
+		var enemy: Enemy = null
+		if target is Enemy:
+			enemy = target
+		elif target is Area2D and target.get_parent() is Enemy:
+			enemy = target.get_parent()
+		if enemy == null or enemy.stats == null:
+			continue
+		var amount: int = int(enemy.stats.maxHp * percent)
+		if amount > 0:
+			enemy.heal(amount)

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -27,8 +27,15 @@ static func ParseSkill(skillDataList: Array) -> Array[Skill]:
 		# Post-cast hold (seconds); enemy default 0.0 - a 0.2 default would
 		# permanently freeze cooldown-0 every-frame recast skills (aura elites).
 		s.recoveryTime = float(skill.get("recovery", 0.0));
-		# `type: passive` = apply once at spawn (no gate/cooldown); default active.
-		s.passive = str(skill.get("type", "active")) == "passive";
+		# Skill kinds: active (default, castWait gate) | passive (once at spawn)
+		# | triggered (fires itself on its trigger condition, bypassing the gate).
+		var typeStr = str(skill.get("type", "active"));
+		s.passive = typeStr == "passive";
+		s.triggered = typeStr == "triggered";
+		var trigger = skill.get("trigger", {});
+		s.trigger_hp_below = float(trigger.get("hp_below", 0.0));
+		if s.triggered and s.trigger_hp_below <= 0.0:
+			push_warning("Triggered skill '", skillName, "' has no trigger condition - it will never fire.");
 		# Player-facing summary tags (same controlled registry as tower skills).
 		# Append str() per entry - a raw YAML Array can't assign into Array[String].
 		for tag in skill.get("tags", []):
@@ -59,6 +66,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill.durationParam = skillData.get("duration_param", "");
 			skill.range_cells = skillData.get("range", 1);
 			skill.authoredTitle = skillData.get("title", "");
+			skill.showArea = skillData.get("show_area", true);
 		"effect_area":
 			# Aura zone applying a registry effect while hosts stay inside.
 			skill = SkillActionEffectArea.new();
@@ -154,6 +162,17 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill.width = skillData.get("width", 1);
 			skill.height = skillData.get("height", 1);
 			skill.cancel_when_empty = skillData.get("cancel_when_empty", true);
+		"dash":
+			# Path dash: slide the casting enemy forward along its path.
+			skill = SkillActionDash.new();
+			var skillData = data.get("data", {});
+			skill.cells = float(skillData.get("cells", 1.0));
+			skill.duration = float(skillData.get("duration", 0.3));
+		"heal_percent_maxhp":
+			# Instant heal = target.maxHp x percent (enemy self heals).
+			skill = SkillActionHealPercentMaxHp.new();
+			var skillData = data.get("data", {});
+			skill.percent = float(skillData.get("percent", 0.0));
 		"damage_percent_maxhp":
 			# Staff-style TRUE damage = enemy.maxHp × percent (boss vs non-boss split).
 			# First caller: A-Chan "Hard Worker Ghost Release!!!".


### PR DESCRIPTION
**Summary:** Turns the placeholder Giant Boar into its real 3-skill kit (Director xlsx design) and ships 4 reusable foundation mechanics for elite+/boss enemies: path dash, HP%-triggered skills, heal (instant + heal-over-time), and the missing magic damage debuff.

**How it works:**
- `dash` action slides the casting enemy along its path by N cells over a duration; dashing past the endpoint leaks into the base by design.
- `type: triggered` + `trigger: hp_below:` - the skill fires itself when HP crosses the threshold, bypassing the castWait pacing gate (the condition is its own telegraph). Single firing path: `recvDamage` only flags pending; the existing `_process` hook casts when the busy flag frees, then re-arms `castWait` like any cast. Once per life.
- Heal pair: `Enemy.heal()` (clamps at maxHp, green floating number, drives the boss HP bar) + instant `heal_percent_maxhp` action + new `hot` effect kind (`HotBehavior`, drift-free interval clock - exactly N ticks for duration N x interval).
- Registry: `magic_mult_down` (magic towers), `rest` (stun-kind self-freeze like royal_command), `rest_recovery` (5% max HP/s). `show_area: false` suppresses the duplicate red flash when one skill applies 2 effects to the same box.
- Giant Boar YAML: Super Charge (dash 2 cells, CD 12), Thick Skin (triggered <40% HP: rest 5s + DR 50% + heal 25% total + wake haste), Bulldoze (5x5, ALL towers -20% damage 8s); moveSpeed 100 -> 60 per design; dead skillCount/buffCount keys dropped.

**Implementation Notes:**
- Found while building HotBehavior: `DotBehavior` (`phoenix_flame`) under-ticks by one (last tick dies with the instance due to `last_tick = elapsed` drift). NOT fixed here - fixing changes live Kiara DOT damage, needs a balance pass. Documented in buff_debuff.md Problems/Plan.
- Drive-by: `is_instance_valid(user)` guard in `resetUsingSkill` - a host freed during a long mid-cast delay routed cancel into a freed instance (pre-existing; Thick Skin's 5s window widens it).
- User-tested in Godot 2026-07-09: all 3 skills, dash-leak, one-time trigger, single flash, both debuff types, King Salam regression - pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
