### PR TITLE
Synergy icon hover tooltip on tower-select cards

### DIFF
--- a/resources/ui_component/tower_select/ui_tower_choice.tscn
+++ b/resources/ui_component/tower_select/ui_tower_choice.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=13 format=3 uid="uid://hrwu7jmu4yv"]
+[gd_scene load_steps=14 format=3 uid="uid://hrwu7jmu4yv"]
 
 [ext_resource type="Script" path="res://scripts/ui/tower_select/tower_select_button.gd" id="1_ydvhw"]
+[ext_resource type="Script" path="res://scripts/ui/tower_select/synergy_chip_icon.gd" id="1_synchip"]
 [ext_resource type="Shader" path="res://resources/ui_component/tower_select/ui_tower_choice.gdshader" id="1_ye0gs"]
 [ext_resource type="FontFile" uid="uid://scv78fddnukv" path="res://resources/ui_component/font/Roboto-Regular.ttf" id="2_oispt"]
 [ext_resource type="Texture2D" uid="uid://tp6ecjda00qg" path="res://resources/currency/evo_token.png" id="3_lbarx"]
@@ -122,9 +123,11 @@ custom_minimum_size = Vector2(45, 45)
 layout_mode = 2
 texture = ExtResource("7_681fe")
 expand_mode = 1
+script = ExtResource("1_synchip")
 
 [node name="Gen" type="TextureRect" parent="Synergies"]
 material = SubResource("ShaderMaterial_eo7vq")
 custom_minimum_size = Vector2(45, 45)
 layout_mode = 2
 texture = ExtResource("7_681fe")
+script = ExtResource("1_synchip")

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -90,15 +90,33 @@ func _breakpoints_text(tier: int) -> String:
 # Rich hover: flavour (scaling value highlighted) + a per-tier table with the
 # active tier marked + tier-coloured and the rest dimmed.
 func _make_custom_tooltip(_for_text: String) -> Object:
+	var panel := make_tooltip_card(_build_hover_bbcode())
+	# Keep a ref so live kills can refresh the open tooltip (see setQuestProgress).
+	_tooltip_label = panel.get_child(0) as RichTextLabel
+	return panel
+
+# Opaque tooltip card shared by the panel hover and the card chips
+# (synergy_chip_icon.gd); style matches the stats-panel skill hover
+# (tower_skill_icon.gd) so every rich tooltip reads as one family.
+# Child 0 is the RichTextLabel (callers may keep it for live refresh).
+static func make_tooltip_card(bbcode: String) -> PanelContainer:
 	var panel := PanelContainer.new()
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.07, 0.05, 0.12, 0.97)
+	style.border_color = Color(0.85, 0.7, 0.45, 0.9)
+	style.set_border_width_all(2)
+	style.set_corner_radius_all(10)
+	style.content_margin_left = 12
+	style.content_margin_right = 12
+	style.content_margin_top = 10
+	style.content_margin_bottom = 10
+	panel.add_theme_stylebox_override("panel", style)
 	var rich := RichTextLabel.new()
 	rich.bbcode_enabled = true
 	rich.fit_content = true
 	rich.custom_minimum_size = Vector2(320, 0)
-	rich.text = _build_hover_bbcode()
+	rich.text = bbcode
 	panel.add_child(rich)
-	# Keep a ref so live kills can refresh the open tooltip (see setQuestProgress).
-	_tooltip_label = rich
 	return panel
 
 func _build_hover_bbcode() -> String:

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -102,29 +102,35 @@ func _make_custom_tooltip(_for_text: String) -> Object:
 	return panel
 
 func _build_hover_bbcode() -> String:
-	if _data == null:
-		return _name
+	return build_hover_bbcode(_data, _name, _tier, _quest_progress)
+
+# Shared with the tower-select card chips (synergy_chip_icon.gd) so both hovers
+# render identical text from one builder; hover colors stay single-source here.
+# tier -1 = definitional view (no active row); quest_progress -1 = no progress line.
+static func build_hover_bbcode(data: SynergyData, fallback_name: String, tier: int, quest_progress: int) -> String:
+	if data == null:
+		return fallback_name
 
 	var lines: PackedStringArray = []
