### PR TITLE
Mori Calliope full kit: Soul stacks, self-AOE, aftershock pattern

### DIFF
--- a/resources/database/effect/effects.yaml
+++ b/resources/database/effect/effects.yaml
@@ -15,7 +15,8 @@
 #   stack      refresh (default) | stack (Batrider-style stack counter)
 #   max_stacks stack rule only; 0 = unlimited
 #   duration   default seconds when the skill omits it; 0 = no self-expiry
-#   lifetime   wave (default; cleared at wave end) | board (synergy only)
+#   lifetime   wave (default; cleared at wave end) | board (run-long:
+#              synergy stat buffs + the Calliope soul counter)
 #   negate     true = apply as a reduction while the authored magnitude stays
 #              positive; for themed debuff ids without the _down suffix
 #   params     behavior extras (interval, tint_modulate, max_hp_percent, ...)
@@ -129,6 +130,23 @@ bull_eyes:
   stack: stack
   max_stacks: 0
   duration: 0
+
+# Mori Calliope Souls: run-permanent kill counter (board lifetime - survives
+# wave end and evolve; a new run rebuilds TowerData, which clears it). kind
+# mark = pure counter, no stat aggregation; skills read it live via the
+# attack action's stack_bonus keys (EffectContainer.stacks_of). First
+# non-synergy board-lifetime effect.
+soul:
+  name: "Souls"
+  desc: "Souls reaped: {value}. Each Soul strengthens Calliope's scythe skills."
+  icon: "ui_asset/effects/buff_generic.png"
+  category: buff
+  host: tower
+  kind: mark
+  stack: stack
+  max_stacks: 0
+  duration: 0
+  lifetime: board
 
 # ---- Tower debuffs (enemy/boss auras) ----
 

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -77,6 +77,8 @@ skills:
         data:
           width: 3
           height: 1
+          # center_on_self: true  # optional — กล่องวางกึ่งกลางตัว tower แกนตรง ไม่หมุนตามเป้า
+          #                       # (สกิลตีรอบตัว เช่น 3x3 ของ Calliope) ไม่ใส่ = กล่องพุ่งหาเป้าแบบเดิม
       - type: play_animation
         data:
           animation: "skill"
@@ -112,6 +114,12 @@ skills:
           #     data:
           #       damage_multiplier: [1.4, 1.5, 1.7]
           #       can_crit: false
+          #
+          # stack_bonus_effect + stack_bonus_per_stack_param_name:
+          #   สกิลสเกลตาม stack (เช่น Soul ของ Calliope) — ตัวคูณเพิ่มขึ้น
+          #   จำนวน stack ของ effect id นั้นบน tower x ค่าต่อ stack (อ่านสดตอนตี)
+          #   ตัวอย่าง: stack_bonus_effect: "soul"
+          #             stack_bonus_per_stack_param_name: "soulBonus"
           # ─────────────────────────────────────────────────────────────────
       - type: play_animation
         data:
@@ -158,6 +166,23 @@ skills:
       #     - type: play_animation
       #       data:
       #         animation: "idle"
+      # ─────────────────────────────────────────────────────────────────
+      # AFTERSHOCK (ระเบิดตามหลัง ไม่บล็อกการตี) — ของจริงดู mori_calliope.yaml
+      #
+      #   วางไว้หลัง attack แรก: action นี้วางระเบิดแล้วจบ cast ทันที tower
+      #   กลับไปตีต่อได้ระหว่างรอ ครบ delay แล้วพื้นที่เดิม (กึ่งกลางตำแหน่ง
+      #   ตอน cast) ระเบิดซ้ำด้วยการหาเป้าใหม่สด — คีย์ damage/crit/stack_bonus
+      #   ชุดเดียวกับ attack ใช้ในระเบิดได้หมด
+      #
+      #   - type: aftershock
+      #     data:
+      #       delay_param_name: "aftershockDelay"   # หรือใส่ delay: 0.5 ตรง ๆ
+      #       width: 3
+      #       height: 3
+      #       damage_multiplier_param_name: "aftershockDamage"
+      #       damage_type: physic
+      #       stack_bonus_effect: "soul"
+      #       stack_bonus_per_stack_param_name: "aftershockSoulBonus"
       # ─────────────────────────────────────────────────────────────────
   passive: null
 

