### PR TITLE
Tower stats panel + single tokenized skill desc

### DIFF
--- a/resources/database/synergy/myth.yaml
+++ b/resources/database/synergy/myth.yaml
@@ -11,7 +11,7 @@ parameters:
 # Hover header (flavour). {energy_return} resolves to the current tier's value
 # and is auto-highlighted by the UI as the scaling number. Voice: units are
 # people - use they/them, never it/its (see game_copy.md voice rule).
-desc_template: "Myth units possess the power of a primordial age, and whenever they cast a skill, all of them restore {energy_return} Energy."
+desc: "Myth units possess the power of a primordial age, and whenever they cast a skill, all of them restore {energy_return} Energy."
 # Hover per-tier table line. One entry -> used for every tier (pure scaling).
 tier_effects:
   - "Restore {energy_return} Energy"

--- a/resources/database/synergy/tempus.yaml
+++ b/resources/database/synergy/tempus.yaml
@@ -19,7 +19,7 @@ parameters:
   # energy_interval seconds.
   energy_percent: 0.1
   energy_interval: 5
-desc_template: "The Tempus guild fights as one - clear each Guild Mission and they grow stronger together."
+desc: "The Tempus guild fights as one - clear each Guild Mission and they grow stronger together."
 # One line per tier (qualitative). {mission_kills} is the per-tier scaling value
 # (highlighted); reward magnitudes read scalar params so the text cannot drift
 # from the applied effect. :percent renders a decimal-scale value as N%.

--- a/resources/database/towers/axel_syrios.yaml
+++ b/resources/database/towers/axel_syrios.yaml
@@ -36,7 +36,7 @@ stats:
 
 skill:
   name: "Skill"
-  desc: "Just a skill"
+  desc: "Axel Syrios strikes the 3x1 line in front of him with a fierce blow, dealing physical damage to every enemy caught in it."
   recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
   actions:
     - type: find_multi_enemy

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -36,7 +36,7 @@ stats:
 
 skill:
   name: "Skill"
-  desc: "Just a skill"
+  desc: "Banzoin Hakka lashes out across the 3x1 line in front of him, dealing physical damage to every enemy caught in the strike."
   recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
   actions:
     - type: find_multi_enemy

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -41,8 +41,7 @@ skills:
   active:
     name: "Skill"
     names: ["Skill I", "Skill II", "Skill III"] # optional UI display names per tower level
-    desc: "Just a skill" # legacy/fallback text
-    desc_template: "Just a skill with {damageBonus:percent} bonus" # UI display template
+    desc: "Just a skill with {damageBonus:percent} bonus" # tokenized display text: {param} / {param:percent} resolve from parameters; token-free text renders as-is
     icon: "" # optional — ว่างได้ ถ้ายังไม่มี icon
     # tags = ป้ายสรุปสกิลแบบผู้เล่นอ่าน (controlled registry ดู tower_skill.md §Tags)
     tags:
@@ -221,8 +220,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Evolved Skill"
-    desc: "Just a stronger skill"
-    desc_template: "Just a stronger skill with {damageBonus:percent} bonus"
+    desc: "Just a stronger skill with {damageBonus:percent} bonus"
     icon: ""
     tags:
       - damage

--- a/resources/database/towers/gavis_bettel.yaml
+++ b/resources/database/towers/gavis_bettel.yaml
@@ -36,7 +36,7 @@ stats:
 
 skill:
   name: "Skill"
-  desc: "Just a skill"
+  desc: "Gavis Bettel springs a phantom trick across the 3x1 line in front of him, dealing physical damage to every enemy caught in the act."
   recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
   actions:
     - type: find_multi_enemy

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -38,8 +38,7 @@ skills:
   active:
     name: "Atlantis Trident"
     names: ["Atlantis Trident I", "Atlantis Trident II", "Atlantis Trident III"]
-    desc: "Gawr Gura wields the Trident of Atlantis to summon 4 storm waves within one tile around her for 10 seconds. Each wave deals damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
-    desc_template: "Gawr Gura wields the Trident of Atlantis to summon 4 storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
+    desc: "Gawr Gura wields the Trident of Atlantis to summon 4 storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
     icon: ""
     tags:
       - damage
@@ -106,8 +105,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Sink to the Void at the Bottom of the Sea!!"
-    desc: "Gawr Gura wields the Trident of Atlantis to summon 8 storm waves within one tile around her for 10 seconds. Each wave deals damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
-    desc_template: "Gawr Gura wields the Trident of Atlantis to summon 8 storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
+    desc: "Gawr Gura wields the Trident of Atlantis to summon 8 storm waves within one tile around her for 10 seconds. Each wave deals {damageMultiplier:percent} damage per hit and stuns foes for 0.1s.\nNote: Gawr Gura does not gain Energy while this skill is active."
     icon: ""
     tags:
       - damage

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -50,8 +50,7 @@ skills:
   passive:
     name: "Bull Eyes"
     names: ["Bull Eyes I", "Bull Eyes II", "Bull Eyes III"]
-    desc: "Josuiji Shinri steadies his aim with every shot: each non-critical hit adds a Bull Eyes stack, each granting bonus critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for extra critical damage, then loses all Bull Eyes stacks."
-    desc_template: "Josuiji Shinri steadies his aim with every shot: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent}, then loses all Bull Eyes stacks."
+    desc: "Josuiji Shinri steadies his aim with every shot: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent}, then loses all Bull Eyes stacks."
     icon: ""
     tags:
       - crit_rate
@@ -73,7 +72,7 @@ skills:
           target_team: enemy
           target_type: enemy
           target_shape: area
-    # Designer-tunable numbers (read by desc_template tokens + the passive runtime).
+    # Designer-tunable numbers (read by desc tokens + the passive runtime).
     parameters:
       critChancePerStack: 5
       # Additive bonus crit damage (x) per level — arrow = ATK × (critDamage + x).
@@ -96,8 +95,7 @@ evolutionStat:
 evolution_skills:
   passive:
     name: "Heartpierce Shot"
-    desc: "Josuiji Shinri's aim turns lethal: each non-critical hit adds a Bull Eyes stack, each granting bonus critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for extra critical damage — and critical hits no longer consume his Bull Eyes stacks."
-    desc_template: "Josuiji Shinri's aim turns lethal: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent} — and critical hits no longer consume his Bull Eyes stacks."
+    desc: "Josuiji Shinri's aim turns lethal: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent} — and critical hits no longer consume his Bull Eyes stacks."
     icon: ""
     tags:
       - crit_rate

--- a/resources/database/towers/machina_x_flayon.yaml
+++ b/resources/database/towers/machina_x_flayon.yaml
@@ -36,7 +36,7 @@ stats:
 
 skill:
   name: "Skill"
-  desc: "Just a skill"
+  desc: "Machina X Flayon drives a mecha strike through the 3x1 line in front of him, dealing physical damage to every enemy caught in it."
   recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
   actions:
     - type: find_multi_enemy

--- a/resources/database/towers/mori_calliope.yaml
+++ b/resources/database/towers/mori_calliope.yaml
@@ -40,8 +40,7 @@ skills:
   active:
     name: "Ricky"
     names: ["Ricky I", "Ricky II", "Ricky III"]
-    desc: "Calliope sweeps her scythe Ricky through the 3x3 area around her, dealing heavy physical damage that grows with every Soul she holds. Each enemy killed by this skill grants her 1 Soul, kept for the whole run."
-    desc_template: "Calliope sweeps her scythe Ricky through the 3x3 area around her, dealing {skillDamage:percent} physical damage plus {soulBonus:percent} more per Soul she holds. Each enemy killed by this skill grants her 1 Soul, kept for the whole run."
+    desc: "Calliope sweeps her scythe Ricky through the 3x3 area around her, dealing {skillDamage:percent} physical damage plus {soulBonus:percent} more per Soul she holds. Each enemy killed by this skill grants her 1 Soul, kept for the whole run."
     icon: ""
     tags:
       - damage
@@ -91,8 +90,7 @@ skills:
   # Souls survive wave end AND evolve (Director 2026-07-12).
   passive:
     name: "Soul Harvest"
-    desc: "Enemies killed by Calliope's skills each grant her a Soul. Souls last the whole run and strengthen her scythe skills."
-    desc_template: "Enemies killed by Calliope's skills each grant her {soulsPerKill} Soul. Souls last the whole run and strengthen her scythe skills."
+    desc: "Enemies killed by Calliope's skills each grant her {soulsPerKill} Soul. Souls last the whole run and strengthen her scythe skills."
     icon: ""
     tags:
       - buff
@@ -127,8 +125,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Excuse My Rudeness, But Could You Please RIP?"
-    desc: "Calliope reaps the 3x3 area around her with massive physical damage, and moments later the same ground erupts again. Both hits grow with her Souls, and each enemy killed grants her 1 Soul."
-    desc_template: "Calliope reaps the 3x3 area around her for {skillDamage:percent} physical damage plus {soulBonus:percent} per Soul. {aftershockDelay}s later the same ground erupts for {aftershockDamage:percent} physical damage plus {aftershockSoulBonus:percent} per Soul she holds at that moment. Each enemy killed grants her 1 Soul."
+    desc: "Calliope reaps the 3x3 area around her for {skillDamage:percent} physical damage plus {soulBonus:percent} per Soul. {aftershockDelay}s later the same ground erupts for {aftershockDamage:percent} physical damage plus {aftershockSoulBonus:percent} per Soul she holds at that moment. Each enemy killed grants her 1 Soul."
     icon: ""
     tags:
       - damage

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -38,8 +38,7 @@ skills:
   active:
     name: "Tentacle"
     names: ["Tentacle I", "Tentacle II", "Tentacle III"]
-    desc: "Ina'nis commands a tentacle of the Ancient One to lash the 1x3 line in front of her, dealing heavy magic damage and stunning every enemy hit for 1.5 seconds."
-    desc_template: "Ina'nis commands a tentacle of the Ancient One to lash the 1x3 line in front of her, dealing {skillDamage:percent} magic damage and stunning every enemy hit for {stunDuration}s."
+    desc: "Ina'nis commands a tentacle of the Ancient One to lash the 1x3 line in front of her, dealing {skillDamage:percent} magic damage and stunning every enemy hit for {stunDuration}s."
     icon: ""
     tags:
       - damage
@@ -102,8 +101,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Book of Ancient Ones"
-    desc: "Ina'nis opens the Book of Ancient Ones and channels its power for 3 seconds, striking the 3x3 area in front of her every 0.25 seconds. Each strike deals magic damage and stuns enemies caught in the zone for 1 second."
-    desc_template: "Ina'nis opens the Book of Ancient Ones and channels its power for {channelDuration} seconds, striking the 3x3 area in front of her every {tickInterval} seconds. Each strike deals {tickDamage:percent} magic damage and stuns enemies caught in the zone for {tickStun}s."
+    desc: "Ina'nis opens the Book of Ancient Ones and channels its power for {channelDuration} seconds, striking the 3x3 area in front of her every {tickInterval} seconds. Each strike deals {tickDamage:percent} magic damage and stuns enemies caught in the zone for {tickStun}s."
     icon: ""
     tags:
       - damage

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -39,8 +39,7 @@ skills:
   active:
     name: "Gun and Blade"
     names: ["Gun and Blade I", "Gun and Blade II", "Gun and Blade III"]
-    desc: "Altare strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals physical damage and reduces armor by 5% for 2s, then a gun volley down a 1x3 lane deals physical damage with a guaranteed critical."
-    desc_template: "Altare strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} physical damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a gun volley down a 1x3 lane deals {beat2Damage:percent} physical damage with a guaranteed critical."
+    desc: "Altare strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} physical damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a gun volley down a 1x3 lane deals {beat2Damage:percent} physical damage with a guaranteed critical."
     icon: ""
     tags:
       - damage