-	lines.append("[b]" + _data.display_name + "[/b]")
+	lines.append("[b]" + data.display_name + "[/b]")
 
 	# Flavour preview the lowest tier's value when not yet proc'd (maxi(tier,0)).
-	var flavor := _data.flavor(maxi(_tier, 0), SCALING_COLOR)
+	var flavor := data.flavor(maxi(tier, 0), SCALING_COLOR)
 	if flavor != "":
 		lines.append(flavor)
 
 	# Per-tier table (only when the synergy defines effect lines).
-	if not _data.tier_effects.is_empty():
+	if not data.tier_effects.is_empty():
 		lines.append("")
-		for i in _data.tier_count():
-			var row := "(" + str(_data.threshold_at(i)) + ")  " + _data.tier_effect(i)
-			if i == _tier:
+		for i in data.tier_count():
+			var row := "(" + str(data.threshold_at(i)) + ")  " + data.tier_effect(i)
+			if i == tier:
 				row = "[color=" + ACTIVE_HIGHLIGHT + "]> " + row + "[/color]"   # active tier (single gold)
 			else:
 				row = "[color=" + DIM_COLOR + "]" + row + "[/color]"
 			lines.append(row)
 
-	if _quest_progress >= 0:
+	if quest_progress >= 0:
 		lines.append("")
-		lines.append("[b]Current Progress: " + str(_quest_progress) + "[/b]")
+		lines.append("[b]Current Progress: " + str(quest_progress) + "[/b]")
 	return "\n".join(lines)

--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -141,8 +141,8 @@ func _apply_cards_to_buttons(cards: Array) -> void:
 		if index < cards.size():
 			var cardSelectData: TowerSelectData = cards[index] as TowerSelectData;
 			# Deck popup callsite passes deck keys (e.g. "myth") as card name, which
-			# are not registered tower names — fall through with default trait icons
-			# so the synergy chips render the "default" sprite instead of crashing.
+			# are not registered tower names - tClass/tGen stay 0 (no real trait)
+			# and Setup() hides the synergy chip bar for those cards.
 			var entry = TowerCenter.getTowerDataByName(cardSelectData.name);
 			var tClass: int = 0;
 			var tGen: int = 0;

--- a/scripts/ui/tower_select/synergy_chip_icon.gd
+++ b/scripts/ui/tower_select/synergy_chip_icon.gd
@@ -1,0 +1,43 @@
+class_name SynergyChipIcon
+extends TextureRect
+
+# Synergy-trait hover for tower-select cards: same text as the synergy panel
+# hover via the shared builder (ui_synergy_content.gd), rendered definitionally
+# (tier -1: no active-tier highlight or quest progress - live state stays on
+# the panel). Opaque card style mirrors tower_skill_icon.gd (ui.md lesson).
+
+var synergy_id: int = 0
+var display_name: String = ""
+
+func set_synergy(p_id: int, p_display_name: String) -> void:
+	synergy_id = p_id
+	display_name = p_display_name
+	# tooltip_text must carry REAL text: the viewport strips whitespace and
+	# shows nothing for a blank tooltip, custom tooltip included.
+	tooltip_text = p_display_name
+	# PASS (not the TextureRect default STOP): hover tooltip still fires while
+	# clicks fall through to the card Button (effect_icon_row.gd pattern).
+	mouse_filter = Control.MOUSE_FILTER_PASS
+
+func _make_custom_tooltip(_for_text: String) -> Object:
+	var panel := PanelContainer.new()
+	# Opaque dark card: the default tooltip theme lets text underneath bleed
+	# through (same fix as tower_skill_icon.gd).
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.07, 0.05, 0.12, 0.97)
+	style.border_color = Color(0.85, 0.7, 0.45, 0.9)
+	style.set_border_width_all(2)
+	style.set_corner_radius_all(10)
+	style.content_margin_left = 12
+	style.content_margin_right = 12
+	style.content_margin_top = 10
+	style.content_margin_bottom = 10
+	panel.add_theme_stylebox_override("panel", style)
+	var rich := RichTextLabel.new()
+	rich.bbcode_enabled = true
+	rich.fit_content = true
+	rich.custom_minimum_size = Vector2(320, 0)
+	var data = ResourceManager.getSynergyData(synergy_id)
+	rich.text = UISynergyContent.build_hover_bbcode(data, display_name, -1, -1)
+	panel.add_child(rich)
+	return panel

