### PR TITLE
Hide synergy chips on deck-add popup cards

### DIFF
--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -141,8 +141,8 @@ func _apply_cards_to_buttons(cards: Array) -> void:
 		if index < cards.size():
 			var cardSelectData: TowerSelectData = cards[index] as TowerSelectData;
 			# Deck popup callsite passes deck keys (e.g. "myth") as card name, which
-			# are not registered tower names — fall through with default trait icons
-			# so the synergy chips render the "default" sprite instead of crashing.
+			# are not registered tower names - tClass/tGen stay 0 (no real trait)
+			# and Setup() hides the synergy chip bar for those cards.
 			var entry = TowerCenter.getTowerDataByName(cardSelectData.name);
 			var tClass: int = 0;
 			var tGen: int = 0;

--- a/scripts/ui/tower_select/tower_select_button.gd
+++ b/scripts/ui/tower_select/tower_select_button.gd
@@ -8,6 +8,7 @@ var towerPortrait: TextureRect;
 
 var towerClassImage: TextureRect;
 var towerGenImage: TextureRect;
+var synergiesNode: Control;
 
 func _ready():
 	add_to_group("tower_buttons")  # Ensures buttons register correctly
@@ -19,6 +20,7 @@ func Setup(p_name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: 
 	towerPortrait = $TowerPortrait
 	towerClassImage = $Synergies/Class
 	towerGenImage = $Synergies/Gen
+	synergiesNode = $Synergies
 
 	towerNameText.text = p_name + ("\nLevel " + str(level) if level > 0 else "")
 	evolutionNode.visible = evolutionCost > 0
@@ -29,6 +31,10 @@ func Setup(p_name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: 
 		var portrait = TowerCenter.getTowerPortraitByName(p_name.to_lower());
 		if(portrait):
 			towerPortrait.texture = portrait
+	# No real trait on either slot (deck-add popup cards) -> no synergy chip bar.
+	synergiesNode.visible = TowerTrait.TOWER_CLASS_NAMES.has(towerClass) or TowerTrait.TOWER_GENERATION_NAMES.has(towerGen)
+	if !synergiesNode.visible:
+		return
 	var tClassName = TowerTrait.TOWER_CLASS_NAMES.get(towerClass, "default").to_lower();
 	var classSprite = ResourceManager.getSprite("synergy", tClassName);
 	if(classSprite == null):


### PR DESCRIPTION
**Problem:** After PR #95's `default.png` fallback, the mid-run "Select Additional Deck" popup shows grey synergy placeholder icons on deck cards. The popup reuses the tower card scene, whose Synergies TextureRects are always visible; deck keys are not registered towers, so both traits resolve to 0 and previously rendered as null (blank) textures.
**Impact:** Deck-add popup cards display meaningless grey synergy diamonds; deck selection has no synergy concept.
**Fix:** `TowerSelectButton.Setup()` hides the Synergies bar when neither trait is a real enum member (trait enums start at 100/200, so 0 = no trait data). Real tower cards keep their class/gen icons and the missing-art `default.png` fallback. Stale comment in `UI_tower_select.gd` updated to match.