@@ -130,8 +129,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Heroic Requiem"
-    desc: "Altare's finisher strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals physical damage and reduces armor by 5% for 2s, then a long gun volley down a 1x6 lane deals physical damage with a guaranteed critical."
-    desc_template: "Altare's finisher strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} physical damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a long gun volley down a 1x6 lane deals {beat2Damage:percent} physical damage with a guaranteed critical."
+    desc: "Altare's finisher strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} physical damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a long gun volley down a 1x6 lane deals {beat2Damage:percent} physical damage with a guaranteed critical."
     icon: ""
     tags:
       - damage

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -37,8 +37,7 @@ skills:
   active:
     name: "Flame Slash"
     names: ["Flame Slash I", "Flame Slash II", "Flame Slash III"]
-    desc: "Kiara swings her immortal phoenix flame sword forward through a 3×1 tile area, dealing physical damage. All enemies hit are scorched by Phoenix Flame, taking magic damage every second for 5 seconds."
-    desc_template: "Kiara swings her immortal phoenix flame sword forward through a 3×1 tile area, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
+    desc: "Kiara swings her immortal phoenix flame sword forward through a 3×1 tile area, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
     icon: ""
     tags:
       - damage
@@ -64,7 +63,7 @@ skills:
     #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     # Single source for balance + desc: skill actions read these via
-    # damage_multiplier_param_name / *_param, and desc_template tokens render the
+    # damage_multiplier_param_name / *_param, and desc tokens render the
     # same values — edit here to retune both at once.
     parameters:
       # Per-tier direct hit scaling — Skill Multiplier (% of Kiara attack).
@@ -116,8 +115,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Hinotori"
-    desc: "Kiara empowers her sword with sacred phoenix fire and unleashes a devastating slash forward through a 3×5 tile corridor, dealing massive physical damage. All enemies hit are scorched by Phoenix Flame, taking magic damage every second for 5 seconds."
-    desc_template: "Kiara empowers her sword with sacred phoenix fire and unleashes a devastating slash forward through a 3×5 tile corridor, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
+    desc: "Kiara empowers her sword with sacred phoenix fire and unleashes a devastating slash forward through a 3×5 tile corridor, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
     icon: ""
     tags:
       - damage
@@ -144,7 +142,7 @@ evolution_skills:
     #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     # Single source for balance + desc: actions read these (projectile damage via
-    # damage_multiplier_param_name default, DOT via *_param); desc_template tokens
+    # damage_multiplier_param_name default, DOT via *_param); desc tokens
     # render the same values. Projectile knobs (speed/lifetime/max_range) live in
     # the action data below.
     parameters:

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -48,8 +48,7 @@ skills:
   active:
     name: "Time Traveler"
     names: ["Time Traveler I", "Time Traveler II", "Time Traveler III"]
-    desc: "Watson Amelia invokes the Clock of Time, increasing her own attack speed for 4 seconds."
-    desc_template: "Watson Amelia invokes the Clock of Time, increasing her own attack speed by {attackSpeedBuff:percent} for 4 seconds."
+    desc: "Watson Amelia invokes the Clock of Time, increasing her own attack speed by {attackSpeedBuff:percent} for 4 seconds."
     icon: ""
     tags:
       - buff
@@ -105,8 +104,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Elementary my dear"
-    desc: "Watson Amelia invokes the Clock of Time, increasing attack speed for herself and nearby towers within 1 tile, and granting herself bonus critical chance for 4 seconds."
-    desc_template: "Watson Amelia invokes the Clock of Time, increasing attack speed by {attackSpeedBuff:percent} for herself and nearby towers within 1 tile, and granting herself {critChanceBuff}% critical chance for 4 seconds."
+    desc: "Watson Amelia invokes the Clock of Time, increasing attack speed by {attackSpeedBuff:percent} for herself and nearby towers within 1 tile, and granting herself {critChanceBuff}% critical chance for 4 seconds."
     icon: ""
     tags:
       - buff

--- a/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gd
@@ -11,6 +11,9 @@ func _ready() -> void:
 	var draw_size := EFFECT_SIZE * BURST_PAD
 	rect.size     = Vector2(draw_size, draw_size)
 	rect.position = Vector2(-draw_size / 2.0, -draw_size / 2.0)
+	# VFX must never eat mouse input: a Control's default filter blocked every
+	# world click under the effect for its whole lifetime (SkillVfx rule).
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 	var mat := ShaderMaterial.new()
 	mat.shader = load(SHADER_PATH)

--- a/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gd
@@ -10,6 +10,9 @@ func _ready() -> void:
 	var draw_size := EFFECT_SIZE * BURST_PAD
 	rect.size     = Vector2(draw_size, draw_size)
 	rect.position = Vector2(-draw_size / 2.0, -draw_size / 2.0)
+	# VFX must never eat mouse input: a Control's default filter blocked every
+	# world click under the effect for its whole lifetime (SkillVfx rule).
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 	var mat := ShaderMaterial.new()
 	mat.shader = load(SHADER_PATH)

--- a/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_evo_aftershock_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_evo_aftershock_effect.gd
@@ -23,6 +23,9 @@ func _ready() -> void:
 	var rect := ColorRect.new()
 	rect.size     = Vector2(draw_size, draw_size)
 	rect.position = Vector2(-draw_size / 2.0, -draw_size / 2.0)
+	# VFX must never eat mouse input: a Control's default filter blocked every
+	# world click under the effect for its whole lifetime (SkillVfx rule).
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 	var mat := ShaderMaterial.new()
 	mat.shader = load(SHADER_PATH)

--- a/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_evo_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_evo_skill_effect.gd
@@ -26,6 +26,9 @@ func _ready() -> void:
 	var rect := ColorRect.new()
 	rect.size     = Vector2(draw_size, draw_size)
 	rect.position = Vector2(-draw_size / 2.0, -draw_size / 2.0)
+	# VFX must never eat mouse input: a Control's default filter blocked every
+	# world click under the effect for its whole lifetime (SkillVfx rule).
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 	var mat := ShaderMaterial.new()
 	mat.shader = load(SHADER_PATH)

--- a/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_skill_effect.gd
@@ -21,6 +21,9 @@ func _ready() -> void:
 	var rect := ColorRect.new()
 	rect.size     = Vector2(draw_size, draw_size)
 	rect.position = Vector2(-draw_size / 2.0, -draw_size / 2.0)
+	# VFX must never eat mouse input: a Control's default filter blocked every
+	# world click under the effect for its whole lifetime (SkillVfx rule).
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 	var mat := ShaderMaterial.new()
 	mat.shader = load(SHADER_PATH)

--- a/resources/ui_component/game_ui.tscn
+++ b/resources/ui_component/game_ui.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=3 uid="uid://bcyr1l11fwy7"]
+[gd_scene load_steps=25 format=3 uid="uid://bcyr1l11fwy7"]
 
 [ext_resource type="PackedScene" uid="uid://dsshuu1axf1t8" path="res://resources/ui_component/synergy/ui_synergy.tscn" id="1_hk82f"]
 [ext_resource type="Script" path="res://scripts/ui/currency.gd" id="2_rqmfg"]
@@ -10,6 +10,7 @@
 [ext_resource type="Texture2D" uid="uid://bkxk2vx0idyr3" path="res://resources/ui_component/btn_pause.png" id="7_8wafk"]
 [ext_resource type="PackedScene" path="res://resources/ui_component/staff_widget.tscn" id="9_staff"]
 [ext_resource type="PackedScene" path="res://resources/ui_component/boss_health_bar.tscn" id="10_bosshp"]