--- a/scripts/ui/tower_select/synergy_chip_icon.gd
+++ b/scripts/ui/tower_select/synergy_chip_icon.gd
@@ -1,10 +1,10 @@
 class_name SynergyChipIcon
 extends TextureRect
 
-# Synergy-trait hover for tower-select cards: same text as the synergy panel
-# hover via the shared builder (ui_synergy_content.gd), rendered definitionally
-# (tier -1: no active-tier highlight or quest progress - live state stays on
-# the panel). Opaque card style mirrors tower_skill_icon.gd (ui.md lesson).
+# Synergy-trait hover for tower-select cards: same text and opaque card as the
+# synergy panel hover via the shared helpers (ui_synergy_content.gd), rendered
+# definitionally (tier -1: no active-tier highlight or quest progress - live
+# state stays on the panel).
 
 var synergy_id: int = 0
 var display_name: String = ""
@@ -20,24 +20,6 @@ func set_synergy(p_id: int, p_display_name: String) -> void:
 	mouse_filter = Control.MOUSE_FILTER_PASS
 
 func _make_custom_tooltip(_for_text: String) -> Object:
-	var panel := PanelContainer.new()
-	# Opaque dark card: the default tooltip theme lets text underneath bleed
-	# through (same fix as tower_skill_icon.gd).
-	var style := StyleBoxFlat.new()
-	style.bg_color = Color(0.07, 0.05, 0.12, 0.97)
-	style.border_color = Color(0.85, 0.7, 0.45, 0.9)
-	style.set_border_width_all(2)
-	style.set_corner_radius_all(10)
-	style.content_margin_left = 12
-	style.content_margin_right = 12
-	style.content_margin_top = 10
-	style.content_margin_bottom = 10
-	panel.add_theme_stylebox_override("panel", style)
-	var rich := RichTextLabel.new()
-	rich.bbcode_enabled = true
-	rich.fit_content = true
-	rich.custom_minimum_size = Vector2(320, 0)
 	var data = ResourceManager.getSynergyData(synergy_id)
-	rich.text = UISynergyContent.build_hover_bbcode(data, display_name, -1, -1)
-	panel.add_child(rich)
-	return panel
+	return UISynergyContent.make_tooltip_card(
+		UISynergyContent.build_hover_bbcode(data, display_name, -1, -1))

--- a/scripts/ui/tower_select/tower_select_button.gd
+++ b/scripts/ui/tower_select/tower_select_button.gd
@@ -6,8 +6,8 @@ var evolutionNode: Node;
 var evolutionCostText: Label;
 var towerPortrait: TextureRect;
 
-var towerClassImage: TextureRect;
-var towerGenImage: TextureRect;
+var towerClassImage: SynergyChipIcon;
+var towerGenImage: SynergyChipIcon;
 var synergiesNode: Control;
 
 func _ready():
