### PR TITLE
Ninomae Ina'nis tower + channel skill pattern

### DIFF
--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -184,6 +184,27 @@ skills:
       #       stack_bonus_effect: "soul"
       #       stack_bonus_per_stack_param_name: "aftershockSoulBonus"
       # ─────────────────────────────────────────────────────────────────
+      # CHANNEL (ร่ายค้าง ฟาดโซนเดิมซ้ำเป็นจังหวะ) — ของจริงดู ninomae_ina_nis.yaml
+      #
+      #   วางต่อจาก find_multi_enemy แรก: โซนล็อกที่จุดเล็งตอนเริ่มร่าย tower
+      #   ค้าง (ไม่ตีปกติ) จน channel จบ แต่ละ tick หาเป้าใหม่สดในโซนเดิม
+      #   ตีทั้งโซน — คีย์ damage/crit/effects ชุดเดียวกับ attack ใช้ได้หมด
+      #   ยกเลิกกลางคัน (จบเวฟ) = หยุดฟาดทันที ไม่กิน Energy
+      #
+      #   - type: channel
+      #     data:
+      #       width: 3
+      #       height: 3
+      #       duration_param_name: "channelDuration"      # หรือ duration: 3.0 ตรง ๆ
+      #       tick_interval_param_name: "tickInterval"    # หรือ tick_interval: 0.25 ตรง ๆ
+      #       animation: "skill"                          # คลิปร่าย เล่นค้างตลอด channel
+      #       damage_multiplier_param_name: "tickDamage"
+      #       damage_type: magic
+      #       can_crit: false
+      #       effects:
+      #         - effect: "stun"
+      #           duration_param: "tickStun"
+      # ─────────────────────────────────────────────────────────────────
   passive: null
 
 # evolutionStat = stat ตอน evolve (block เดียว ไม่ใช่ array)

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -10,7 +10,7 @@ evolve_sound: "evo_ina"
 
 stats:
   - damage: 140
-    attackRange: 4.0
+    attackRange: 3.0
     attackSpeed: 60
     mana: 100
     initialMana: 60
@@ -18,7 +18,7 @@ stats:
     critMultiplier: 1.5
 
   - damage: 160
-    attackRange: 4.0
+    attackRange: 3.0
     attackSpeed: 60
     mana: 100
     initialMana: 60
@@ -26,7 +26,7 @@ stats:
     critMultiplier: 1.5
 
   - damage: 200
-    attackRange: 4.0
+    attackRange: 3.0
     attackSpeed: 60
     mana: 100
     initialMana: 60
@@ -45,6 +45,7 @@ skills:
       - damage
       - aoe
       - stun
+      - duration
     target_summary:
       target_team: enemy
       target_type: enemy
@@ -101,14 +102,15 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Book of Ancient Ones"
-    desc: "Ina'nis opens the Book of Ancient Ones and channels its power for 3 seconds, striking the 3x3 area in front of her every 0.25 seconds. Each strike deals magic damage and stuns enemies caught in the zone for 1 second. These strikes never critically hit."
-    desc_template: "Ina'nis opens the Book of Ancient Ones and channels its power for {channelDuration} seconds, striking the 3x3 area in front of her every {tickInterval} seconds. Each strike deals {tickDamage:percent} magic damage and stuns enemies caught in the zone for {tickStun}s. These strikes never critically hit."
+    desc: "Ina'nis opens the Book of Ancient Ones and channels its power for 3 seconds, striking the 3x3 area in front of her every 0.25 seconds. Each strike deals magic damage and stuns enemies caught in the zone for 1 second."
+    desc_template: "Ina'nis opens the Book of Ancient Ones and channels its power for {channelDuration} seconds, striking the 3x3 area in front of her every {tickInterval} seconds. Each strike deals {tickDamage:percent} magic damage and stuns enemies caught in the zone for {tickStun}s."
     icon: ""
     tags:
       - damage
       - aoe
       - stun
       - channel