+[ext_resource type="PackedScene" path="res://resources/ui_component/tower_stats_panel.tscn" id="11_twstats"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_uyb7r"]
 bg_color = Color(0.6, 0.254902, 0.6, 1)
@@ -262,6 +263,8 @@ offset_top = 20.0
 offset_right = 300.0
 offset_bottom = 96.0
 grow_horizontal = 2
+
+[node name="TowerStatsPanel" parent="." instance=ExtResource("11_twstats")]
 
 [node name="PauseButton" type="Button" parent="."]
 visible = false

--- a/resources/ui_component/tower_stats_panel.tscn
+++ b/resources/ui_component/tower_stats_panel.tscn
@@ -174,18 +174,8 @@ layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_body")
 
-[node name="CritName" type="Label" parent="StatsGrid"]
-custom_minimum_size = Vector2(90, 0)
-layout_mode = 2
-text = "Crit Rate"
-label_settings = SubResource("LabelSettings_dim")
-
-[node name="CritValue" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "0%"
-label_settings = SubResource("LabelSettings_body")
-
 [node name="TypeName" type="Label" parent="StatsGrid"]
+custom_minimum_size = Vector2(90, 0)
 layout_mode = 2
 text = "Attack Type"
 label_settings = SubResource("LabelSettings_dim")
@@ -195,14 +185,14 @@ layout_mode = 2
 text = "Physical"
 label_settings = SubResource("LabelSettings_body")
 
-[node name="CritDmgName" type="Label" parent="StatsGrid"]
+[node name="RangeName" type="Label" parent="StatsGrid"]
 layout_mode = 2
-text = "Crit DMG"
+text = "Range"
 label_settings = SubResource("LabelSettings_dim")
 
-[node name="CritDmgValue" type="Label" parent="StatsGrid"]
+[node name="RangeValue" type="Label" parent="StatsGrid"]
 layout_mode = 2
-text = "100%"
+text = "0"
 label_settings = SubResource("LabelSettings_body")
 
 [node name="AsName" type="Label" parent="StatsGrid"]
@@ -215,14 +205,24 @@ layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_body")
 
-[node name="RangeName" type="Label" parent="StatsGrid"]
+[node name="CritName" type="Label" parent="StatsGrid"]
 layout_mode = 2
-text = "Range"
+text = "Crit Rate"
 label_settings = SubResource("LabelSettings_dim")
 
-[node name="RangeValue" type="Label" parent="StatsGrid"]
+[node name="CritValue" type="Label" parent="StatsGrid"]
 layout_mode = 2
-text = "0"
+text = "0%"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="CritDmgName" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "Crit DMG"
+label_settings = SubResource("LabelSettings_dim")
+
+[node name="CritDmgValue" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "100%"
 label_settings = SubResource("LabelSettings_body")
 
 [node name="EnergyRow" type="Control" parent="."]

--- a/resources/ui_component/tower_stats_panel.tscn
+++ b/resources/ui_component/tower_stats_panel.tscn
@@ -65,7 +65,7 @@ font_color = Color(0.88, 0.92, 1, 1)
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 16.0
-offset_top = -306.0
+offset_top = -330.0
 offset_right = 576.0
 offset_bottom = -16.0
 grow_vertical = 0
@@ -154,12 +154,12 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_sep")
 
 [node name="StatsGrid" type="GridContainer" parent="."]
 offset_left = 16.0
-offset_top = 164.0
+offset_top = 162.0
 offset_right = 464.0
-offset_bottom = 250.0
+offset_bottom = 262.0
 mouse_filter = 2
 theme_override_constants/h_separation = 14
-theme_override_constants/v_separation = 14
+theme_override_constants/v_separation = 12
 columns = 4
 
 [node name="AtkName" type="Label" parent="StatsGrid"]
@@ -169,7 +169,7 @@ text = "Attack"
 label_settings = SubResource("LabelSettings_dim")
 
 [node name="AtkValue" type="Label" parent="StatsGrid"]
-custom_minimum_size = Vector2(130, 0)
+custom_minimum_size = Vector2(110, 0)
 layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_body")
@@ -185,14 +185,14 @@ layout_mode = 2
 text = "0%"
 label_settings = SubResource("LabelSettings_body")
 
-[node name="AsName" type="Label" parent="StatsGrid"]
+[node name="TypeName" type="Label" parent="StatsGrid"]
 layout_mode = 2
-text = "Attack Speed"
+text = "Attack Type"
 label_settings = SubResource("LabelSettings_dim")
 
-[node name="AsValue" type="Label" parent="StatsGrid"]
+[node name="TypeValue" type="Label" parent="StatsGrid"]
 layout_mode = 2
-text = "0"
+text = "Physical"
 label_settings = SubResource("LabelSettings_body")
 
 [node name="CritDmgName" type="Label" parent="StatsGrid"]
@@ -205,11 +205,31 @@ layout_mode = 2
 text = "100%"
 label_settings = SubResource("LabelSettings_body")
 
+[node name="AsName" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "Attack Speed"
+label_settings = SubResource("LabelSettings_dim")
+
+[node name="AsValue" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "0"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="RangeName" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "Range"
+label_settings = SubResource("LabelSettings_dim")
+
+[node name="RangeValue" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "0"
+label_settings = SubResource("LabelSettings_body")
+
 [node name="EnergyRow" type="Control" parent="."]
 offset_left = 16.0
-offset_top = 246.0
+offset_top = 270.0
 offset_right = 464.0
-offset_bottom = 272.0
+offset_bottom = 296.0
 mouse_filter = 2
 
 [node name="EnergyLabel" type="Label" parent="EnergyRow"]
@@ -245,6 +265,6 @@ vertical_alignment = 1
 offset_left = 484.0
 offset_top = 16.0
 offset_right = 548.0
-offset_bottom = 274.0
+offset_bottom = 298.0
 mouse_filter = 2
 theme_override_constants/separation = 10

--- a/resources/ui_component/tower_stats_panel.tscn
+++ b/resources/ui_component/tower_stats_panel.tscn
@@ -1,58 +1,72 @@
-[gd_scene load_steps=9 format=3]
+[gd_scene load_steps=12 format=3]
 
 [ext_resource type="Script" path="res://scripts/ui/tower_stats_panel.gd" id="1_twstats"]
 [ext_resource type="FontFile" uid="uid://scv78fddnukv" path="res://resources/ui_component/font/Roboto-Regular.ttf" id="2_font"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panelbg"]
-bg_color = Color(0.09, 0.06, 0.14, 0.92)
+bg_color = Color(0.07, 0.05, 0.12, 0.94)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.85, 0.7, 0.45, 0.9)
-corner_radius_top_left = 14
-corner_radius_top_right = 14
-corner_radius_bottom_right = 14
-corner_radius_bottom_left = 14
+border_color = Color(0.85, 0.7, 0.45, 0.85)
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_sep"]
+bg_color = Color(0.85, 0.7, 0.45, 0.25)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_barbg"]
 bg_color = Color(0.12, 0.11, 0.2, 1)
-corner_radius_top_left = 6
-corner_radius_top_right = 6
-corner_radius_bottom_right = 6
-corner_radius_bottom_left = 6
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.85, 0.7, 0.45, 0.4)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_barfill"]
 bg_color = Color(0.3, 0.65, 1, 1)
-corner_radius_top_left = 6
-corner_radius_top_right = 6
-corner_radius_bottom_right = 6
-corner_radius_bottom_left = 6
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
 
 [sub_resource type="LabelSettings" id="LabelSettings_title"]
 font = ExtResource("2_font")
 font_size = 26
+font_color = Color(0.96, 0.85, 0.6, 1)
 
 [sub_resource type="LabelSettings" id="LabelSettings_sub"]
 font = ExtResource("2_font")
-font_size = 19
-font_color = Color(0.95, 0.8, 0.5, 1)
+font_size = 18
+font_color = Color(0.85, 0.85, 0.9, 1)
 
 [sub_resource type="LabelSettings" id="LabelSettings_body"]
 font = ExtResource("2_font")
 font_size = 18
 
+[sub_resource type="LabelSettings" id="LabelSettings_dim"]
+font = ExtResource("2_font")
+font_size = 17
+font_color = Color(0.62, 0.62, 0.7, 1)
+
 [sub_resource type="LabelSettings" id="LabelSettings_small"]
 font = ExtResource("2_font")
 font_size = 14
-font_color = Color(0.78, 0.78, 0.85, 1)
+font_color = Color(0.88, 0.92, 1, 1)
 
 [node name="TowerStatsPanel" type="Control"]
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 16.0
-offset_top = -416.0
-offset_right = 536.0
+offset_top = -356.0
+offset_right = 576.0
 offset_bottom = -16.0
 grow_vertical = 0
 mouse_filter = 0
@@ -71,38 +85,38 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_panelbg")
 [node name="Portrait" type="TextureRect" parent="."]
 offset_left = 16.0
 offset_top = 16.0
-offset_right = 144.0
-offset_bottom = 144.0
+offset_right = 136.0
+offset_bottom = 136.0
 mouse_filter = 2
 expand_mode = 1
 stretch_mode = 5
 
 [node name="NameLabel" type="Label" parent="."]
-offset_left = 160.0
-offset_top = 14.0
-offset_right = 504.0
+offset_left = 152.0
+offset_top = 16.0
+offset_right = 460.0
 offset_bottom = 46.0
 text = "Tower Name"
 label_settings = SubResource("LabelSettings_title")
 
 [node name="LevelLabel" type="Label" parent="."]
-offset_left = 160.0
+offset_left = 152.0
 offset_top = 50.0
-offset_right = 504.0
-offset_bottom = 76.0
+offset_right = 460.0
+offset_bottom = 74.0
 text = "Level 1"
 label_settings = SubResource("LabelSettings_sub")
 
 [node name="TraitRow" type="HBoxContainer" parent="."]
-offset_left = 160.0
-offset_top = 84.0
-offset_right = 504.0
-offset_bottom = 122.0
+offset_left = 152.0
+offset_top = 82.0
+offset_right = 460.0
+offset_bottom = 116.0
 mouse_filter = 2
-theme_override_constants/separation = 10
+theme_override_constants/separation = 8
 
 [node name="ClassIcon" type="TextureRect" parent="TraitRow"]
-custom_minimum_size = Vector2(32, 32)
+custom_minimum_size = Vector2(30, 30)
 layout_mode = 2
 mouse_filter = 2
 expand_mode = 1
@@ -114,12 +128,12 @@ text = "Class"
 label_settings = SubResource("LabelSettings_body")
 
 [node name="TraitSpacer" type="Control" parent="TraitRow"]
-custom_minimum_size = Vector2(12, 0)
+custom_minimum_size = Vector2(14, 0)
 layout_mode = 2
 mouse_filter = 2
 
 [node name="GenIcon" type="TextureRect" parent="TraitRow"]
-custom_minimum_size = Vector2(32, 32)
+custom_minimum_size = Vector2(30, 30)
 layout_mode = 2
 mouse_filter = 2
 expand_mode = 1
@@ -130,61 +144,61 @@ layout_mode = 2
 text = "Generation"
 label_settings = SubResource("LabelSettings_body")
 
+[node name="Separator" type="Panel" parent="."]
+offset_left = 16.0
+offset_top = 148.0
+offset_right = 464.0
+offset_bottom = 150.0
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_sep")
+
 [node name="StatsGrid" type="GridContainer" parent="."]
 offset_left = 16.0
-offset_top = 152.0
-offset_right = 504.0
-offset_bottom = 300.0
+offset_top = 164.0
+offset_right = 464.0
+offset_bottom = 250.0
 mouse_filter = 2
-theme_override_constants/h_separation = 10
-theme_override_constants/v_separation = 6
-columns = 2
+theme_override_constants/h_separation = 14
+theme_override_constants/v_separation = 14
+columns = 4
 
 [node name="AtkName" type="Label" parent="StatsGrid"]
-custom_minimum_size = Vector2(240, 0)
+custom_minimum_size = Vector2(120, 0)
 layout_mode = 2
 text = "Attack"
-label_settings = SubResource("LabelSettings_body")
+label_settings = SubResource("LabelSettings_dim")
 
 [node name="AtkValue" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "0"
-label_settings = SubResource("LabelSettings_body")
-
-[node name="TypeName" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "Attack Type"
-label_settings = SubResource("LabelSettings_body")
-
-[node name="TypeValue" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "Physical"
-label_settings = SubResource("LabelSettings_body")
-
-[node name="AsName" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "Attack Speed"
-label_settings = SubResource("LabelSettings_body")
-
-[node name="AsValue" type="Label" parent="StatsGrid"]
+custom_minimum_size = Vector2(130, 0)
 layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_body")
 
 [node name="CritName" type="Label" parent="StatsGrid"]
+custom_minimum_size = Vector2(90, 0)
 layout_mode = 2
 text = "Crit Rate"
-label_settings = SubResource("LabelSettings_body")
+label_settings = SubResource("LabelSettings_dim")
 
 [node name="CritValue" type="Label" parent="StatsGrid"]
 layout_mode = 2
 text = "0%"
 label_settings = SubResource("LabelSettings_body")
 
+[node name="AsName" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "Attack Speed"
+label_settings = SubResource("LabelSettings_dim")
+
+[node name="AsValue" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "0"
+label_settings = SubResource("LabelSettings_body")
+
 [node name="CritDmgName" type="Label" parent="StatsGrid"]
 layout_mode = 2
 text = "Crit DMG"
-label_settings = SubResource("LabelSettings_body")
+label_settings = SubResource("LabelSettings_dim")
 
 [node name="CritDmgValue" type="Label" parent="StatsGrid"]
 layout_mode = 2
@@ -193,22 +207,22 @@ label_settings = SubResource("LabelSettings_body")
 
 [node name="EnergyRow" type="Control" parent="."]
 offset_left = 16.0
-offset_top = 306.0
-offset_right = 504.0
-offset_bottom = 336.0
+offset_top = 286.0
+offset_right = 464.0
+offset_bottom = 316.0
 mouse_filter = 2
 
 [node name="EnergyLabel" type="Label" parent="EnergyRow"]
 offset_top = 2.0
-offset_right = 86.0
+offset_right = 80.0
 offset_bottom = 28.0
 text = "Energy"
-label_settings = SubResource("LabelSettings_body")
+label_settings = SubResource("LabelSettings_dim")
 
 [node name="EnergyBar" type="ProgressBar" parent="EnergyRow"]
-offset_left = 92.0
+offset_left = 88.0
 offset_top = 3.0
-offset_right = 488.0
+offset_right = 448.0
 offset_bottom = 27.0
 mouse_filter = 2
 theme_override_styles/background = SubResource("StyleBoxFlat_barbg")
@@ -227,10 +241,10 @@ label_settings = SubResource("LabelSettings_small")
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="SkillRow" type="HBoxContainer" parent="."]
-offset_left = 16.0
-offset_top = 344.0
-offset_right = 504.0
-offset_bottom = 394.0
+[node name="SkillColumn" type="VBoxContainer" parent="."]
+offset_left = 484.0
+offset_top = 16.0
+offset_right = 548.0
+offset_bottom = 324.0
 mouse_filter = 2
 theme_override_constants/separation = 10

--- a/resources/ui_component/tower_stats_panel.tscn
+++ b/resources/ui_component/tower_stats_panel.tscn
@@ -188,7 +188,7 @@ label_settings = SubResource("LabelSettings_body")
 
 [node name="CritDmgValue" type="Label" parent="StatsGrid"]
 layout_mode = 2
-text = "x1"
+text = "100%"
 label_settings = SubResource("LabelSettings_body")
 
 [node name="EnergyRow" type="Control" parent="."]
@@ -208,7 +208,7 @@ label_settings = SubResource("LabelSettings_body")
 [node name="EnergyBar" type="ProgressBar" parent="EnergyRow"]
 offset_left = 92.0
 offset_top = 3.0
-offset_right = 382.0
+offset_right = 488.0
 offset_bottom = 27.0
 mouse_filter = 2
 theme_override_styles/background = SubResource("StyleBoxFlat_barbg")
@@ -226,14 +226,6 @@ text = "0 / 0"
 label_settings = SubResource("LabelSettings_small")
 horizontal_alignment = 1
 vertical_alignment = 1
-
-[node name="StartLabel" type="Label" parent="EnergyRow"]
-offset_left = 390.0
-offset_top = 4.0
-offset_right = 488.0
-offset_bottom = 28.0
-text = "Start 0"
-label_settings = SubResource("LabelSettings_small")
 
 [node name="SkillRow" type="HBoxContainer" parent="."]
 offset_left = 16.0

--- a/resources/ui_component/tower_stats_panel.tscn
+++ b/resources/ui_component/tower_stats_panel.tscn
@@ -1,0 +1,244 @@
+[gd_scene load_steps=9 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/tower_stats_panel.gd" id="1_twstats"]
+[ext_resource type="FontFile" uid="uid://scv78fddnukv" path="res://resources/ui_component/font/Roboto-Regular.ttf" id="2_font"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panelbg"]
+bg_color = Color(0.09, 0.06, 0.14, 0.92)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.85, 0.7, 0.45, 0.9)
+corner_radius_top_left = 14
+corner_radius_top_right = 14
+corner_radius_bottom_right = 14
+corner_radius_bottom_left = 14
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_barbg"]
+bg_color = Color(0.12, 0.11, 0.2, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_barfill"]
+bg_color = Color(0.3, 0.65, 1, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="LabelSettings" id="LabelSettings_title"]
+font = ExtResource("2_font")
+font_size = 26
+
+[sub_resource type="LabelSettings" id="LabelSettings_sub"]
+font = ExtResource("2_font")
+font_size = 19
+font_color = Color(0.95, 0.8, 0.5, 1)
+
+[sub_resource type="LabelSettings" id="LabelSettings_body"]
+font = ExtResource("2_font")
+font_size = 18
+
+[sub_resource type="LabelSettings" id="LabelSettings_small"]
+font = ExtResource("2_font")
+font_size = 14
+font_color = Color(0.78, 0.78, 0.85, 1)
+
+[node name="TowerStatsPanel" type="Control"]
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 16.0
+offset_top = -416.0
+offset_right = 536.0
+offset_bottom = -16.0
+grow_vertical = 0
+mouse_filter = 0
+script = ExtResource("1_twstats")
+
+[node name="BG" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_panelbg")
+
+[node name="Portrait" type="TextureRect" parent="."]
+offset_left = 16.0
+offset_top = 16.0
+offset_right = 144.0
+offset_bottom = 144.0
+mouse_filter = 2
+expand_mode = 1
+stretch_mode = 5
+
+[node name="NameLabel" type="Label" parent="."]
+offset_left = 160.0
+offset_top = 14.0
+offset_right = 504.0
+offset_bottom = 46.0
+text = "Tower Name"
+label_settings = SubResource("LabelSettings_title")
+
+[node name="LevelLabel" type="Label" parent="."]
+offset_left = 160.0
+offset_top = 50.0
+offset_right = 504.0
+offset_bottom = 76.0
+text = "Level 1"
+label_settings = SubResource("LabelSettings_sub")
+
+[node name="TraitRow" type="HBoxContainer" parent="."]
+offset_left = 160.0
+offset_top = 84.0
+offset_right = 504.0
+offset_bottom = 122.0
+mouse_filter = 2
+theme_override_constants/separation = 10
+
+[node name="ClassIcon" type="TextureRect" parent="TraitRow"]
+custom_minimum_size = Vector2(32, 32)
+layout_mode = 2
+mouse_filter = 2
+expand_mode = 1
+stretch_mode = 5
+
+[node name="ClassLabel" type="Label" parent="TraitRow"]
+layout_mode = 2
+text = "Class"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="TraitSpacer" type="Control" parent="TraitRow"]
+custom_minimum_size = Vector2(12, 0)
+layout_mode = 2
+mouse_filter = 2
+
+[node name="GenIcon" type="TextureRect" parent="TraitRow"]
+custom_minimum_size = Vector2(32, 32)
+layout_mode = 2
+mouse_filter = 2
+expand_mode = 1
+stretch_mode = 5
+
+[node name="GenLabel" type="Label" parent="TraitRow"]
+layout_mode = 2
+text = "Generation"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="StatsGrid" type="GridContainer" parent="."]
+offset_left = 16.0
+offset_top = 152.0
+offset_right = 504.0
+offset_bottom = 300.0
+mouse_filter = 2
+theme_override_constants/h_separation = 10
+theme_override_constants/v_separation = 6
+columns = 2
+
+[node name="AtkName" type="Label" parent="StatsGrid"]
+custom_minimum_size = Vector2(240, 0)
+layout_mode = 2
+text = "Attack"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="AtkValue" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "0"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="TypeName" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "Attack Type"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="TypeValue" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "Physical"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="AsName" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "Attack Speed"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="AsValue" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "0"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="CritName" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "Crit Rate"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="CritValue" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "0%"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="CritDmgName" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "Crit DMG"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="CritDmgValue" type="Label" parent="StatsGrid"]
+layout_mode = 2
+text = "x1"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="EnergyRow" type="Control" parent="."]
+offset_left = 16.0
+offset_top = 306.0
+offset_right = 504.0
+offset_bottom = 336.0
+mouse_filter = 2
+
+[node name="EnergyLabel" type="Label" parent="EnergyRow"]
+offset_top = 2.0
+offset_right = 86.0
+offset_bottom = 28.0
+text = "Energy"
+label_settings = SubResource("LabelSettings_body")
+
+[node name="EnergyBar" type="ProgressBar" parent="EnergyRow"]
+offset_left = 92.0
+offset_top = 3.0
+offset_right = 382.0
+offset_bottom = 27.0
+mouse_filter = 2
+theme_override_styles/background = SubResource("StyleBoxFlat_barbg")
+theme_override_styles/fill = SubResource("StyleBoxFlat_barfill")
+show_percentage = false
+
+[node name="EnergyText" type="Label" parent="EnergyRow/EnergyBar"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "0 / 0"
+label_settings = SubResource("LabelSettings_small")
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="StartLabel" type="Label" parent="EnergyRow"]
+offset_left = 390.0
+offset_top = 4.0
+offset_right = 488.0
+offset_bottom = 28.0
+text = "Start 0"
+label_settings = SubResource("LabelSettings_small")
+
+[node name="SkillRow" type="HBoxContainer" parent="."]
+offset_left = 16.0
+offset_top = 344.0
+offset_right = 504.0
+offset_bottom = 394.0
+mouse_filter = 2
+theme_override_constants/separation = 10

--- a/resources/ui_component/tower_stats_panel.tscn
+++ b/resources/ui_component/tower_stats_panel.tscn
@@ -58,14 +58,14 @@ font_color = Color(0.62, 0.62, 0.7, 1)
 
 [sub_resource type="LabelSettings" id="LabelSettings_small"]
 font = ExtResource("2_font")
-font_size = 14
+font_size = 13
 font_color = Color(0.88, 0.92, 1, 1)
 
 [node name="TowerStatsPanel" type="Control"]
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 16.0
-offset_top = -356.0
+offset_top = -306.0
 offset_right = 576.0
 offset_bottom = -16.0
 grow_vertical = 0
@@ -207,23 +207,23 @@ label_settings = SubResource("LabelSettings_body")
 
 [node name="EnergyRow" type="Control" parent="."]
 offset_left = 16.0
-offset_top = 286.0
+offset_top = 246.0
 offset_right = 464.0
-offset_bottom = 316.0
+offset_bottom = 272.0
 mouse_filter = 2
 
 [node name="EnergyLabel" type="Label" parent="EnergyRow"]
-offset_top = 2.0
+offset_top = 1.0
 offset_right = 80.0
-offset_bottom = 28.0
+offset_bottom = 25.0
 text = "Energy"
 label_settings = SubResource("LabelSettings_dim")
 
 [node name="EnergyBar" type="ProgressBar" parent="EnergyRow"]
 offset_left = 88.0
-offset_top = 3.0
+offset_top = 4.0
 offset_right = 448.0
-offset_bottom = 27.0
+offset_bottom = 22.0
 mouse_filter = 2
 theme_override_styles/background = SubResource("StyleBoxFlat_barbg")
 theme_override_styles/fill = SubResource("StyleBoxFlat_barfill")
@@ -245,6 +245,6 @@ vertical_alignment = 1
 offset_left = 484.0
 offset_top = 16.0
 offset_right = 548.0
-offset_bottom = 324.0
+offset_bottom = 274.0
 mouse_filter = 2
 theme_override_constants/separation = 10

--- a/scripts/effect/effect_def.gd
+++ b/scripts/effect/effect_def.gd
@@ -9,8 +9,8 @@ var id: String = ""
 var display_name: String = ""
 # Player-facing tooltip line (game_copy.md voice). Numbers are NEVER typed
 # in: the "{value}" token resolves to the instance's real applied magnitude
-# (stacks included) at display time - same single-source rule as skill
-# desc_template.
+# (stacks included) at display time - same single-source rule as the
+# tokenized skill desc.
 var desc: String = ""
 var icon_path: String = ""
 var category: EffectTypes.Category = EffectTypes.Category.BUFF

--- a/scripts/effect/effect_utility.gd
+++ b/scripts/effect/effect_utility.gd
@@ -62,7 +62,7 @@ static func parse_effect_list(list: Array, parameters: Dictionary, source_id: St
 	return result
 
 # Resolve a numeric field: prefer parameters[<param_key>] (scalar; single
-# source with desc_template tokens), else the literal field.
+# source with the tokenized skill desc), else the literal field.
 static func _resolve_field(data: Dictionary, parameters: Dictionary, literal_key: String, param_key: String, default_value):
 	if data.has(param_key):
 		var pname = data[param_key]

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -148,6 +148,14 @@ func _process(delta):
 	if enableAttack && !attacking && !usingSkill && !skillReady:
 		attackEnemy();
 
+# Area2D pick (uses the Hitbox shape). Fires only for events no Control/GUI or
+# game_scene._input consumed; place-mode clicks are suppressed at the source.
+func _input_event(_viewport, event, _shape_idx):
+	if inPlaceMode:
+		return;
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		tower_clicked.emit(self);
+
 func setup(p_id: String, p_onPlace: Callable, p_onRemove: Callable):
 	self.id = p_id;
 	self.name = p_id;
@@ -428,3 +436,5 @@ func _exit_tree():
 signal on_animation_finished(name: String);
 # Emitted after this tower completes a skill cast (drives synergy effects).
 signal skill_cast_succeeded(tower);
+# Emitted when the player left-clicks this placed tower (drives the stats panel).
+signal tower_clicked(tower);

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -90,8 +90,6 @@ func _ready():
 	if iconRow != null and data != null:
 		iconRow.setup(data.effects)
 
-	_create_click_area();
-
 	isReady = true;
 
 func _hasActiveSkill() -> bool:
@@ -149,38 +147,6 @@ func _process(delta):
 
 	if enableAttack && !attacking && !usingSkill && !skillReady:
 		attackEnemy();
-
-# Click-pick area: the gameplay Hitbox circle only covers the base, so head
-# clicks missed (Director feedback 2026-07-16). A dedicated Area2D keeps the
-# pick surface tall without touching gameplay hit shapes. Width matches the
-# Hitbox (240); the box is raised to cover the sprite head.
-const PICK_SIZE := Vector2(240, 360)
-const PICK_OFFSET := Vector2(0, -120)
-
-func _create_click_area() -> void:
-	var area := Area2D.new()
-	area.name = "ClickArea"
-	area.monitoring = false
-	# Own layer bit (10) + empty mask: gameplay area/enemy queries never see it,
-	# while viewport picking (mask-agnostic) still does.
-	area.collision_layer = 1 << 9
-	area.collision_mask = 0
-	var shape := CollisionShape2D.new()
-	var rect := RectangleShape2D.new()
-	rect.size = PICK_SIZE
-	shape.shape = rect
-	shape.position = PICK_OFFSET
-	area.add_child(shape)
-	area.input_event.connect(_on_pick_input)
-	add_child(area)
-
-# Fires only for events no Control/GUI or game_scene._input consumed;
-# place-mode clicks are suppressed at the source.
-func _on_pick_input(_viewport, event, _shape_idx):
-	if inPlaceMode:
-		return;
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		tower_clicked.emit(self);
 
 func setup(p_id: String, p_onPlace: Callable, p_onRemove: Callable):
 	self.id = p_id;
@@ -462,5 +428,3 @@ func _exit_tree():
 signal on_animation_finished(name: String);
 # Emitted after this tower completes a skill cast (drives synergy effects).
 signal skill_cast_succeeded(tower);
-# Emitted when the player left-clicks this placed tower (drives the stats panel).
-signal tower_clicked(tower);

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -90,6 +90,8 @@ func _ready():
 	if iconRow != null and data != null:
 		iconRow.setup(data.effects)
 
+	_create_click_area();
+
 	isReady = true;
 
 func _hasActiveSkill() -> bool:
@@ -148,9 +150,33 @@ func _process(delta):
 	if enableAttack && !attacking && !usingSkill && !skillReady:
 		attackEnemy();
 
-# Area2D pick (uses the Hitbox shape). Fires only for events no Control/GUI or
-# game_scene._input consumed; place-mode clicks are suppressed at the source.
-func _input_event(_viewport, event, _shape_idx):
+# Click-pick area: the gameplay Hitbox circle only covers the base, so head
+# clicks missed (Director feedback 2026-07-16). A dedicated Area2D keeps the
+# pick surface tall without touching gameplay hit shapes. Width matches the
+# Hitbox (240); the box is raised to cover the sprite head.
+const PICK_SIZE := Vector2(240, 360)
+const PICK_OFFSET := Vector2(0, -120)
+
+func _create_click_area() -> void:
+	var area := Area2D.new()
+	area.name = "ClickArea"
+	area.monitoring = false
+	# Own layer bit (10) + empty mask: gameplay area/enemy queries never see it,
+	# while viewport picking (mask-agnostic) still does.
+	area.collision_layer = 1 << 9
+	area.collision_mask = 0
+	var shape := CollisionShape2D.new()
+	var rect := RectangleShape2D.new()
+	rect.size = PICK_SIZE
+	shape.shape = rect
+	shape.position = PICK_OFFSET
+	area.add_child(shape)
+	area.input_event.connect(_on_pick_input)
+	add_child(area)
+
+# Fires only for events no Control/GUI or game_scene._input consumed;
+# place-mode clicks are suppressed at the source.
+func _on_pick_input(_viewport, event, _shape_idx):
 	if inPlaceMode:
 		return;
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -118,6 +118,17 @@ static func _resolve_skill_block(data: Dictionary, slot_root_key: String, legacy
 		return legacy_skill_data
 	return default_block
 
+# Display-only Skill built from a passive params block (no runtime actions):
+# passives are stored as raw Dictionaries, so this gives UI consumers (stats
+# panel tooltip) the same metadata surface as an active skill. Runtime passive
+# behavior is untouched.
+static func build_passive_display_skill(passive_data: Dictionary) -> Skill:
+	if passive_data == null or passive_data.is_empty():
+		return null
+	var skill := Skill.new()
+	_apply_skill_data(skill, passive_data, "Passive")
+	return skill
+
 static func _resolve_passive_block(data: Dictionary, slot_root_key: String) -> Dictionary:
 	if not data.has(slot_root_key):
 		return {}
@@ -157,8 +168,12 @@ static func _apply_skill_data(skill: Skill, skill_data: Dictionary, default_name
 		skill.name = skill.names[0]
 	# Custom YAML parser preserves backslash escapes literally; translate "\n" tokens
 	# from skill copy into real newlines so designers can split notes onto their own line.
+	# Single tokenized desc key; a stale file still carrying the removed
+	# desc_template key warns and its tokenized text wins.
 	skill.desc = str(skill_data.get("desc", "")).replace("\\n", "\n")
-	skill.desc_template = str(skill_data.get("desc_template", "")).replace("\\n", "\n")
+	if skill_data.has("desc_template"):
+		push_warning("Skill '" + skill.name + "': 'desc_template' was merged into 'desc' - rename the key (its tokenized text is used).")
+		skill.desc = str(skill_data.get("desc_template", "")).replace("\\n", "\n")
 	skill.parameters = skill_data.get("parameters", {})
 	skill.castTime = skill_data.get("cast_time", 0.0)
 	skill.recoveryTime = skill_data.get("recovery", 0.2)

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -73,14 +73,41 @@ func _input(event):
 			_cancel_staff_skill_cast()
 
 func _unhandled_input(event):
-	# Runs after GUI consumed UI clicks but BEFORE physics picking: a left-click
-	# reaching here hit no UI -> deselect; if it lands on a tower, Tower._input_event
-	# re-selects in the same frame (deliberate ordering).
+	# Tower select via a direct pick-box lookup, NOT physics picking: GUI-consumed
+	# clicks never reach here, the placement/staff commit branches mark their
+	# clicks handled, and (unlike Area2D input_event, which missed clicks while a
+	# tower was mid-cast) this path has no physics dependency at all.
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		if state == "tower_placement" or state == "staff_skill_casting":
+		if state == "tower_placement" or state == "staff_skill_casting" or _popup_open or state == "game_over":
 			return
-		if _tower_stats_panel != null:
+		if _tower_stats_panel == null:
+			return
+		var tower := _pick_tower_at(get_global_mouse_position())
+		if tower != null:
+			_tower_stats_panel.show_tower(tower)
+		else:
 			_tower_stats_panel.clear()
+
+# Pick box in tower-local px (tower.position = cell center): full sprite incl.
+# head, wide enough to survive skill-pose shifts, narrower/shorter than the
+# 512px cell pitch so vertical neighbors' boxes don't overlap.
+const TOWER_PICK_HALF_WIDTH := 160.0
+const TOWER_PICK_TOP := -440.0
+const TOWER_PICK_BOTTOM := 70.0
+
+func _pick_tower_at(world_pos: Vector2) -> Tower:
+	var best: Tower = null
+	for node in get_tree().get_nodes_in_group("tower"):
+		var tower := node as Tower
+		if tower == null or tower.inPlaceMode:
+			continue
+		var local := world_pos - tower.position
+		if absf(local.x) <= TOWER_PICK_HALF_WIDTH and local.y >= TOWER_PICK_TOP and local.y <= TOWER_PICK_BOTTOM:
+			# Boundary tie: prefer the lower tower - the clicked pixel is nearer
+			# its body than the upper one's feet.
+			if best == null or tower.position.y > best.position.y:
+				best = tower
+	return best
 
 func _process(_delta):
 	if state == "staff_skill_casting" and _skill_cast_indicator != null:
@@ -386,9 +413,6 @@ func _on_option_selected(selection):
 			if(map != null):
 				map.toggle_grid(true);
 			add_child(result.tower);
-			# Every placed tower enters the scene exactly here; upgrades/evolves reuse
-			# the already-connected instance.
-			Utility.ConnectSignal(result.tower, "tower_clicked", Callable(self, "_on_tower_clicked"))
 			t = result.tower
 			state = "tower_placement"
 
@@ -421,13 +445,3 @@ func startWave():
 	state = "wave"
 	if(waveController):
 		waveController.start()
-
-# === Tower selection (stats panel) ===
-
-func _on_tower_clicked(tower: Tower):
-	# Selection is display-only; never react during placement / staff aiming /
-	# popups / game over (belt over the _input consume guards above).
-	if state == "tower_placement" or state == "staff_skill_casting" or _popup_open or state == "game_over":
-		return
-	if _tower_stats_panel != null:
-		_tower_stats_panel.show_tower(tower)

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -88,26 +88,19 @@ func _unhandled_input(event):
 		else:
 			_tower_stats_panel.clear()
 
-# Pick box in tower-local px (tower.position = cell center): full sprite incl.
-# head, wide enough to survive skill-pose shifts, narrower/shorter than the
-# 512px cell pitch so vertical neighbors' boxes don't overlap.
-const TOWER_PICK_HALF_WIDTH := 160.0
-const TOWER_PICK_TOP := -440.0
-const TOWER_PICK_BOTTOM := 70.0
-
+# Square pick box = the tower's own visible grid square (tower.position is the
+# square's center), so neighbor squares tile exactly with no overlap (Director
+# feedback 2026-07-16).
 func _pick_tower_at(world_pos: Vector2) -> Tower:
-	var best: Tower = null
+	var half := GridHelper.CELL_SIZE / 2.0
 	for node in get_tree().get_nodes_in_group("tower"):
 		var tower := node as Tower
 		if tower == null or tower.inPlaceMode:
 			continue
 		var local := world_pos - tower.position
-		if absf(local.x) <= TOWER_PICK_HALF_WIDTH and local.y >= TOWER_PICK_TOP and local.y <= TOWER_PICK_BOTTOM:
-			# Boundary tie: prefer the lower tower - the clicked pixel is nearer
-			# its body than the upper one's feet.
-			if best == null or tower.position.y > best.position.y:
-				best = tower
-	return best
+		if absf(local.x) <= half and absf(local.y) <= half:
+			return tower
+	return null
 
 func _process(_delta):
 	if state == "staff_skill_casting" and _skill_cast_indicator != null:

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -40,6 +40,9 @@ var _state_before_skill_cast: String = ""
 # Ref to the Staff HUD widget so _input can ask whether a click landed on the skill button.
 var _staff_widget: StaffWidget = null
 
+# Bottom-left tower stats panel (display-only selection surface).
+var _tower_stats_panel: TowerStatsPanel = null
+
 func _input(event):
 	if state == "tower_placement" and event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
 		if(t != null && !t.isOnValidCell):
@@ -50,6 +53,9 @@ func _input(event):
 		if(map != null):
 			map.toggle_grid(false);
 		startWave();
+		# Consume the commit click: state is already back to "wave" here, and physics
+		# picking runs last - without this, the same click would select the placed tower.
+		get_viewport().set_input_as_handled();
 	elif state == "staff_skill_casting":
 		if event is InputEventMouseButton and event.pressed:
 			if event.button_index == MOUSE_BUTTON_LEFT:
@@ -58,10 +64,23 @@ func _input(event):
 				if _staff_widget != null and _staff_widget.is_skill_button_hovered():
 					return
 				_commit_staff_skill_cast()
+				# Same race as the placement commit: consume so the cast click cannot
+				# also pick whatever tower sits under the cursor.
+				get_viewport().set_input_as_handled()
 			elif event.button_index == MOUSE_BUTTON_RIGHT:
 				_cancel_staff_skill_cast()
 		elif event is InputEventKey and event.pressed and event.keycode == KEY_ESCAPE:
 			_cancel_staff_skill_cast()
+
+func _unhandled_input(event):
+	# Runs after GUI consumed UI clicks but BEFORE physics picking: a left-click
+	# reaching here hit no UI -> deselect; if it lands on a tower, Tower._input_event
+	# re-selects in the same frame (deliberate ordering).
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		if state == "tower_placement" or state == "staff_skill_casting":
+			return
+		if _tower_stats_panel != null:
+			_tower_stats_panel.clear()
 
 func _process(_delta):
 	if state == "staff_skill_casting" and _skill_cast_indicator != null:
@@ -83,6 +102,7 @@ func _ready():
 
 	# Staff system: load data → instantiate entity → wire widget → spawn endpoint sprite.
 	setup_staff()
+	_tower_stats_panel = get_node_or_null("GameUI/TowerStatsPanel") as TowerStatsPanel
 	var camera = get_node("Camera2D")
 	camera.make_current()
 	if(map != null):
@@ -366,6 +386,9 @@ func _on_option_selected(selection):
 			if(map != null):
 				map.toggle_grid(true);
 			add_child(result.tower);
+			# Every placed tower enters the scene exactly here; upgrades/evolves reuse
+			# the already-connected instance.
+			Utility.ConnectSignal(result.tower, "tower_clicked", Callable(self, "_on_tower_clicked"))
 			t = result.tower
 			state = "tower_placement"
 
@@ -398,3 +421,13 @@ func startWave():
 	state = "wave"
 	if(waveController):
 		waveController.start()
+
+# === Tower selection (stats panel) ===
+
+func _on_tower_clicked(tower: Tower):
+	# Selection is display-only; never react during placement / staff aiming /
+	# popups / game over (belt over the _input consume guards above).
+	if state == "tower_placement" or state == "staff_skill_casting" or _popup_open or state == "game_over":
+		return
+	if _tower_stats_panel != null:
+		_tower_stats_panel.show_tower(tower)

--- a/scripts/skill/skill.gd
+++ b/scripts/skill/skill.gd
@@ -35,7 +35,10 @@ func get_display_name(level: int) -> String:
 		return names[index]
 	return name
 
-func get_display_desc(level: int) -> String:
+# highlight_color (BBCode hex, e.g. "#5AC8FA"): wraps values coming from a
+# per-level (array) parameter so the player sees which number scales -
+# mirrors SynergyData._render. "" returns plain text.
+func get_display_desc(level: int, highlight_color: String = "") -> String:
 	if desc == "":
 		return ""
 
@@ -48,7 +51,10 @@ func get_display_desc(level: int) -> String:
 		var param_name := match_result.get_string(1)
 		var format := match_result.get_string(2)
 		var value = _get_display_parameter(param_name, level)
-		result = result.substr(0, match_result.get_start()) + _format_display_parameter(value, format) + result.substr(match_result.get_end())
+		var text := _format_display_parameter(value, format)
+		if highlight_color != "" and parameters.get(param_name) is Array:
+			text = "[color=" + highlight_color + "]" + text + "[/color]"
+		result = result.substr(0, match_result.get_start()) + text + result.substr(match_result.get_end())
 	return result
 
 func _get_display_parameter(param_name: String, level: int):

--- a/scripts/skill/skill.gd
+++ b/scripts/skill/skill.gd
@@ -4,9 +4,10 @@ class_name Skill
 enum TARGET_TYPE {ENEMY, FRIENDLY}
 
 @export var name:String = "Skill"
-@export var desc:String = "Just a skill"
+# Single tokenized desc source: {param} / {param:percent} resolve from
+# `parameters` at display time; a token-free desc renders as-is.
+@export var desc:String = ""
 @export var names: Array[String] = []
-@export var desc_template: String = ""
 @export var oneTimeUse: bool = false
 @export var castTime: float = 0.0
 @export var recoveryTime: float = 0.0
@@ -20,7 +21,7 @@ enum TARGET_TYPE {ENEMY, FRIENDLY}
 var using = false;
 var disable = false;
 
-func _init(p_name:String="Skill", p_desc:String="Just a skill", p_actions:Array[SkillAction]=[], p_parameters:Dictionary={}, p_oneTimeUse: bool = false, p_castTime: float = 0.0):
+func _init(p_name:String="Skill", p_desc:String="", p_actions:Array[SkillAction]=[], p_parameters:Dictionary={}, p_oneTimeUse: bool = false, p_castTime: float = 0.0):
 	self.name = p_name;
 	self.desc = p_desc;
 	self.actions = p_actions;
@@ -35,13 +36,13 @@ func get_display_name(level: int) -> String:
 	return name
 
 func get_display_desc(level: int) -> String:
-	if desc_template == "":
-		return desc
+	if desc == "":
+		return ""
 
-	var result := desc_template
+	var result := desc
 	var regex := RegEx.new()
 	regex.compile("\\{([^}:]+)(?::([^}]+))?\\}")
-	var matches := regex.search_all(desc_template)
+	var matches := regex.search_all(desc)
 	for i in range(matches.size() - 1, -1, -1):
 		var match_result := matches[i]
 		var param_name := match_result.get_string(1)

--- a/scripts/synergy/synergy_data.gd
+++ b/scripts/synergy/synergy_data.gd
@@ -3,7 +3,7 @@ class_name SynergyData
 # One synergy definition loaded from resources/database/synergy/<id>.yaml.
 # Values live in YAML (designer-tunable); behaviour lives in SynergyEffect.
 # Numbers are read through get_parameter so the displayed text and the applied
-# effect share one source (mirrors Skill.parameters / desc_template).
+# effect share one source (mirrors Skill.parameters / tokenized desc).
 
 var id: String = ""                # file/data key, e.g. "myth"
 var synergy_id: int = 0            # TowerTrait enum int (resolved at load)
@@ -13,8 +13,7 @@ var type: String = "normal"       # UI category: normal | quest | special
 var effect: String = ""           # SynergyEffect handler key ("" = placeholder)
 var thresholds: Array = []        # proc count per tier (untyped: YamlParser yields untyped Array)
 var parameters: Dictionary = {}   # name -> per-tier array (or scalar)
-var desc_template: String = ""    # flavour line (hover header), may hold {param} tokens
-var desc: String = ""             # plain fallback when desc_template is empty
+var desc: String = ""             # flavour line (hover header), may hold {param} tokens
 # Per-tier effect lines for the hover table. size 1 -> the one template is used
 # for every tier (pure scaling, e.g. Myth); size == tier_count -> one line per
 # tier (qualitative tiers, e.g. a Tempus-style "unlock" at a higher tier).
@@ -53,8 +52,7 @@ func get_parameter(param_name: String, tier: int):
 # that come from a per-tier (array) parameter, so the player sees which number
 # scales; "" returns plain text.
 func flavor(tier: int, highlight_color: String = "") -> String:
-	var template := desc_template if desc_template != "" else desc
-	return _render(template, tier, highlight_color)
+	return _render(desc, tier, highlight_color)
 
 # One hover-table line for a tier (see tier_effects).
 func tier_effect(tier: int, highlight_color: String = "") -> String:

--- a/scripts/synergy/synergy_data_loader.gd
+++ b/scripts/synergy/synergy_data_loader.gd
@@ -33,10 +33,13 @@ static func _build(raw: Dictionary, path: String) -> SynergyData:
 	d.kind = str(raw.get("kind", ""))
 	d.type = str(raw.get("type", "normal"))
 	d.effect = str(raw.get("effect", ""))
-	d.desc = str(raw.get("desc", ""))
 	# YamlParser does not process escapes; translate \n loader-side, only for the
 	# text fields that want it (data_pipeline.md Problem #1).
-	d.desc_template = str(raw.get("desc_template", "")).replace("\\n", "\n")
+	# Single tokenized desc key; a stale desc_template key warns and wins.
+	d.desc = str(raw.get("desc", "")).replace("\\n", "\n")
+	if raw.has("desc_template"):
+		push_warning("Synergy '" + d.id + "': 'desc_template' was merged into 'desc' - rename the key (its tokenized text is used).")
+		d.desc = str(raw.get("desc_template", "")).replace("\\n", "\n")
 	for line in raw.get("tier_effects", []):
 		d.tier_effects.append(str(line).replace("\\n", "\n"))
 

--- a/scripts/ui/tower_skill_icon.gd
+++ b/scripts/ui/tower_skill_icon.gd
@@ -1,10 +1,14 @@
 class_name TowerSkillIcon
 extends TextureRect
 
-# Skill-icon hover for the tower stats panel: rich tooltip built from Skill
-# display metadata (get_display_name / get_display_desc) at the tower's current
-# level - the template desc path, never raw legacy desc. Mirrors the
-# StaffSkillTooltip pattern (staff_skill_tooltip.gd).
+# Skill-icon hover for the tower stats panel: Dota2-style rich tooltip built
+# from Skill display metadata at the tower's current level - name, kind line,
+# affects/tags lines, then the desc with per-level scaling values highlighted.
+# Palette + layout mirror the synergy hover (ui_synergy_content.gd).
+
+const SCALING_COLOR := "#5AC8FA"   # per-level scaling value (synergy hover palette)
+const DIM_COLOR := "#7A7A7A"       # metadata lines (affects / tags)
+const KIND_COLOR := "#FFD15A"      # kind line (single gold)
 
 var skill: Skill = null
 var kind_label: String = ""
@@ -33,12 +37,41 @@ func _build_hover_bbcode() -> String:
 	if skill == null:
 		return ""
 	var lines: PackedStringArray = []
-	var title := "[b]" + skill.get_display_name(level) + "[/b]"
+	lines.append("[b]" + skill.get_display_name(level) + "[/b]")
+
 	if kind_label != "":
-		title += " (" + kind_label + ")"
-	lines.append(title)
-	var desc := skill.get_display_desc(level)
+		var kind_line := kind_label.to_upper()
+		if kind_label == "Active":
+			kind_line += " - CASTS AT FULL ENERGY"
+		lines.append("[color=" + KIND_COLOR + "]" + kind_line + "[/color]")
+
+	var affects := _affects_line()
+	if affects != "":
+		lines.append("[color=" + DIM_COLOR + "]" + affects + "[/color]")
+
+	if not skill.tags.is_empty():
+		var tag_names: PackedStringArray = []
+		for tag in skill.tags:
+			tag_names.append(str(tag).capitalize().to_upper())
+		lines.append("[color=" + DIM_COLOR + "]TAGS: " + ", ".join(tag_names) + "[/color]")
+
+	var desc := skill.get_display_desc(level, SCALING_COLOR)
 	if desc != "":
 		lines.append("")
 		lines.append(desc)
 	return "\n".join(lines)
+
+# "AFFECTS: ENEMY - AREA" from the skill's target_summary (team + shape).
+func _affects_line() -> String:
+	if skill.target_summary.is_empty():
+		return ""
+	var parts: PackedStringArray = []
+	var team := str(skill.target_summary.get("target_team", ""))
+	var shape := str(skill.target_summary.get("target_shape", ""))
+	if team != "":
+		parts.append(team.to_upper())
+	if shape != "":
+		parts.append(shape.to_upper())
+	if parts.is_empty():
+		return ""
+	return "AFFECTS: " + " - ".join(parts)

--- a/scripts/ui/tower_skill_icon.gd
+++ b/scripts/ui/tower_skill_icon.gd
@@ -14,8 +14,9 @@ func setup(p_skill: Skill, p_kind: String, p_level: int) -> void:
 	skill = p_skill
 	kind_label = p_kind
 	level = p_level
-	# Non-empty tooltip_text is required for _make_custom_tooltip to trigger.
-	tooltip_text = " "
+	# tooltip_text must carry REAL text: the viewport strips whitespace and
+	# shows nothing for a blank tooltip, custom tooltip included.
+	tooltip_text = p_skill.get_display_name(p_level) if p_skill != null else ""
 	mouse_filter = Control.MOUSE_FILTER_STOP
 
 func _make_custom_tooltip(_for_text: String) -> Object:

--- a/scripts/ui/tower_skill_icon.gd
+++ b/scripts/ui/tower_skill_icon.gd
@@ -25,10 +25,22 @@ func setup(p_skill: Skill, p_kind: String, p_level: int) -> void:
 
 func _make_custom_tooltip(_for_text: String) -> Object:
 	var panel := PanelContainer.new()
+	# Opaque dark card (stats-panel palette): the default tooltip theme let the
+	# panel text underneath bleed through and the two texts collided.
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.07, 0.05, 0.12, 0.97)
+	style.border_color = Color(0.85, 0.7, 0.45, 0.9)
+	style.set_border_width_all(2)
+	style.set_corner_radius_all(10)
+	style.content_margin_left = 12
+	style.content_margin_right = 12
+	style.content_margin_top = 10
+	style.content_margin_bottom = 10
+	panel.add_theme_stylebox_override("panel", style)
 	var rich := RichTextLabel.new()
 	rich.bbcode_enabled = true
 	rich.fit_content = true
-	rich.custom_minimum_size = Vector2(320, 0)
+	rich.custom_minimum_size = Vector2(340, 0)
 	rich.text = _build_hover_bbcode()
 	panel.add_child(rich)
 	return panel
@@ -40,20 +52,18 @@ func _build_hover_bbcode() -> String:
 	lines.append("[b]" + skill.get_display_name(level) + "[/b]")
 
 	if kind_label != "":
-		var kind_line := kind_label.to_upper()
-		if kind_label == "Active":
-			kind_line += " - CASTS AT FULL ENERGY"
-		lines.append("[color=" + KIND_COLOR + "]" + kind_line + "[/color]")
+		lines.append("[color=" + KIND_COLOR + "]" + kind_label.to_upper() + "[/color]")
 
 	var affects := _affects_line()
 	if affects != "":
 		lines.append("[color=" + DIM_COLOR + "]" + affects + "[/color]")
 
+	# Bare tag list, no "TAGS:" prefix (long lists eat the line - Director).
 	if not skill.tags.is_empty():
 		var tag_names: PackedStringArray = []
 		for tag in skill.tags:
 			tag_names.append(str(tag).capitalize().to_upper())
-		lines.append("[color=" + DIM_COLOR + "]TAGS: " + ", ".join(tag_names) + "[/color]")
+		lines.append("[color=" + DIM_COLOR + "]" + ", ".join(tag_names) + "[/color]")
 
 	var desc := skill.get_display_desc(level, SCALING_COLOR)
 	if desc != "":

--- a/scripts/ui/tower_skill_icon.gd
+++ b/scripts/ui/tower_skill_icon.gd
@@ -1,0 +1,43 @@
+class_name TowerSkillIcon
+extends TextureRect
+
+# Skill-icon hover for the tower stats panel: rich tooltip built from Skill
+# display metadata (get_display_name / get_display_desc) at the tower's current
+# level - the template desc path, never raw legacy desc. Mirrors the
+# StaffSkillTooltip pattern (staff_skill_tooltip.gd).
+
+var skill: Skill = null
+var kind_label: String = ""
+var level: int = 1
+
+func setup(p_skill: Skill, p_kind: String, p_level: int) -> void:
+	skill = p_skill
+	kind_label = p_kind
+	level = p_level
+	# Non-empty tooltip_text is required for _make_custom_tooltip to trigger.
+	tooltip_text = " "
+	mouse_filter = Control.MOUSE_FILTER_STOP
+
+func _make_custom_tooltip(_for_text: String) -> Object:
+	var panel := PanelContainer.new()
+	var rich := RichTextLabel.new()
+	rich.bbcode_enabled = true
+	rich.fit_content = true
+	rich.custom_minimum_size = Vector2(320, 0)
+	rich.text = _build_hover_bbcode()
+	panel.add_child(rich)
+	return panel
+
+func _build_hover_bbcode() -> String:
+	if skill == null:
+		return ""
+	var lines: PackedStringArray = []
+	var title := "[b]" + skill.get_display_name(level) + "[/b]"
+	if kind_label != "":
+		title += " (" + kind_label + ")"
+	lines.append(title)
+	var desc := skill.get_display_desc(level)
+	if desc != "":
+		lines.append("")
+		lines.append(desc)
+	return "\n".join(lines)

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -1,0 +1,143 @@
+class_name TowerStatsPanel
+extends Control
+
+# Placeholder tower stats panel (bottom-left HUD). Artist design pass pending.
+# The skeleton (portrait / name+level header / trait row / stat grid / energy
+# bar / skill icon row) is the shared layout convention for the future enemy
+# stats panel (ui.md).
+
+@onready var _portrait: TextureRect = $Portrait
+@onready var _name_label: Label = $NameLabel
+@onready var _level_label: Label = $LevelLabel
+@onready var _class_icon: TextureRect = $TraitRow/ClassIcon
+@onready var _class_label: Label = $TraitRow/ClassLabel
+@onready var _gen_icon: TextureRect = $TraitRow/GenIcon
+@onready var _gen_label: Label = $TraitRow/GenLabel
+@onready var _atk_value: Label = $StatsGrid/AtkValue
+@onready var _type_value: Label = $StatsGrid/TypeValue
+@onready var _as_value: Label = $StatsGrid/AsValue
+@onready var _crit_value: Label = $StatsGrid/CritValue
+@onready var _crit_dmg_value: Label = $StatsGrid/CritDmgValue
+@onready var _energy_row: Control = $EnergyRow
+@onready var _energy_bar: ProgressBar = $EnergyRow/EnergyBar
+@onready var _energy_text: Label = $EnergyRow/EnergyBar/EnergyText
+@onready var _start_label: Label = $EnergyRow/StartLabel
+@onready var _skill_row: HBoxContainer = $SkillRow
+
+var _tower: Tower = null
+# Rebuild key for the skill-icon row ("level_isEvolved"): icons/tooltips only
+# change on level-up or evolve, so the per-frame poll skips the rebuild.
+var _skills_key: String = ""
+
+func _ready():
+	visible = false
+
+func show_tower(tower: Tower) -> void:
+	_tower = tower
+	_skills_key = ""
+	visible = true
+	_refresh()
+
+func clear() -> void:
+	_tower = null
+	visible = false
+
+func _process(_delta):
+	if not visible:
+		return
+	if _tower == null or not is_instance_valid(_tower):
+		clear()
+		return
+	_refresh()
+
+func _refresh() -> void:
+	var data: TowerData = _tower.data
+	if data == null:
+		clear()
+		return
+
+	# Identity: tower.id is the data key; display name + portrait come from the
+	# TowerCenter registry (same access pattern as Tower.setup).
+	var entry = TowerCenter._towers_data.get(_tower.id.to_lower(), null)
+	_set_text(_name_label, entry.name if entry != null else _tower.id)
+	_portrait.texture = TowerCenter._tower_portrait.get(entry.data_name, null) if entry != null else null
+
+	_set_text(_level_label, "Evolved" if data.isEvolved else "Level %d" % data.level)
+
+	# Traits: display names + synergy icons (default.png fallback, PR #95 pattern).
+	var class_display: String = TowerTrait.TOWER_CLASS_NAMES.get(data.towerClass, "default")
+	var gen_display: String = TowerTrait.TOWER_GENERATION_NAMES.get(data.generation, "default")
+	_set_text(_class_label, class_display)
+	_set_text(_gen_label, gen_display)
+	_class_icon.texture = _trait_sprite(class_display)
+	_gen_icon.texture = _trait_sprite(gen_display)
+
+	# Stats: live getters, so buffs/debuffs show (player-facing terms per game_copy.md).
+	_set_text(_atk_value, str(data.getTotalAttack()))
+	_set_text(_type_value, "Magic" if data.attackType == Damage.DamageType.MAGIC else "Physical")
+	_set_text(_as_value, _format_number(data.getAttackSpeed()))
+	_set_text(_crit_value, _format_number(data.getCritChance()) + "%")
+	_set_text(_crit_dmg_value, "x" + _format_number(data.getCritDamage()))
+
+	# Energy: evolve swaps the SkillController (tower.gd evolve) - re-read every
+	# frame, never cache. Passive-only towers have none -> hide the row.
+	var sc = _tower.skillController
+	_energy_row.visible = sc != null
+	if sc != null:
+		_energy_bar.max_value = sc.maxMana
+		_energy_bar.value = sc.currentMana
+		_set_text(_energy_text, "%d / %d" % [int(sc.currentMana), int(sc.maxMana)])
+		_set_text(_start_label, "Start %d" % int(data.getStat().initialMana))
+
+	var skills_key := "%d_%s" % [data.level, data.isEvolved]
+	if skills_key != _skills_key:
+		_skills_key = skills_key
+		_rebuild_skill_row(data)
+
+func _rebuild_skill_row(data: TowerData) -> void:
+	for child in _skill_row.get_children():
+		child.queue_free()
+
+	var level: int = data.level
+	var active: Skill = data.evolutionSkill if data.isEvolved and data.evolutionSkill != null else data.skill
+	if active != null and not active.actions.is_empty():
+		_skill_row.add_child(_make_skill_icon(active, "Active", level))
+
+	var passive_params: Dictionary = data.evolutionPassive if data.isEvolved and not data.evolutionPassive.is_empty() else data.passive
+	var passive_skill: Skill = TowerDataLoader.build_passive_display_skill(passive_params)
+	if passive_skill != null:
+		_skill_row.add_child(_make_skill_icon(passive_skill, "Passive", level))
+
+func _make_skill_icon(skill: Skill, kind: String, level: int) -> TowerSkillIcon:
+	var icon := TowerSkillIcon.new()
+	icon.custom_minimum_size = Vector2(48, 48)
+	icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	icon.setup(skill, kind, level)
+
+	# No tower skill icon art exists yet; the shared synergy default placeholder
+	# stands in (a dedicated skills/default asset needs a Godot-generated .import,
+	# so reuse beats hand-adding a binary - see tower_skill.md icon note).
+	var texture: Texture2D = null
+	if skill.icon != "":
+		texture = ResourceManager.loadImage("skill_icon", skill.icon, skill.icon)
+	if texture == null:
+		texture = ResourceManager.getSprite("synergy", "default")
+	icon.texture = texture
+	return icon
+
+func _trait_sprite(trait_display: String) -> Texture2D:
+	var sprite = ResourceManager.getSprite("synergy", trait_display.to_lower())
+	if sprite == null:
+		sprite = ResourceManager.getSprite("synergy", "default")
+	return sprite
+
+# Skip no-op text writes so per-frame polling doesn't churn label layout (PR #20 rule).
+func _set_text(label: Label, value: String) -> void:
+	if label.text != value:
+		label.text = value
+
+func _format_number(value: float) -> String:
+	if is_equal_approx(value, round(value)):
+		return str(int(round(value)))
+	return "%.1f" % value

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -21,7 +21,6 @@ extends Control
 @onready var _energy_row: Control = $EnergyRow
 @onready var _energy_bar: ProgressBar = $EnergyRow/EnergyBar
 @onready var _energy_text: Label = $EnergyRow/EnergyBar/EnergyText
-@onready var _start_label: Label = $EnergyRow/StartLabel
 @onready var _skill_row: HBoxContainer = $SkillRow
 
 var _tower: Tower = null
@@ -77,7 +76,9 @@ func _refresh() -> void:
 	_set_text(_type_value, "Magic" if data.attackType == Damage.DamageType.MAGIC else "Physical")
 	_set_text(_as_value, _format_number(data.getAttackSpeed()))
 	_set_text(_crit_value, _format_number(data.getCritChance()) + "%")
-	_set_text(_crit_dmg_value, "x" + _format_number(data.getCritDamage()))
+	# Display-only percent form (1.5 -> "150%"); the damage formula still uses
+	# the raw multiplier.
+	_set_text(_crit_dmg_value, _format_number(data.getCritDamage() * 100.0) + "%")
 
 	# Energy: evolve swaps the SkillController (tower.gd evolve) - re-read every
 	# frame, never cache. Passive-only towers have none -> hide the row.
@@ -87,7 +88,6 @@ func _refresh() -> void:
 		_energy_bar.max_value = sc.maxMana
 		_energy_bar.value = sc.currentMana
 		_set_text(_energy_text, "%d / %d" % [int(sc.currentMana), int(sc.maxMana)])
-		_set_text(_start_label, "Start %d" % int(data.getStat().initialMana))
 
 	var skills_key := "%d_%s" % [data.level, data.isEvolved]
 	if skills_key != _skills_key:

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -14,9 +14,11 @@ extends Control
 @onready var _gen_icon: TextureRect = $TraitRow/GenIcon
 @onready var _gen_label: Label = $TraitRow/GenLabel
 @onready var _atk_value: Label = $StatsGrid/AtkValue
+@onready var _type_value: Label = $StatsGrid/TypeValue
 @onready var _as_value: Label = $StatsGrid/AsValue
 @onready var _crit_value: Label = $StatsGrid/CritValue
 @onready var _crit_dmg_value: Label = $StatsGrid/CritDmgValue
+@onready var _range_value: Label = $StatsGrid/RangeValue
 @onready var _energy_row: Control = $EnergyRow
 @onready var _energy_bar: ProgressBar = $EnergyRow/EnergyBar
 @onready var _energy_text: Label = $EnergyRow/EnergyBar/EnergyText
@@ -73,10 +75,11 @@ func _refresh() -> void:
 	_gen_icon.texture = _trait_sprite(gen_display)
 
 	# Stats: live getters, so buffs/debuffs show (player-facing terms per
-	# game_copy.md). Attack type rides the Attack value to keep the grid 2x2.
-	var type_display := "Magic" if data.attackType == Damage.DamageType.MAGIC else "Physical"
-	_set_text(_atk_value, "%d (%s)" % [data.getTotalAttack(), type_display])
+	# game_copy.md). 3x2 grid: attack block left, crit block + range right.
+	_set_text(_atk_value, str(data.getTotalAttack()))
+	_set_text(_type_value, "Magic" if data.attackType == Damage.DamageType.MAGIC else "Physical")
 	_set_text(_as_value, _format_number(data.getAttackSpeed()))
+	_set_text(_range_value, _format_number(data.getAttackRange()))
 	_set_text(_crit_value, _format_number(data.getCritChance()) + "%")
 	# Display-only percent form (1.5 -> "150%"); the damage formula still uses
 	# the raw multiplier.

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -3,8 +3,8 @@ extends Control
 
 # Placeholder tower stats panel (bottom-left HUD). Artist design pass pending.
 # The skeleton (portrait / name+level header / trait row / stat grid / energy
-# bar / skill icon row) is the shared layout convention for the future enemy
-# stats panel (ui.md).
+# bar / right-edge skill icon column) is the shared layout convention for the
+# future enemy stats panel (ui.md).
 
 @onready var _portrait: TextureRect = $Portrait
 @onready var _name_label: Label = $NameLabel
@@ -14,14 +14,15 @@ extends Control
 @onready var _gen_icon: TextureRect = $TraitRow/GenIcon
 @onready var _gen_label: Label = $TraitRow/GenLabel
 @onready var _atk_value: Label = $StatsGrid/AtkValue
-@onready var _type_value: Label = $StatsGrid/TypeValue
 @onready var _as_value: Label = $StatsGrid/AsValue
 @onready var _crit_value: Label = $StatsGrid/CritValue
 @onready var _crit_dmg_value: Label = $StatsGrid/CritDmgValue
 @onready var _energy_row: Control = $EnergyRow
 @onready var _energy_bar: ProgressBar = $EnergyRow/EnergyBar
 @onready var _energy_text: Label = $EnergyRow/EnergyBar/EnergyText
-@onready var _skill_row: HBoxContainer = $SkillRow
+# Right-edge column: the hover popup opens toward the open playfield instead of
+# over the panel's own stat text (Director feedback 2026-07-16).
+@onready var _skill_column: VBoxContainer = $SkillColumn
 
 var _tower: Tower = null
 # Rebuild key for the skill-icon row ("level_isEvolved"): icons/tooltips only
@@ -71,9 +72,10 @@ func _refresh() -> void:
 	_class_icon.texture = _trait_sprite(class_display)
 	_gen_icon.texture = _trait_sprite(gen_display)
 
-	# Stats: live getters, so buffs/debuffs show (player-facing terms per game_copy.md).
-	_set_text(_atk_value, str(data.getTotalAttack()))
-	_set_text(_type_value, "Magic" if data.attackType == Damage.DamageType.MAGIC else "Physical")
+	# Stats: live getters, so buffs/debuffs show (player-facing terms per
+	# game_copy.md). Attack type rides the Attack value to keep the grid 2x2.
+	var type_display := "Magic" if data.attackType == Damage.DamageType.MAGIC else "Physical"
+	_set_text(_atk_value, "%d (%s)" % [data.getTotalAttack(), type_display])
 	_set_text(_as_value, _format_number(data.getAttackSpeed()))
 	_set_text(_crit_value, _format_number(data.getCritChance()) + "%")
 	# Display-only percent form (1.5 -> "150%"); the damage formula still uses
@@ -95,22 +97,22 @@ func _refresh() -> void:
 		_rebuild_skill_row(data)
 
 func _rebuild_skill_row(data: TowerData) -> void:
-	for child in _skill_row.get_children():
+	for child in _skill_column.get_children():
 		child.queue_free()
 
 	var level: int = data.level
 	var active: Skill = data.evolutionSkill if data.isEvolved and data.evolutionSkill != null else data.skill
 	if active != null and not active.actions.is_empty():
-		_skill_row.add_child(_make_skill_icon(active, "Active", level))
+		_skill_column.add_child(_make_skill_icon(active, "Active", level))
 
 	var passive_params: Dictionary = data.evolutionPassive if data.isEvolved and not data.evolutionPassive.is_empty() else data.passive
 	var passive_skill: Skill = TowerDataLoader.build_passive_display_skill(passive_params)
 	if passive_skill != null:
-		_skill_row.add_child(_make_skill_icon(passive_skill, "Passive", level))
+		_skill_column.add_child(_make_skill_icon(passive_skill, "Passive", level))
 
 func _make_skill_icon(skill: Skill, kind: String, level: int) -> TowerSkillIcon:
 	var icon := TowerSkillIcon.new()
-	icon.custom_minimum_size = Vector2(48, 48)
+	icon.custom_minimum_size = Vector2(56, 56)
 	icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
 	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	icon.setup(skill, kind, level)

--- a/scripts/ui_scenes/deck_selection.gd
+++ b/scripts/ui_scenes/deck_selection.gd
@@ -180,13 +180,15 @@ func _refresh_staff_card():
 		var icon_path = "res://resources/" + data.hud_skill_icon
 		if ResourceLoader.exists(icon_path):
 			_manager_skill_icon.texture = load(icon_path)
-	# Phase 2: skill is now a Skill resource (data.skill). Read .name / .desc when present;
-	# fall back to scene placeholder text when staff has no skill defined or fields are empty.
+	# Skill text goes through the display metadata path (tokens resolve; a plain
+	# desc renders as-is). Fall back to scene placeholder text when staff has no
+	# skill defined or fields are empty.
 	if data.skill != null:
-		if data.skill.name != "":
-			_manager_skill_name.text = data.skill.name
-		if data.skill.desc != "":
-			_manager_skill_desc.text = data.skill.desc
+		if data.skill.get_display_name(1) != "":
+			_manager_skill_name.text = data.skill.get_display_name(1)
+		var skill_desc: String = data.skill.get_display_desc(1)
+		if skill_desc != "":
+			_manager_skill_desc.text = skill_desc
 
 func _on_exit():
 	get_tree().change_scene_to_file("res://scenes/main_menu.tscn")


### PR DESCRIPTION
**Summary:** First player-facing tower stats panel (bottom-left; click a placed tower) plus corpus-wide skill-desc unification: the legacy plain `desc` / tokenized `desc_template` pair is merged into a single tokenized `desc` key.

**How it works:**
- Click-select: `game_scene._unhandled_input` runs a direct grid-square lookup (`_pick_tower_at`, box = the tower's own `CELL_SIZE` square) - no physics picking. GUI clicks never reach it, and the tower-placement / staff-cast commit clicks are consumed with `set_input_as_handled` so a commit click cannot also select.
- Panel (`tower_stats_panel.tscn` / `tower_stats_panel.gd`, instanced in `game_ui.tscn`): portrait, name, Level/Evolved, both traits with synergy icons, 3x2 live stat grid (Attack, Attack Type, Range, Attack Speed, Crit Rate, Crit DMG as percent), live Energy bar (hidden for passive-only towers), right-edge skill icon column. Values poll per frame with no-op text writes skipped.
- Skill hover (`tower_skill_icon.gd`): opaque Dota-style card - skill name, ACTIVE/PASSIVE, AFFECTS line, tag list, then the desc resolved at the tower's current level with per-level (array) parameter values highlighted (`Skill.get_display_desc` gained an optional highlight color, mirroring `SynergyData._render`). Passives render through a display-only `Skill` built from the passive dict (`TowerDataLoader.build_passive_display_skill`); runtime passives untouched.
- Desc unification: `Skill.desc` is now the single tokenized source (`{param}` / `{param:percent}` from `parameters`; token-free desc renders as-is). Applied across `Skill`, `SynergyData`, both loaders (which warn and prefer the tokenized text if a stale `desc_template` key ever reappears), 8 tower YAML, synergy YAML, and `deck_selection` (now reads `get_display_desc`). The 4 Tempus legacy-block towers got neutral-word desc with no digits; their numbers move into `parameters` + tokens at each tower's balance pass.

**Implementation Notes:**
- Root-cause fix riding along: 5 skill-effect scripts (Calliope x3, Amelia x2) created VFX `ColorRect`s without setting `mouse_filter`, so the Control-default STOP silently ate every world click under the effect while it played. Now `MOUSE_FILTER_IGNORE`, matching `SkillVfx.make_lane_rect`. This was the "cannot select a tower mid-cast" bug.
- Skill icons fall back to the shared synergy `default.png` placeholder; a dedicated skills placeholder would need a Godot-generated `.import` sidecar, so no new binary is added.
- `resources/database/skill/takanashi_kiara_skill.tres` still carries the old desc shape but is dead content ext_resourced only by the (also dead) `takanashi_kiara_data.tres` - left for the existing dead-`.tres` Lead-confirm item rather than deleted here.

**Touched scenes:** resources/ui_component/game_ui.tscn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