--- a/resources/database/towers/mori_calliope.yaml
+++ b/resources/database/towers/mori_calliope.yaml
@@ -4,14 +4,13 @@ generation: myth
 attackType: physic
 evolutionCost: 1
 
-# skill: "res://resources/database/skill/gawr_gura_skill.tres"
-attack_sound: "hit_calliope"
+attack_sound: "hit_caliope"   # enum key is hit_caliope (sound_database.gd) - the old "hit_calliope" fell back to the generic hit with an error per attack
 open_sound: "debut_caliope"
 evolve_sound: "evo_caliope"
 
 stats:
   - damage: 80
-    attackRange: 2.0
+    attackRange: 1.0
     attackSpeed: 100
     mana: 40
     initialMana: 10
@@ -19,7 +18,7 @@ stats:
     critMultiplier: 1.5
 
   - damage: 100
-    attackRange: 2.0
+    attackRange: 1.0
     attackSpeed: 100
     mana: 40
     initialMana: 10
@@ -27,38 +26,160 @@ stats:
     critMultiplier: 1.5
 
   - damage: 140
-    attackRange: 2.0
+    attackRange: 1.0
     attackSpeed: 100
     mana: 40
     initialMana: 10
     critChance: 0
     critMultiplier: 1.5
 
-skill:
-  name: "Skill"
-  desc: "Just a skill"
-  recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
-  actions:
-    - type: find_multi_enemy
-      data:
-        width: 3
-        height: 1
-    - type: play_animation
-      data:
-        animation: "skill"
-    - type: attack
-      data:
-        damage: 100
-        damage_type: physic
-    - type: play_animation
-      data:
-        animation: "idle"
+# Active Skill - "Ricky": self-centered 3x3 scythe sweep that scales with
+# Souls. Reference example for: center_on_self + attack stack_bonus keys.
+# Souls themselves are granted by the "Soul Harvest" passive below.
+skills:
+  active:
+    name: "Ricky"
+    names: ["Ricky I", "Ricky II", "Ricky III"]
+    desc: "Calliope sweeps her scythe Ricky through the 3x3 area around her, dealing heavy physical damage that grows with every Soul she holds. Each enemy killed by this skill grants her 1 Soul, kept for the whole run."
+    desc_template: "Calliope sweeps her scythe Ricky through the 3x3 area around her, dealing {skillDamage:percent} physical damage plus {soulBonus:percent} more per Soul she holds. Each enemy killed by this skill grants her 1 Soul, kept for the whole run."
+    icon: ""
+    tags:
+      - damage
+      - attack
+      - aoe
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Scythe Sweep"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    recovery: 0.2 # post-cast hold (s) before resuming attack - see default_tower.yaml
+    parameters:
+      skillDamage:
+        - 1.2
+        - 1.3
+        - 1.4
+      soulBonus: 0.05
+    actions:
+      - type: find_multi_enemy
+        data:
+          width: 3
+          height: 3
+          center_on_self: true        # box centered on Calliope, hits all sides
+      - type: play_animation
+        data:
+          animation: "skill"
+          duration: 0.5
+      - type: attack
+        data:
+          damage_multiplier_param_name: "skillDamage"
+          damage_type: physic
+          stack_bonus_effect: "soul"                    # registry id (effects.yaml)
+          stack_bonus_per_stack_param_name: "soulBonus" # live count at execute
+      - type: play_animation
+        data:
+          animation: "idle"
+  # Passive - grants the Souls the active spends. Run-permanent by design:
+  # Souls survive wave end AND evolve (Director 2026-07-12).
+  passive:
+    name: "Soul Harvest"
+    desc: "Enemies killed by Calliope's skills each grant her a Soul. Souls last the whole run and strengthen her scythe skills."
+    desc_template: "Enemies killed by Calliope's skills each grant her {soulsPerKill} Soul. Souls last the whole run and strengthen her scythe skills."
+    icon: ""
+    tags:
+      - buff
+      - self
+    target_summary:
+      target_team: self
+      target_type: tower
+      target_shape: single
+    effects:
+      - name: "Soul Stacking"
+        target:
+          target_team: self
+          target_type: tower
+          target_shape: single
+    parameters:
+      soulsPerKill: 1
+    behavior: "soul_harvest"
 
 evolutionStat:
   damage: 200