+      - duration
     target_summary:
       target_team: enemy
       target_type: enemy

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -4,7 +4,6 @@ generation: myth
 attackType: magic
 evolutionCost: 1
 
-# skill: "res://resources/database/skill/gawr_gura_skill.tres"
 attack_sound: "hit_ina"
 open_sound: "debut_ina"
 evolve_sound: "evo_ina"
@@ -34,28 +33,117 @@ stats:
     critChance: 0
     critMultiplier: 1.5
 
-skill:
-  name: "Skill"
-  desc: "Just a skill"
-  recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
-  actions:
-    - type: "create_circle_projectile"
-      data:
-        circle_radius: 1.0
-        angular_speed: 180.0
-        initial_angle: 0.0
-        angle_offset: 90.0
-        lifetime: 5.0
-        count: 4
-        damage_multiplier: 1.0
-        damage_type: "magic"
-        damage_multiplier_param_name: "damageMultiplier"
+# Active Skill - "Tentacle": aimed 1x3 tentacle lash with a stun.
+skills:
+  active:
+    name: "Tentacle"
+    names: ["Tentacle I", "Tentacle II", "Tentacle III"]
+    desc: "Ina'nis commands a tentacle of the Ancient One to lash the 1x3 line in front of her, dealing heavy magic damage and stunning every enemy hit for 1.5 seconds."
+    desc_template: "Ina'nis commands a tentacle of the Ancient One to lash the 1x3 line in front of her, dealing {skillDamage:percent} magic damage and stunning every enemy hit for {stunDuration}s."
+    icon: ""
+    tags:
+      - damage
+      - aoe
+      - stun
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Tentacle Lash"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    recovery: 0.2 # post-cast hold (s) before resuming attack - see default_tower.yaml
+    parameters:
+      skillDamage:
+        - 2.0
+        - 2.4
+        - 3.0
+      stunDuration: 1.5
+    actions:
+      - type: find_multi_enemy
+        data:
+          width: 1
+          height: 3
+      - type: play_animation
+        data:
+          animation: "skill"
+          duration: 0.5
+      - type: attack
+        data:
+          damage_multiplier_param_name: "skillDamage"
+          damage_type: magic
+          effects:
+            - effect: "stun"
+              duration_param: "stunDuration"
+      - type: play_animation
+        data:
+          animation: "idle"
+  passive: null
 
 evolutionStat:
   damage: 500
   attackRange: 4.0
-  attackSpeed: 80
+  attackSpeed: 60
   mana: 100
   initialMana: 60
   critChance: 50.0
   critMultiplier: 1.5
+
+# Evolved Active Skill - the game's first "channel" pattern skill: Ina'nis
+# locks the 3x3 zone in front of her and strikes it 12 times over 3 seconds
+# (every 0.25s), stunning enemies caught inside on every strike. She is busy
+# for the whole channel (no auto-attack). The ticks NEVER crit by design;
+# the evolved BASE stat keeps critChance 50 for her normal attacks
+# (stat-consistency verdict, Director 2026-07-14).
+evolution_skills:
+  active:
+    name: "Book of Ancient Ones"
+    desc: "Ina'nis opens the Book of Ancient Ones and channels its power for 3 seconds, striking the 3x3 area in front of her every 0.25 seconds. Each strike deals magic damage and stuns enemies caught in the zone for 1 second. These strikes never critically hit."
+    desc_template: "Ina'nis opens the Book of Ancient Ones and channels its power for {channelDuration} seconds, striking the 3x3 area in front of her every {tickInterval} seconds. Each strike deals {tickDamage:percent} magic damage and stuns enemies caught in the zone for {tickStun}s. These strikes never critically hit."
+    icon: ""
+    tags:
+      - damage
+      - aoe
+      - stun
+      - channel
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Ancient Onslaught"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    recovery: 0.2 # post-cast hold (s) before resuming attack - see default_tower.yaml
+    parameters:
+      tickDamage: 1.5
+      tickStun: 1.0
+      channelDuration: 3.0
+      tickInterval: 0.25
+    actions:
+      - type: find_multi_enemy       # cast-start aim: cancels (Energy kept) if empty; publishes area_center
+        data:
+          width: 3
+          height: 3
+      - type: channel                # BLOCKS for channelDuration; re-strikes the locked zone every tick
+        data:
+          width: 3
+          height: 3
+          duration_param_name: "channelDuration"
+          tick_interval_param_name: "tickInterval"
+          animation: "skill"
+          damage_multiplier_param_name: "tickDamage"
+          damage_type: magic
+          can_crit: false            # channel ticks never crit (base-stat crit stays for normal attacks)
+          effects:
+            - effect: "stun"
+              duration_param: "tickStun"
+      - type: play_animation
+        data:
+          animation: "idle"
+  passive: null

