### PR TITLE
chore(effect): fix stale hot_behavior header comment

### DIFF
--- a/scripts/effect/behaviors/hot_behavior.gd
+++ b/scripts/effect/behaviors/hot_behavior.gd
@@ -4,11 +4,12 @@ extends EffectBehavior
 # Heal-over-time (first user: Giant Boar rest_recovery). Per-tick heal:
 #     heal = params.max_hp_percent * host.maxHp
 # Ticks every params.interval seconds; a duration of N*interval yields exactly
-# N ticks (t = interval .. duration). Unlike DotBehavior's `last_tick = elapsed`
-# the tick clock advances `last_tick += interval`, so timing never drifts and
-# the final tick still lands: the container runs behavior.process BEFORE the
-# expiry check in the same tick() pass, and elapsed/remaining accumulate the
-# same deltas, so the last tick and expiry share a frame with the tick first.
+# N ticks (t = interval .. duration). The tick clock advances
+# `last_tick += interval` (same clock as DotBehavior), so timing never drifts
+# and the final tick still lands: the container runs behavior.process BEFORE
+# the expiry check in the same tick() pass, and elapsed/remaining accumulate
+# the same deltas, so the last tick and expiry share a frame with the tick
+# first.
 
 func process(delta: float, host: Node, inst: EffectInstance) -> void:
 	var interval := float(inst.param("interval", 1.0))


### PR DESCRIPTION
**Problem:** The `hot_behavior.gd` header comment still contrasts DotBehavior's old `last_tick = elapsed` tick clock - false since PR #90 aligned both behaviors to the same clock. The hunk was excluded from #90 because the file was new in the then-unmerged #89 (cherry-pick modify/delete conflict).

**Impact:** None in-game - comment-only, no executable line touched. Dev-facing accuracy only.

**Fix:** Reword the header: both behaviors share the exact-N-ticks clock. No Godot test needed (comment-only, Director pre-approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