-  attackRange: 2.0
+  attackRange: 1.0
   attackSpeed: 120
   mana: 80
   initialMana: 40
   critChance: 50.0
   critMultiplier: 1.5
+
+# Evolved Active Skill - the first hit plants an "aftershock": 0.5s later the
+# same ground erupts again WITHOUT interrupting Calliope (she resumes
+# attacking during the delay). Souls are counted live at each hit, so kills
+# by the first hit strengthen the aftershock immediately.
+evolution_skills:
+  active:
+    name: "Excuse My Rudeness, But Could You Please RIP?"
+    desc: "Calliope reaps the 3x3 area around her with massive physical damage, and moments later the same ground erupts again. Both hits grow with her Souls, and each enemy killed grants her 1 Soul."
+    desc_template: "Calliope reaps the 3x3 area around her for {skillDamage:percent} physical damage plus {soulBonus:percent} per Soul. {aftershockDelay}s later the same ground erupts for {aftershockDamage:percent} physical damage plus {aftershockSoulBonus:percent} per Soul she holds at that moment. Each enemy killed grants her 1 Soul."
+    icon: ""
+    tags:
+      - damage
+      - attack
+      - aoe
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Reaping Blow"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+      - name: "Soul Aftershock"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    recovery: 0.2 # post-cast hold (s) before resuming attack - see default_tower.yaml
+    parameters:
+      skillDamage: 2.0
+      soulBonus: 0.05
+      aftershockDamage: 1.0
+      aftershockSoulBonus: 0.025
+      aftershockDelay: 0.5
+    actions:
+      - type: find_multi_enemy
+        data:
+          width: 3
+          height: 3
+          center_on_self: true
+      - type: play_animation
+        data:
+          animation: "skill"
+          duration: 0.5
+      - type: attack
+        data:
+          damage_multiplier_param_name: "skillDamage"
+          damage_type: physic
+          stack_bonus_effect: "soul"
+          stack_bonus_per_stack_param_name: "soulBonus"
+      - type: aftershock                 # plants the bomb and returns - does NOT block the tower
+        data:
+          delay_param_name: "aftershockDelay"
+          width: 3
+          height: 3
+          damage_multiplier_param_name: "aftershockDamage"
+          damage_type: physic
+          stack_bonus_effect: "soul"
+          stack_bonus_per_stack_param_name: "aftershockSoulBonus"
+      - type: play_animation
+        data:
+          animation: "idle"
+  # Empty evolved passive -> the loader falls back to the base Soul Harvest
+  # passive (tower.gd _setupPassive), so Souls keep accruing after evolve.
+  passive: null

--- a/resources/database/towers/mori_calliope.yaml
+++ b/resources/database/towers/mori_calliope.yaml
@@ -110,7 +110,7 @@ skills:
 evolutionStat:
   damage: 200
   attackRange: 1.0
-  attackSpeed: 120
+  attackSpeed: 100
   mana: 80
   initialMana: 40
   critChance: 50.0

--- a/scripts/effect/effect_container.gd
+++ b/scripts/effect/effect_container.gd
@@ -118,6 +118,16 @@ func clear_all() -> void:
 		_remove_instance(inst)
 	_mark_thresholds.clear()
 