--- a/scripts/skill/skillActions/skill_action_channel.gd
+++ b/scripts/skill/skillActions/skill_action_channel.gd
@@ -1,0 +1,140 @@
+class_name SkillActionChannel
+extends SkillAction
+
+# "channel" execution pattern (tower_skill.md): the cast locks the aimed zone
+# and holds the tower busy for `duration` seconds while re-striking that zone
+# every `tick_interval`. BLOCKING - execute() awaits until the channel ends, so
+# the controller keeps usingSkill true and Energy drains only at onSuccess
+# (a wave-end cancel keeps Energy). Each tick resolves fresh: live target
+# query at the locked center, live Total Attack, effects re-applied (REFRESH).
+# First user: Ninomae Ina'nis evolved skill.
+
+@export var duration: float = 3.0
+@export var tick_interval: float = 0.25
+@export var width: int = 3
+@export var height: int = 3
+@export var animation: String = "skill"
+# Inner actions built at parse time from the same data block (skill_utility.gd)
+# so every tick reuses the full find/attack pipelines.
+var find_action: SkillActionFindMultipleInRange
+var attack_action: SkillActionAttack
+# Optional per-tick VFX hook (parity with aftershock); unset = the find's red
+# Hitbox rect is the visible tick flash.
+var effect_action: SkillActionPlayEffect
+
+func execute(context: SkillContext):
+	var tower: Tower = context.user as Tower
+	if tower == null or find_action == null or attack_action == null:
+		return
+	# Zone center locked at cast start: the skill's first find_multi_enemy
+	# published the world center of the box it queried. Fallbacks mirror the
+	# finder's own aimed-mode math in case the key is ever absent.
+	var center: Vector2 = tower.global_position
+	var area_center = context.extra.get("area_center", null)
+	if area_center is Vector2:
+		center = area_center
+	else:
+		var aim_dir = context.extra.get("aim_dir", null)
+		if aim_dir is Vector2:
+			var rot: float = aim_dir.angle() - PI / 2
+			var actual_height: float = height * GridHelper.CELL_SIZE + (GridHelper.CELL_SIZE * 0.5)
+			center = tower.global_position + Vector2(0, actual_height * 0.5).rotated(rot)
+	# Cast clip plays once, no await - a looping clip (the base tower "skill"
+	# clip loops) runs for the whole channel; the skill's trailing idle
+	# play_animation action restores idle after.
+	if tower.has_animation(animation):
+		tower.play_animation(animation)
+	var ticker := ChannelTicker.new()
+	ticker.setup(self, tower, tower.skill_lock_generation, center,
+			context.extra.get("parameter", {}), context.skillName)
+	tower.add_child(ticker)
+	# The blocking hold: every ticker exit path emits finished exactly once,
+	# so this await can never hang.
+	await ticker.finished
+
+# Tick clock node. The _process delta freezes with pause and scales with x2
+# speed (same clock as aftershock/the effect system); a SceneTree create_timer
+# keeps counting while paused - do not swap this for one.
+class ChannelTicker:
+	extends Node2D
+
+	var action: SkillActionChannel
+	var tower: Tower
+	var gen: int
+	var center: Vector2
+	var params: Dictionary
+	var skill_name: String
+	var elapsed: float = 0.0
+	var ticks_fired: int = 0
+	var total_ticks: int = 0
+	var in_flight: int = 0
+	var done: bool = false
+
+	signal finished
+
+	func setup(p_action: SkillActionChannel, p_tower: Tower, p_gen: int,
+			p_center: Vector2, p_params: Dictionary, p_skill_name: String) -> void:
+		action = p_action
+		tower = p_tower
+		gen = p_gen
+		center = p_center
+		params = p_params
+		skill_name = p_skill_name
+		total_ticks = int(round(action.duration / action.tick_interval))
+
+	func _process(delta: float) -> void:
+		if done:
+			return
+		# resetForWave() bumps skill_lock_generation, so a wave-end cancel
+		# stops the ticks immediately; the emit releases the awaiting cast,
+		# whose controller then skips onSuccess (Energy kept).
+		if not is_instance_valid(tower) or tower.skill_lock_generation != gen:
+			_finish()
+			return
+		elapsed += delta
+		# Tick k fires at k * interval (first tick at one interval, never t=0).
+		# ticks_fired increments BEFORE the fire: _process keeps running during
+		# the tick's Hitbox physics-frame await and would re-enter = double tick.
+		while ticks_fired < total_ticks and elapsed >= float(ticks_fired + 1) * action.tick_interval:
+			ticks_fired += 1
+			_fire_tick()
+		if ticks_fired >= total_ticks:
+			_finish()
+
+	func _fire_tick() -> void:
+		# in_flight defers queue_free while this coroutine is suspended in the
+		# Hitbox await - freeing on _finish() the same frame as the final tick
+		# would kill the suspended coroutine and lose that tick's attack.
+		in_flight += 1
+		var ctx := SkillContext.new()
+		ctx.user = tower
+		ctx.skillName = skill_name
+		ctx.extra["parameter"] = params
+		# Locked cast-time center -> the finder's centered override path
+		# (axis-aligned box, same query the aftershock explosion uses).
+		ctx.extra["target_position"] = center
+		if action.effect_action != null:
+			action.effect_action.execute(ctx)
+		await action.find_action.execute(ctx)
+		if is_instance_valid(tower) and tower.skill_lock_generation == gen:
+			# Empty zone = whiff tick: no damage, the channel continues.
+			if not ctx.target.is_empty():
+				await action.attack_action.execute(ctx)
+		in_flight -= 1
+		if done and in_flight == 0:
+			queue_free()
+
+	func _finish() -> void:
+		if done:
+			return
+		done = true
+		finished.emit()
+		if in_flight == 0:
+			queue_free()
+
+	func _exit_tree() -> void:
+		# Freed externally (e.g. the tower node was freed mid-channel): still
+		# release the awaiting execute() so the skill controller never hangs.
+		if not done:
+			done = true
+			finished.emit()