@@ -35,15 +35,20 @@ func Setup(p_name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: 
 	synergiesNode.visible = TowerTrait.TOWER_CLASS_NAMES.has(towerClass) or TowerTrait.TOWER_GENERATION_NAMES.has(towerGen)
 	if !synergiesNode.visible:
 		return
-	var tClassName = TowerTrait.TOWER_CLASS_NAMES.get(towerClass, "default").to_lower();
-	var classSprite = ResourceManager.getSprite("synergy", tClassName);
+	# Display names feed both the sprite key (lowered) and the hover fallback,
+	# which must stay player-facing case ("SpellCaster", not "spellcaster").
+	var classDisplayName = TowerTrait.TOWER_CLASS_NAMES.get(towerClass, "default");
+	var genDisplayName = TowerTrait.TOWER_GENERATION_NAMES.get(towerGen, "default");
+	var classSprite = ResourceManager.getSprite("synergy", classDisplayName.to_lower());
 	if(classSprite == null):
 		classSprite = ResourceManager.getSprite("synergy", "default");
-	var genSprite = ResourceManager.getSprite("synergy", TowerTrait.TOWER_GENERATION_NAMES.get(towerGen, "default").to_lower());
+	var genSprite = ResourceManager.getSprite("synergy", genDisplayName.to_lower());
 	if(genSprite == null):
 		genSprite = ResourceManager.getSprite("synergy", "default");
 	if(towerClassImage):
 		towerClassImage.texture = classSprite
+		towerClassImage.set_synergy(towerClass, classDisplayName)
 
 	if(towerGenImage):
 		towerGenImage.texture = genSprite
+		towerGenImage.set_synergy(towerGen, genDisplayName)

--- a/scripts/ui/tower_select/tower_select_button.gd
+++ b/scripts/ui/tower_select/tower_select_button.gd
@@ -8,6 +8,7 @@ var towerPortrait: TextureRect;
 
 var towerClassImage: TextureRect;
 var towerGenImage: TextureRect;
+var synergiesNode: Control;
 
 func _ready():
 	add_to_group("tower_buttons")  # Ensures buttons register correctly
@@ -19,6 +20,7 @@ func Setup(p_name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: 
 	towerPortrait = $TowerPortrait
 	towerClassImage = $Synergies/Class
 	towerGenImage = $Synergies/Gen
+	synergiesNode = $Synergies
 
 	towerNameText.text = p_name + ("\nLevel " + str(level) if level > 0 else "")
 	evolutionNode.visible = evolutionCost > 0
@@ -29,6 +31,10 @@ func Setup(p_name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: 
 		var portrait = TowerCenter.getTowerPortraitByName(p_name.to_lower());
 		if(portrait):
 			towerPortrait.texture = portrait
+	# No real trait on either slot (deck-add popup cards) -> no synergy chip bar.
+	synergiesNode.visible = TowerTrait.TOWER_CLASS_NAMES.has(towerClass) or TowerTrait.TOWER_GENERATION_NAMES.has(towerGen)
+	if !synergiesNode.visible:
+		return
 	var tClassName = TowerTrait.TOWER_CLASS_NAMES.get(towerClass, "default").to_lower();
 	var classSprite = ResourceManager.getSprite("synergy", tClassName);
 	if(classSprite == null):


### PR DESCRIPTION
**Summary:** Players can hover the synergy trait icons on tower-select cards to learn what each synergy does (new-player onboarding). The synergy panel hover adopts the same opaque tooltip card so all rich tooltips read as one family.

**How it works:** The panel hover's bbcode builder is extracted to a static `UISynergyContent.build_hover_bbcode` (single text source from the synergy YAML - editing a desc updates panel and cards together), and the opaque card construction to `UISynergyContent.make_tooltip_card` (shared by both synergy hovers). New `SynergyChipIcon` script on the card's Class/Gen TextureRects renders the definitional view (tier -1: no active-tier highlight, no quest-progress line - live state stays on the panel). `MOUSE_FILTER_PASS` keeps hover alive while clicks fall through to the card button - this also fixes a pre-existing issue where the icon area ate card clicks.

**Implementation Notes:**
- Stacks on PR #97 content: please merge #97 first. Until then this PR's diff also shows #97's commit (`954fb7b`); it collapses to this task's two commits once #97 lands.
- Synergies without a YAML definition (Warrior/Marksman/SpellCaster/Robotic/King/Gen0/Indo1) show only the player-facing trait name; their descriptions appear automatically once the YAML is authored, no code change needed.
- Quest live-refresh (Tempus Current Progress) keeps its label reference through the shared helper (child 0 of the returned card).

**Touched scenes:** resources/ui_component/tower_select/ui_tower_choice.tscn