+# Total stacks of one effect id across all sources, any category - generic
+# stack-counter reader (e.g. the Calliope soul buff; mark_stacks below is
+# MARK-category only).
+func stacks_of(effect_id: String) -> int:
+	var total := 0
+	for inst: EffectInstance in _effects.values():
+		if inst.def.id == effect_id:
+			total += inst.stacks
+	return total
+
 # ---- Mark API (framework; no consumer tower yet - see buff_debuff.md) ----
 
 func has_mark(effect_id: String) -> bool:

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -100,6 +100,11 @@ func _hasActiveSkill() -> bool:
 func _setupPassive() -> void:
 	if passive != null:
 		passive.reset();
+		# Detach external listeners (e.g. PassiveSoulHarvest's kill signal)
+		# before the rebuild - the connection keeps the old RefCounted alive,
+		# and a leaked listener would double its effect after evolve.
+		if passive.has_method("dispose"):
+			passive.dispose();
 		passive = null;
 
 	var params: Dictionary = data.evolutionPassive if data.isEvolved and not data.evolutionPassive.is_empty() else data.passive;
@@ -109,6 +114,8 @@ func _setupPassive() -> void:
 	match str(params.get("behavior", "")):
 		"crit_pierce":
 			passive = PassiveCritPierce.new(self, params);
+		"soul_harvest":
+			passive = PassiveSoulHarvest.new(self, params);
 		_:
 			push_warning("Tower '" + towerName + "': unknown passive behavior '" + str(params.get("behavior", "")) + "'");
 
@@ -411,6 +418,8 @@ func remove_effect_source(source_id: String) -> void:
 # this node: clear wave-scoped effects when the tower leaves the board so a
 # re-placed tower never resumes a frozen buff (plan F3).
 func _exit_tree():
+	if passive != null and passive.has_method("dispose"):
+		passive.dispose()
 	if data != null:
 		data.effects.clear_wave_scoped()
 		if data.effects.get_host() == self:

--- a/scripts/skill/passive/passive_soul_harvest.gd
+++ b/scripts/skill/passive/passive_soul_harvest.gd
@@ -1,0 +1,62 @@
+class_name PassiveSoulHarvest
+extends RefCounted
+
+# Soul-harvest passive (Mori Calliope): +soulsPerKill Soul per enemy KILLED BY
+# HER SKILLS. Attribution: skill attacks (including the aftershock's inner
+# attack) stamp Damage.source = the casting tower, while normal hitscan
+# attacks stamp null (tower_data.calculateFinalDamage), so
+# cause.source == tower is exact skill-kill attribution for this kit.
+#
+# Souls are run-permanent by design (Director 2026-07-12): board lifetime, no
+# cap, kept across wave end AND evolve - reset() is deliberately a no-op (do
+# NOT copy PassiveCritPierce.reset(), which drops its stacks).
+
+const SOUL_EFFECT := "soul"
+# FIXED source id: identity = source_id + "/" + def.id must stay the same when
+# the skill name changes on evolve (Ricky -> RIP), or the stacks would fork.
+const SOUL_SOURCE := "calli_souls"
+
+var tower: Tower
+var souls_per_kill: int = 1
+var _wave_controller: Node = null
+
+func _init(owner: Tower, params: Dictionary) -> void:
+	tower = owner
+	var parameters: Dictionary = params.get("parameters", {})
+	souls_per_kill = int(parameters.get("soulsPerKill", 1))
+	_wave_controller = tower.get_tree().get_first_node_in_group("wave_controller")
+	if _wave_controller != null:
+		Utility.ConnectSignal(_wave_controller, "onEnemyDead", Callable(self, "_on_enemy_dead"))
+
+func _on_enemy_dead(_enemy, cause: Damage, _reward) -> void:
+	if cause == null or not is_instance_valid(tower) or cause.source != tower:
+		return
+	for i in souls_per_kill:
+		var inst := EffectUtility.make_instance(SOUL_EFFECT, SOUL_SOURCE, 1.0, 0.0)
+		if inst != null:
+			tower.data.effects.apply(inst)
+
+# ---- Tower passive contract (tower.gd calls these on any non-null passive) ----
+
+func replaces_attack_on_crit() -> bool:
+	return false
+
+func on_normal_attack() -> void:
+	pass
+
+func on_crit_attack(_target: Enemy) -> void:
+	pass
+
+# Wave reset / passive rebuild hook: Souls persist - no-op by design (header).
+func reset() -> void:
+	pass
+
+# Detach from the wave controller. The signal connection holds this RefCounted
+# alive, so without this the evolve-time _setupPassive rebuild would leave the
+# old listener connected = double Souls per kill.
+func dispose() -> void:
+	if _wave_controller != null and is_instance_valid(_wave_controller):
+		var cb := Callable(self, "_on_enemy_dead")
+		if _wave_controller.is_connected("onEnemyDead", cb):
+			_wave_controller.disconnect("onEnemyDead", cb)
+	_wave_controller = null