--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -79,6 +79,10 @@ func find_targets_in_rotated_range(context: SkillContext):
 	# Offset: tower mode extends forward from anchor; player-aim mode centers on click.
 	var local_offset = Vector2(0, 0) if center_on_anchor else Vector2(0, actual_height * 0.5)
 
+	# Publish the world center of the queried box for actions that re-strike the
+	# same zone later (channel). Correct in all three anchor modes.
+	context.extra["area_center"] = user_position + local_offset.rotated(user_rotation)
+
 	# Place the hitbox at the resolved anchor
 	var hitbox_position = user_position
 

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -185,6 +185,38 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			# Optional explosion-time VFX, spawned at _fire (e.g. Calliope evolve slash).
 			if skillData.has("effect_script"):
 				skill.effect_action = ParseAction({"type": "play_effect", "data": {"effect_script": skillData["effect_script"]}}, parameters) as SkillActionPlayEffect;
+		"channel":
+			# Blocking zone-locked multi-tick ("channel" pattern - tower_skill.md).
+			# The inner find/attack are built from this same data block via this
+			# parser, so damage_multiplier_param_name, damage_type, can_crit, and
+			# effects all work per tick.
+			skill = SkillActionChannel.new();
+			var skillData = data.get("data", {});
+			skill.width = int(skillData.get("width", 3));
+			skill.height = int(skillData.get("height", 3));
+			var durationParam = skillData.get("duration_param_name", "");
+			if durationParam != "" and parameters.has(durationParam):
+				skill.duration = float(parameters[durationParam]);
+			else:
+				skill.duration = float(skillData.get("duration", 3.0));
+			var intervalParam = skillData.get("tick_interval_param_name", "");
+			if intervalParam != "" and parameters.has(intervalParam):
+				skill.tick_interval = float(parameters[intervalParam]);
+			else:
+				skill.tick_interval = float(skillData.get("tick_interval", 0.25));
+			if skill.tick_interval <= 0.0:
+				push_warning("channel: tick_interval must be > 0; falling back to 0.25.");
+				skill.tick_interval = 0.25;
+			skill.animation = str(skillData.get("animation", "skill"));
+			var channelFind := SkillActionFindMultipleInRange.new();
+			channelFind.width = skill.width;
+			channelFind.height = skill.height;
+			channelFind.cancel_when_empty = false;
+			skill.find_action = channelFind;
+			skill.attack_action = ParseAction({"type": "attack", "data": skillData}, parameters) as SkillActionAttack;
+			# Optional per-tick VFX, spawned each tick alongside the find.
+			if skillData.has("effect_script"):
+				skill.effect_action = ParseAction({"type": "play_effect", "data": {"effect_script": skillData["effect_script"]}}, parameters) as SkillActionPlayEffect;
 		"clear_enemy":
 			skill = SkillActionClearEnemy.new();
 		"find_multi_enemy":


