### PR TITLE
fix(effect): DOT final-tick drift + refresh re-snapshot

### DIFF
--- a/scripts/effect/behaviors/dot_behavior.gd
+++ b/scripts/effect/behaviors/dot_behavior.gd
@@ -5,6 +5,13 @@ extends EffectBehavior
 #     dmg = (value * snapshotAttack) + (params.max_hp_percent * target.maxHp)
 # where the instance `value` is the attack-percent knob.
 #
+# Ticks every params.interval seconds; a duration of N*interval yields exactly
+# N ticks (t = interval .. duration). The tick clock advances
+# `last_tick += interval` (never `= elapsed` - frame overshoot would
+# accumulate and drop the final tick); the container runs behavior.process
+# BEFORE the expiry check in the same tick() pass, so the last tick and expiry
+# share a frame with the tick first.
+#
 # Caster attack is snapshotted at apply (Dota Liquid Fire convention - locked
 # design): the DOT does not react to caster buffs applied after the cast, and
 # never holds a live caster reference.
@@ -20,7 +27,7 @@ func process(delta: float, host: Node, inst: EffectInstance) -> void:
 	var last := float(inst.snapshot.get("last_tick", 0.0))
 	if elapsed - last < interval:
 		return
-	inst.snapshot["last_tick"] = elapsed
+	inst.snapshot["last_tick"] = last + interval
 	if not (host is Enemy) or not is_instance_valid(host):
 		return
 	var enemy := host as Enemy

--- a/scripts/effect/effect_container.gd
+++ b/scripts/effect/effect_container.gd
@@ -40,6 +40,11 @@ func apply(inst: EffectInstance) -> EffectInstance:
 		# Both rules refresh the (shared) timer - player-favorable.
 		existing.duration = inst.duration
 		existing.remaining = inst.duration
+		# Re-adopt caster data captured at this application (e.g. the DOT
+		# attack snapshot - Liquid Fire: snapshot at EVERY apply). A fresh
+		# instance's snapshot holds only capture()-written keys, so runtime
+		# keys (tick clock, prev_modulate) are never clobbered.
+		existing.snapshot.merge(inst.snapshot, true)
 		_agg_cache.clear()
 		effect_updated.emit(existing)
 		_check_mark_threshold(existing)


### PR DESCRIPTION
**Problem:** DotBehavior advanced its tick clock to the current elapsed time (`last_tick = elapsed`), so per-frame overshoot accumulated and the final tick's due time drifted past the effect duration - the tick died with the instance. Kiara's Phoenix Flame (5s duration, 1s interval) delivered 4 ticks instead of the 5 its skill description promises. Bundled second bug: re-applying the same DOT refreshed value/duration but discarded the fresh caster snapshot, so a refreshed burn kept the attack value from the FIRST application.

**Impact:** Phoenix Flame total DOT damage ran ~20% below design on every cast, and skill text disagreed with actual behavior. If Kiara's attack changed mid-burn (e.g. Tempus quest buff), a re-hit kept ticking with the stale attack value.

**Fix:** Align DotBehavior's tick clock to the HotBehavior clock (`last_tick += interval`) - a duration of N*interval now yields exactly N ticks; EffectContainer already runs behavior process before the expiry check, so the final tick and expiry share a frame with the tick first. The container's refresh branch now overwrite-merges the fresh instance's capture snapshot (re-snapshot at every application, Dota Liquid Fire convention); runtime snapshot keys (tick clock, tint restore) are untouched because a fresh instance carries only capture()-written keys. Per-tick numbers unchanged by Director decision - the restored 5th tick matches the shipped desc. Note: a comment-only touch-up to `hot_behavior.gd` was excluded because that file is new in unmerged #89; one-line follow-up after #89 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