--- a/scripts/skill/skillActions/skill_action_aftershock.gd
+++ b/scripts/skill/skillActions/skill_action_aftershock.gd
@@ -1,0 +1,83 @@
+class_name SkillActionAftershock
+extends SkillAction
+
+# "aftershock" execution pattern (tower_skill.md): the cast plants a delayed
+# re-hit of the SAME area and returns immediately - the tower resumes normal
+# behavior while the bomb waits. Everything resolves at EXPLOSION time: fresh
+# target query at the snapshotted cast-time center, live Total Attack, live
+# crit chance, live stack bonus (e.g. Calliope Souls raised by the first
+# hit's kills). First user: Mori Calliope evolved skill.
+
+@export var delay: float = 0.5
+@export var width: int = 3
+@export var height: int = 3
+# Inner actions built at parse time from the same data block (skill_utility.gd)
+# so the explosion reuses the full find/attack pipelines.
+var find_action: SkillActionFindMultipleInRange
+var attack_action: SkillActionAttack
+
+func execute(context: SkillContext):
+	var tower: Tower = context.user as Tower
+	if tower == null or find_action == null or attack_action == null:
+		return
+	var timer := AftershockTimer.new()
+	timer.setup(self, tower, tower.skill_lock_generation, tower.global_position,
+			context.extra.get("parameter", {}), context.skillName)
+	tower.add_child(timer)
+	# No await: the cast finishes normally while the bomb counts down.
+
+# One-shot countdown node. The _process delta freezes with pause and scales
+# with x2 speed (same clock as the effect system); a SceneTree create_timer
+# keeps counting while paused - do not swap this for one.
+class AftershockTimer:
+	extends Node2D
+
+	var action: SkillActionAftershock
+	var tower: Tower
+	var gen: int
+	var center: Vector2
+	var params: Dictionary
+	var skill_name: String
+	var elapsed: float = 0.0
+	var fired: bool = false
+
+	func setup(p_action: SkillActionAftershock, p_tower: Tower, p_gen: int,
+			p_center: Vector2, p_params: Dictionary, p_skill_name: String) -> void:
+		action = p_action
+		tower = p_tower
+		gen = p_gen
+		center = p_center
+		params = p_params
+		skill_name = p_skill_name
+
+	func _process(delta: float) -> void:
+		# resetForWave() bumps skill_lock_generation, so a bomb pending at wave
+		# end (or from any stale cast) drops silently instead of exploding into
+		# the next wave.
+		if not is_instance_valid(tower) or tower.skill_lock_generation != gen:
+			queue_free()
+			return
+		if fired:
+			return
+		elapsed += delta
+		if elapsed >= action.delay:
+			# Must flip BEFORE _fire's awaits: _process keeps ticking during the
+			# Hitbox physics-frame await and would re-enter = double explosion.
+			fired = true
+			_fire()
+
+	func _fire() -> void:
+		var ctx := SkillContext.new()
+		ctx.user = tower
+		ctx.skillName = skill_name
+		ctx.extra["parameter"] = params
+		# Snapshotted cast-time center -> the finder's centered override path
+		# (axis-aligned box, same query the Staff player-aim uses).
+		ctx.extra["target_position"] = center
+		await action.find_action.execute(ctx)
+		if not is_instance_valid(tower) or tower.skill_lock_generation != gen:
+			queue_free()
+			return
+		if not ctx.target.is_empty():
+			await action.attack_action.execute(ctx)
+		queue_free()