### PR DESCRIPTION
**Summary:** Ninomae Ina'nis full kit (per Director design sheet) + the game's first "channel" skill execution pattern: a blocking cast that locks the aimed zone at cast start and re-strikes it on a fixed tick.

**How it works:** Normal active "Tentacle I-III" is all existing tech (aimed 1x3 find -> attack with magic damage + 1.5s stun via the attack `effects` list). Evolved "Book of Ancient Ones" uses the new `channel` action (`skill_action_channel.gd`, parse case in `skill_utility.gd`): the skill's first `find_multi_enemy` now publishes its box world center as `context.extra["area_center"]` (1 additive line, all anchor modes); the channel then holds the cast for `channelDuration` (3s) while a `_process`-delta ticker (pause-freezes, x2-scales - aftershock clock) re-queries that locked center every `tickInterval` (0.25s, 12 ticks) through the finder's `target_position` override and runs the shared attack pipeline per tick (`can_crit: false`, stun refresh 1.0s). Extension points: `duration_param_name`/`tick_interval_param_name` bind to skill parameters; the full attack key set works per tick; optional `effect_script` hook per tick for future VFX. Channel example documented in `default_tower.yaml`.

**Implementation Notes:** Ticker teardown is the non-obvious part: every exit path emits `finished` exactly once (a silent free would hang the awaiting cast coroutine), and the ticker defers `queue_free` while a tick coroutine is suspended in the Hitbox await (freeing on the same frame as the final tick would eat tick 12's damage). Wave-end cancel rides the existing `skill_lock_generation` bump + controller cancel: ticks stop next frame and `onSuccess` is skipped, so Energy is kept. Empty zone = whiff ticks, channel never ends early (matches the documented commit/whiff standard). Ina YAML rewritten to the new slot structure; evolve attackSpeed corrected 80 -> 60 per design sheet; Director post-test tune included (base range 4 -> 3). Director tested in Godot: full pass incl. pause/x2/wave-end-mid-channel/no-crit and Calliope+Altare regressions.