--- a/scripts/skill/skillActions/skill_action_attack.gd
+++ b/scripts/skill/skillActions/skill_action_attack.gd
@@ -32,6 +32,12 @@ class_name SkillActionAttack
 # state never bleeds between enemies.
 @export var statusEffects: Array[EffectSpec] = []
 
+# Stack-scaling bonus: adds (caster's stacks of an effect id) x per-stack value
+# to the Skill Multiplier, read at execute time so the count is always live
+# (e.g. Calliope Souls). Generic - a stack-scaling tower authors YAML only.
+@export var stackBonusEffectId: String = ""
+@export var stackBonusPerStack: float = 0.0
+
 func execute(context: SkillContext):
 	var tower: Tower = context.user as Tower
 
@@ -47,6 +53,10 @@ func execute(context: SkillContext):
 	if damageMultiplierPerLevel.size() > 0:
 		var idx: int = clampi(tower.data.level - 1, 0, damageMultiplierPerLevel.size() - 1)
 		mult = damageMultiplierPerLevel[idx]
+
+	# Stack-scaling bonus (live count at execute time - see export note above)
+	if stackBonusEffectId != "" and stackBonusPerStack != 0.0:
+		mult += float(tower.data.effects.stacks_of(stackBonusEffectId)) * stackBonusPerStack
 
 	# Resolve hits — empty distribution = single hit
 	var hits: Array[float] = hitDistribution if hitDistribution.size() > 0 else ([1.0] as Array[float])

--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -4,6 +4,10 @@ class_name SkillActionFindMultipleInRange
 @export var width: int = 1 # Width in cells
 @export var height: int = 2 # Height in cells
 var cancel_when_empty: bool = true
+# Self-centered grid AOE (e.g. Calliope scythe): axis-aligned box centered on
+# the caster, no aim rotation or forward extend. A target_position override
+# in context.extra still wins (it re-centers the same box elsewhere).
+var center_on_self: bool = false
 
 var target_group: String = "enemy" # Group name for potential targets
 var max_attempt := 1
@@ -39,6 +43,10 @@ func find_targets_in_rotated_range(context: SkillContext):
 	var override_position = context.extra.get("target_position", null)
 	if override_position != null and override_position is Vector2:
 		user_position = override_position
+		user_rotation = 0.0
+		center_on_anchor = true
+	elif center_on_self:
+		# Same centered/axis-aligned query as the override, anchored on the caster.
 		user_rotation = 0.0
 		center_on_anchor = true
 	elif context.user is Tower:

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -146,6 +146,14 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 				skill.hitDistribution = hdArr
 			skill.canCrit = skillData.get("can_crit", true)
 			skill.forcedCrit = skillData.get("force_crit", false)
+			# Stack-scaling bonus (e.g. Calliope Souls): + stacks x per-stack
+			# value on the multiplier, count read live at execute time.
+			skill.stackBonusEffectId = str(skillData.get("stack_bonus_effect", ""))
+			var sbParam = skillData.get("stack_bonus_per_stack_param_name", "")
+			if sbParam != "" and parameters.has(sbParam):
+				skill.stackBonusPerStack = float(parameters[sbParam])
+			else:
+				skill.stackBonusPerStack = float(skillData.get("stack_bonus_per_stack", 0.0))
 			if skillData.has("damage_type"):
 				skill.damageType = Utility.parse_string_to_enum(Damage.DamageType, skillData["damage_type"])
 				skill.damageTypeOverride = true
@@ -154,6 +162,26 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			var attackEffectList = skillData.get("effects", []);
 			if attackEffectList.size() > 0:
 				skill.statusEffects = EffectUtility.parse_effect_list(attackEffectList, parameters, "action_" + str(skill.get_instance_id()));
+		"aftershock":
+			# Delayed non-blocking re-hit of a snapshotted area ("aftershock"
+			# pattern - tower_skill.md). The inner find/attack are built from
+			# this same data block via this parser, so damage_multiplier_param_name,
+			# damage_type, can_crit, and stack_bonus_* all work in the explosion.
+			skill = SkillActionAftershock.new();
+			var skillData = data.get("data", {});
+			skill.width = int(skillData.get("width", 3));
+			skill.height = int(skillData.get("height", 3));
+			var delayParam = skillData.get("delay_param_name", "");
+			if delayParam != "" and parameters.has(delayParam):
+				skill.delay = float(parameters[delayParam]);
+			else:
+				skill.delay = float(skillData.get("delay", 0.5));
+			var findAction := SkillActionFindMultipleInRange.new();
+			findAction.width = skill.width;
+			findAction.height = skill.height;
+			findAction.cancel_when_empty = false;
+			skill.find_action = findAction;
+			skill.attack_action = ParseAction({"type": "attack", "data": skillData}, parameters) as SkillActionAttack;
 		"clear_enemy":
 			skill = SkillActionClearEnemy.new();
 		"find_multi_enemy":
@@ -162,6 +190,8 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill.width = skillData.get("width", 1);
 			skill.height = skillData.get("height", 1);
 			skill.cancel_when_empty = skillData.get("cancel_when_empty", true);
+			# Self-centered axis-aligned box (no aim rotation/forward extend).
+			skill.center_on_self = skillData.get("center_on_self", false);
 		"dash":
 			# Path dash: slide the casting enemy forward along its path.
 			skill = SkillActionDash.new();


### PR DESCRIPTION
**Summary:** Full Mori Calliope kit - the game's first stack-scaling tower (run-permanent "Souls") plus a new reusable skill pattern: **aftershock** (delayed re-hit that does not block the tower).

**How it works:**
- `Ricky I-III` (active): self-centered 3x3 scythe sweep via a new `center_on_self` flag on `find_multi_enemy` (reuses the Staff centered-query path). Damage multiplier = `skillDamage` + Souls x 0.05, read live at execute via new generic `attack` keys `stack_bonus_effect` / `stack_bonus_per_stack_param_name` (next stack-scaling tower is YAML-only).
- `Soul Harvest` (passive, new `soul_harvest` behavior): +1 Soul per enemy killed by her skills. Attribution = `Damage.source == tower` (skill attacks stamp the tower; normal attacks stamp null). Souls live in the effect registry (`soul`: `stack`, `kind: mark`, `lifetime: board`) - run-permanent by design: survive wave end AND evolve, no cap; new run resets. Stack count renders on the existing effect icon row.
- Evolved `RIP` skill: first hit 2.0 + Souls x 0.05, then a 0.5s **aftershock** (new `SkillAction` + one-shot `_process`-clock timer node): the cast ends normally and the tower resumes auto-attack while the bomb waits; at explosion it re-queries the same snapshotted 3x3 live (fresh targets, live Total Attack/crit/Soul count - first-hit kills already count).
- Extension points: `aftershock` accepts the full `attack` key set inside its block; `EffectContainer.stacks_of()` is a generic any-category stack reader.

**Implementation Notes:**
- Timer node deliberately uses `_process` delta, NOT `create_timer`: it must freeze on pause and scale with x2 (SceneTree timers keep counting while paused). Generation-guarded (`skill_lock_generation`) so a bomb pending at wave end dies silently; `fired` flag set before the Hitbox await to prevent a double explosion.
- `tower.gd` now calls a guarded `passive.dispose()` on passive rebuild/`_exit_tree`: the kill-signal connection holds the old RefCounted passive alive, and without dispose an evolved Calli would earn 2 Souls per kill.
- `PassiveSoulHarvest.reset()` is a deliberate no-op (Souls are run-permanent) - do not "fix" it to match Shinri's stack reset.
- Sound-key fix: `hit_calliope` -> `hit_caliope` (was falling back to the generic hit with an error logged per attack; audibly identical today).
- Director post-test tune included: evolve attack speed 120 -> 100.
- Docs updated in the claude-state repo: `tower_skill.md` (aftershock model + DSL keys), `buff_debuff.md` (first non-synergy BOARD effect). VFX for this kit is a separate future task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
