### PR TITLE
Enemy stats panel + enemy skill desc parameter sync

### DIFF
--- a/resources/database/enemy/forest01/boss/giant_boar.yaml
+++ b/resources/database/enemy/forest01/boss/giant_boar.yaml
@@ -1,9 +1,11 @@
 # Boss. `name` is the display name; the sprite + id come from the file path
 # (resources/enemy/forest01/boss/giant_boar/giant_boar.png). `wave` lists the
 # waves this boss is eligible to spawn on; `scale` is the visual/hitbox size
-# multiplier applied at spawn. Skills are inline (3 max by design); enemy
-# skills are single-level, so desc uses concrete numbers (see enemy_skill.md).
-# Design source: Director xlsx 2026-07-09 (boss.md Giant Boar).
+# multiplier applied at spawn. Skills are inline (3 max by design); balance
+# numbers live once in each skill's `parameters` - actions bind via *_param
+# keys and the desc renders the same values via {token} (enemy_skill.md).
+# Area sizes ("5x5") stay literal in desc until the structural parameterize
+# task (post-demo). Design source: Director xlsx 2026-07-09 (boss.md Giant Boar).
 name: Giant Boar
 scale: 2
 wave:
@@ -20,53 +22,64 @@ skill:
     recovery: 0.2
     tags:
       - movement
-    desc: "The Giant Boar braces, then charges 2 tiles forward along the path."
+    parameters:
+      charge_cells: 2
+    desc: "The Giant Boar braces, then charges {charge_cells} tiles forward along the path."
     action:
       - type: dash
         data:
-          cells: 2
+          cells_param: charge_cells
           duration: 0.3
   - name: Thick Skin
     type: triggered
     trigger:
-      hp_below: 0.4
+      hp_below_param: trigger_hp
     oneTime: true
     cast_time: 0.5
     recovery: 0.2
     tags:
       - defense
       - heal
-    desc: "When its health falls below 40%, the Giant Boar lies down to rest for 5 seconds - taking 50% less damage and recovering 5% of its max health every second. On waking it gains 50% movement speed for 5 seconds."
+    parameters:
+      trigger_hp: 0.4
+      rest_duration: 5
+      damage_reduction: 0.5
+      haste: 0.5
+      haste_duration: 5
+    # The "5% of max health every second" magnitude lives in the effect
+    # registry (rest_recovery params.max_hp_percent) - a different single-source
+    # layer, so that one desc number stays literal.
+    desc: "When its health falls below {trigger_hp:percent}, the Giant Boar lies down to rest for {rest_duration} seconds - taking {damage_reduction:percent} less damage and recovering 5% of its max health every second. On waking it gains {haste:percent} movement speed for {haste_duration} seconds."
     action:
       - type: target_self
       - type: apply_effect
         data:
           effect: rest
           target: targets
-          duration: 5
+          duration_param: rest_duration
           title: "Thick Skin - Resting"
       - type: apply_effect
         data:
           effect: damage_reduction_up
           target: targets
-          value: 0.5
-          duration: 5
+          value_param: damage_reduction
+          duration_param: rest_duration
           title: "Thick Skin - Hardened"
       - type: apply_effect
         data:
           effect: rest_recovery
           target: targets
-          duration: 5
+          duration_param: rest_duration
           title: "Thick Skin - Recovering"
       - type: delay
         data:
-          delay: 5
+          delay_param: rest_duration
       - type: apply_effect
         data:
           effect: move_speed_up
           target: targets
-          value: 0.5
-          duration: 5
+          value_param: haste
+          duration_param: haste_duration
           title: "Thick Skin - Haste"
   - name: Bulldoze
     cooldown: 20
@@ -75,22 +88,28 @@ skill:
     tags:
       - debuff
       - aoe
-    desc: "The Giant Boar stomps the ground, shaking a 5x5 area - units caught inside deal 20% less damage for 8 seconds."
+    parameters:
+      damage_down: 20
+      debuff_duration: 8
+    # damage_down uses the whole-percent scale (attack_mult/magic_mult kinds
+    # divide by 100 at consumption), so the desc token is {damage_down}% with a
+    # literal % sign - NOT {damage_down:percent}, which would render "2000%".
+    desc: "The Giant Boar stomps the ground, shaking a 5x5 area - units caught inside deal {damage_down}% less damage for {debuff_duration} seconds."
     action:
       - type: apply_effect
         data:
           effect: attack_mult_down
           target: towers_in_range
           range: 2
-          value: 20
-          duration: 8
+          value_param: damage_down
+          duration_param: debuff_duration
           title: "Bulldoze - Damage Down"
       - type: apply_effect
         data:
           effect: magic_mult_down
           target: towers_in_range
           range: 2
-          value: 20
-          duration: 8
+          value_param: damage_down
+          duration_param: debuff_duration
           show_area: false
           title: "Bulldoze - Magic Down"

--- a/resources/database/enemy/forest01/boss/king_salam.yaml
+++ b/resources/database/enemy/forest01/boss/king_salam.yaml
@@ -1,8 +1,11 @@
 # Boss. `name` is the display name; the sprite + id come from the file path
 # (resources/enemy/forest01/boss/king_salam/king_salam.png). `wave` lists the
 # waves this boss is eligible to spawn on; `scale` is the visual/hitbox size
-# multiplier applied at spawn. Skills are inline (3 max by design); enemy
-# skills are single-level, so desc uses concrete numbers (see enemy_skill.md).
+# multiplier applied at spawn. Skills are inline (3 max by design); balance
+# numbers live once in each skill's `parameters` - actions bind via *_param
+# keys and the desc renders the same values via {token} (enemy_skill.md).
+# Area sizes ("7x7") stay literal in desc until the structural parameterize
+# task (post-demo).
 name: King Salam
 scale: 1.75
 wave:
@@ -19,15 +22,18 @@ skill:
     tags:
       - defense
       - self
-    desc: "King Salam adapts his royal hide, reducing all damage he takes by 20% for 5 seconds."
+    parameters:
+      reduction: 0.2
+      duration: 5
+    desc: "King Salam adapts his royal hide, reducing all damage he takes by {reduction:percent} for {duration} seconds."
     action:
       - type: target_self
       - type: apply_effect
         data:
           effect: damage_reduction_up
           target: targets
-          value: 0.2
-          duration: 5
+          value_param: reduction
+          duration_param: duration
           title: "Adaptation"
   - name: Slime Fluid
     cooldown: 15
@@ -37,15 +43,18 @@ skill:
       - debuff
       - attack_speed
       - aoe
-    desc: "King Salam splashes his slime across a 7x7 area, coating units in Slime Fluid that slows their attack speed by 10% for 10 seconds."
+    parameters:
+      slow: 0.1
+      duration: 10
+    desc: "King Salam splashes his slime across a 7x7 area, coating units in Slime Fluid that slows their attack speed by {slow:percent} for {duration} seconds."
     action:
       - type: apply_effect
         data:
           effect: slime_fluid
           target: towers_in_range
           range: 3
-          value: 0.1
-          duration: 10
+          value_param: slow
+          duration_param: duration
   - name: King's Command
     cooldown: 30
     cast_time: 0.5
@@ -53,24 +62,27 @@ skill:
     tags:
       - invincible
       - summon
-    desc: "King Salam stands his ground, invincible and untargetable for 2 seconds, then commands 10 Armored Salam to join the battle at his side."
+    parameters:
+      stand_duration: 2
+      summon_count: 10
+    desc: "King Salam stands his ground, invincible and untargetable for {stand_duration} seconds, then commands {summon_count} Armored Salam to join the battle at his side."
     action:
       - type: target_self
       - type: apply_effect
         data:
           effect: invincible
           target: targets
-          duration: 2
+          duration_param: stand_duration
       - type: apply_effect
         data:
           effect: royal_command
           target: targets
-          duration: 2
+          duration_param: stand_duration
       - type: delay
         data:
-          delay: 2
+          delay_param: stand_duration
       - type: summon_enemy
         data:
           enemy: armored_salam
-          count: 10
+          count_param: summon_count
           interval: 0.2

--- a/resources/database/enemy/forest01/elite/armored_boar.yaml
+++ b/resources/database/enemy/forest01/elite/armored_boar.yaml
@@ -1,3 +1,7 @@
+# Elite: Armored Boar. Value-scale fix 2026-07-17 (Director): armor_mult is a
+# FRACTION at consumption ((1 + agg) in EnemyStat), so the old `value: 2.5`
+# meant +250%, not the +2.5% the desc claimed - corrected to 0.025 to match
+# the authored design. Aura duration 10000 = up for the enemy's whole life.
 stats:
   hp: 5000
   def: 2
@@ -6,13 +10,18 @@ stats:
 skill:
   - name: Protector Aura
     type: passive # aura up from spawn - a buff that must exist at engagement cannot be an Active under the cast gate
-    desc: สร้างออร่าเพิ่ม Defense 2.5% ให้กับฝ่ายเดียวกันในระยะ 1*1 ช่อง
+    tags:
+      - defense
+      - aoe
+    parameters:
+      armor_up: 0.025
+    desc: "A protective aura surrounds the Armored Boar, hardening the armor of nearby monsters by {armor_up:percent}."
     action:
       - type: target_self
       - type: effect_area
         data:
           effect: armor_mult_up
-          value: 2.5
+          value_param: armor_up
           duration: 10000
           radius: 1
           affects: enemies

--- a/resources/database/enemy/forest01/elite/flying_flower.yaml
+++ b/resources/database/enemy/forest01/elite/flying_flower.yaml
@@ -1,3 +1,7 @@
+# Elite: Flying Flower. Value-scale fix 2026-07-17 (Director): armor_mult is a
+# FRACTION at consumption ((1 + agg) in EnemyStat), so the old `value: 5`
+# meant +500%, not the +5% the desc claimed - corrected to 0.05 to match the
+# authored design. Duration 10000 = up for the enemy's whole life.
 stats:
   hp: 3000
   def: 0
@@ -5,13 +9,18 @@ stats:
   moveSpeed: 40
 skill:
   - name: Sweat Spore
-    type: passive # aura up from spawn - a buff that must exist at engagement cannot be an Active under the cast gate
-    desc: เพิ่ม def ให้ตนเอง 5%
+    type: passive # buff up from spawn - a buff that must exist at engagement cannot be an Active under the cast gate
+    tags:
+      - defense
+      - self
+    parameters:
+      armor_up: 0.05
+    desc: "Sweat spores bloom across the Flying Flower, hardening their armor by {armor_up:percent}."
     action:
       - type: target_self
       - type: apply_effect
         data:
           effect: armor_mult_up
           target: targets
-          value: 5
+          value_param: armor_up
           duration: 10000

--- a/resources/ui_component/enemy_stats_panel.tscn
+++ b/resources/ui_component/enemy_stats_panel.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=12 format=3]
 
-[ext_resource type="Script" path="res://scripts/ui/tower_stats_panel.gd" id="1_twstats"]
+[ext_resource type="Script" path="res://scripts/ui/enemy_stats_panel.gd" id="1_enstats"]
 [ext_resource type="FontFile" uid="uid://scv78fddnukv" path="res://resources/ui_component/font/Roboto-Regular.ttf" id="2_font"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panelbg"]
@@ -31,7 +31,7 @@ corner_radius_bottom_right = 8
 corner_radius_bottom_left = 8
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_barfill"]
-bg_color = Color(0.3, 0.65, 1, 1)
+bg_color = Color(0.8, 0.22, 0.22, 1)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -61,7 +61,7 @@ font = ExtResource("2_font")
 font_size = 13
 font_color = Color(0.88, 0.92, 1, 1)
 
-[node name="TowerStatsPanel" type="Control"]
+[node name="EnemyStatsPanel" type="Control"]
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 8.0
@@ -70,7 +70,7 @@ offset_right = 568.0
 offset_bottom = -8.0
 grow_vertical = 0
 mouse_filter = 0
-script = ExtResource("1_twstats")
+script = ExtResource("1_enstats")
 
 [node name="BG" type="Panel" parent="."]
 layout_mode = 1
@@ -93,56 +93,19 @@ stretch_mode = 5
 
 [node name="NameLabel" type="Label" parent="."]
 offset_left = 152.0
-offset_top = 16.0
+offset_top = 12.0
 offset_right = 460.0
-offset_bottom = 46.0
-text = "Tower Name"
+offset_bottom = 48.0
+text = "Enemy Name"
 label_settings = SubResource("LabelSettings_title")
 
-[node name="LevelLabel" type="Label" parent="."]
+[node name="TierLabel" type="Label" parent="."]
 offset_left = 152.0
 offset_top = 50.0
 offset_right = 460.0
-offset_bottom = 74.0
-text = "Level 1"
+offset_bottom = 77.0
+text = "Normal"
 label_settings = SubResource("LabelSettings_sub")
-
-[node name="TraitRow" type="HBoxContainer" parent="."]
-offset_left = 152.0
-offset_top = 82.0
-offset_right = 460.0
-offset_bottom = 116.0
-mouse_filter = 2
-theme_override_constants/separation = 8
-
-[node name="ClassIcon" type="TextureRect" parent="TraitRow"]
-custom_minimum_size = Vector2(30, 30)
-layout_mode = 2
-mouse_filter = 2
-expand_mode = 1
-stretch_mode = 5
-
-[node name="ClassLabel" type="Label" parent="TraitRow"]
-layout_mode = 2
-text = "Class"
-label_settings = SubResource("LabelSettings_body")
-
-[node name="TraitSpacer" type="Control" parent="TraitRow"]
-custom_minimum_size = Vector2(14, 0)
-layout_mode = 2
-mouse_filter = 2
-
-[node name="GenIcon" type="TextureRect" parent="TraitRow"]
-custom_minimum_size = Vector2(30, 30)
-layout_mode = 2
-mouse_filter = 2
-expand_mode = 1
-stretch_mode = 5
-
-[node name="GenLabel" type="Label" parent="TraitRow"]
-layout_mode = 2
-text = "Generation"
-label_settings = SubResource("LabelSettings_body")
 
 [node name="Separator" type="Panel" parent="."]
 offset_left = 16.0
@@ -162,84 +125,54 @@ theme_override_constants/h_separation = 14
 theme_override_constants/v_separation = 12
 columns = 4
 
-[node name="AtkName" type="Label" parent="StatsGrid"]
+[node name="MsName" type="Label" parent="StatsGrid"]
 custom_minimum_size = Vector2(120, 0)
 layout_mode = 2
-text = "Attack"
+text = "Move Speed"
 label_settings = SubResource("LabelSettings_dim")
 
-[node name="AtkValue" type="Label" parent="StatsGrid"]
+[node name="MsValue" type="Label" parent="StatsGrid"]
 custom_minimum_size = Vector2(110, 0)
 layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_body")
 
-[node name="TypeName" type="Label" parent="StatsGrid"]
+[node name="ArmorName" type="Label" parent="StatsGrid"]
 custom_minimum_size = Vector2(90, 0)
 layout_mode = 2
-text = "Attack Type"
+text = "Armor"
 label_settings = SubResource("LabelSettings_dim")
 
-[node name="TypeValue" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "Physical"
-label_settings = SubResource("LabelSettings_body")
-
-[node name="RangeName" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "Range"
-label_settings = SubResource("LabelSettings_dim")
-
-[node name="RangeValue" type="Label" parent="StatsGrid"]
+[node name="ArmorValue" type="Label" parent="StatsGrid"]
 layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_body")
 
-[node name="AsName" type="Label" parent="StatsGrid"]
+[node name="MrName" type="Label" parent="StatsGrid"]
 layout_mode = 2
-text = "Attack Speed"
+text = "Magic Resist"
 label_settings = SubResource("LabelSettings_dim")
 
-[node name="AsValue" type="Label" parent="StatsGrid"]
+[node name="MrValue" type="Label" parent="StatsGrid"]
 layout_mode = 2
 text = "0"
 label_settings = SubResource("LabelSettings_body")
 
-[node name="CritName" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "Crit Rate"
-label_settings = SubResource("LabelSettings_dim")
-
-[node name="CritValue" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "0%"
-label_settings = SubResource("LabelSettings_body")
-
-[node name="CritDmgName" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "Crit DMG"
-label_settings = SubResource("LabelSettings_dim")
-
-[node name="CritDmgValue" type="Label" parent="StatsGrid"]
-layout_mode = 2
-text = "100%"
-label_settings = SubResource("LabelSettings_body")
-
-[node name="EnergyRow" type="Control" parent="."]
+[node name="HpRow" type="Control" parent="."]
 offset_left = 16.0
 offset_top = 270.0
 offset_right = 464.0
 offset_bottom = 296.0
 mouse_filter = 2
 
-[node name="EnergyLabel" type="Label" parent="EnergyRow"]
+[node name="HpLabel" type="Label" parent="HpRow"]
 offset_top = 1.0
 offset_right = 80.0
 offset_bottom = 25.0
-text = "Energy"
+text = "HP"
 label_settings = SubResource("LabelSettings_dim")
 
-[node name="EnergyBar" type="ProgressBar" parent="EnergyRow"]
+[node name="HpBar" type="ProgressBar" parent="HpRow"]
 offset_left = 88.0
 offset_top = 4.0
 offset_right = 448.0
@@ -249,7 +182,7 @@ theme_override_styles/background = SubResource("StyleBoxFlat_barbg")
 theme_override_styles/fill = SubResource("StyleBoxFlat_barfill")
 show_percentage = false
 
-[node name="EnergyText" type="Label" parent="EnergyRow/EnergyBar"]
+[node name="HpText" type="Label" parent="HpRow/HpBar"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0

--- a/resources/ui_component/game_ui.tscn
+++ b/resources/ui_component/game_ui.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=3 uid="uid://bcyr1l11fwy7"]
+[gd_scene load_steps=26 format=3 uid="uid://bcyr1l11fwy7"]
 
 [ext_resource type="PackedScene" uid="uid://dsshuu1axf1t8" path="res://resources/ui_component/synergy/ui_synergy.tscn" id="1_hk82f"]
 [ext_resource type="Script" path="res://scripts/ui/currency.gd" id="2_rqmfg"]
@@ -11,6 +11,7 @@
 [ext_resource type="PackedScene" path="res://resources/ui_component/staff_widget.tscn" id="9_staff"]
 [ext_resource type="PackedScene" path="res://resources/ui_component/boss_health_bar.tscn" id="10_bosshp"]
 [ext_resource type="PackedScene" path="res://resources/ui_component/tower_stats_panel.tscn" id="11_twstats"]
+[ext_resource type="PackedScene" path="res://resources/ui_component/enemy_stats_panel.tscn" id="12_enstats"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_uyb7r"]
 bg_color = Color(0.6, 0.254902, 0.6, 1)
@@ -265,6 +266,8 @@ offset_bottom = 96.0
 grow_horizontal = 2
 
 [node name="TowerStatsPanel" parent="." instance=ExtResource("11_twstats")]
+
+[node name="EnemyStatsPanel" parent="." instance=ExtResource("12_enstats")]
 
 [node name="PauseButton" type="Button" parent="."]
 visible = false

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -9,6 +9,9 @@ class_name Enemy
 var originalModulate: Color
 
 var enemyType: EnemyType = EnemyType.Normal;
+# Player-facing name for the stats panel; set by WaveController right after
+# spawn (roster display_name, or the boss's authored name).
+var display_name: String = "";
 
 # Unified buff/debuff store (created in setup; icon row binds there too -
 # _ready runs a frame BEFORE setup in the factory flow, so never bind at

--- a/scripts/entity/enemy/enemy_data_loader.gd
+++ b/scripts/entity/enemy/enemy_data_loader.gd
@@ -47,4 +47,5 @@ static func _load_enemy(mapName: String, tier: String, id: String) -> EnemyDBDat
 	if skillRaw is Array and skillRaw.size() > 0:
 		skills = SkillUtility.ParseSkill(skillRaw)
 
-	return EnemyDBData.new(id, tier, stats, skills)
+	# Optional player-facing `name:`; EnemyDBData falls back to the prettified id.
+	return EnemyDBData.new(id, tier, stats, skills, str(parsed.get("name", "")))

--- a/scripts/entity/enemy/enemy_db_data.gd
+++ b/scripts/entity/enemy/enemy_db_data.gd
@@ -7,9 +7,12 @@ var id: String
 var tier: String                 # "normal" / "elite" / "boss" - drives sprite path + leak damage
 var stats: Dictionary
 var skills: Array[Skill] = []
+# Player-facing name (stats panel). Authored `name:` key, or prettified id.
+var display_name: String = ""
 
-func _init(p_id: String, p_tier: String, p_stats: Dictionary, p_skills: Array[Skill] = []):
+func _init(p_id: String, p_tier: String, p_stats: Dictionary, p_skills: Array[Skill] = [], p_display_name: String = ""):
 	self.id = p_id
 	self.tier = p_tier
 	self.stats = p_stats
 	self.skills = p_skills
+	self.display_name = p_display_name if p_display_name != "" else p_id.capitalize()

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -228,6 +228,7 @@ func spawnEnemy(groupIndex: int):
 		enemyAliveCount -= 1;
 		return;
 
+	enemy.display_name = db.display_name;
 	connectSignalToEnemy(enemy);
 
 func _tierToEnemyType(tier: String) -> Enemy.EnemyType:
@@ -278,6 +279,7 @@ func spawnBoss():
 		enemyAliveCount -= 1;
 		return;
 
+	boss.display_name = bossData.name;
 	connectSignalToEnemy(boss);
 	if bossHpBar != null:
 		bossHpBar.track(boss, bossData.name);
@@ -315,6 +317,7 @@ func summon(enemyId: String, count: int, interval: float, pathProgress: float):
 			# Summons render above everything on the path - the (scaled) boss
 			# sprite must not hide them (Director 2026-07-07).
 			enemy.z_index = 1
+			enemy.display_name = db.display_name
 			connectSignalToEnemy(enemy)
 
 		if i < count - 1:
@@ -375,6 +378,7 @@ func testSpawnBoss(index: int = -1):
 	if enemy == null:
 		enemyAliveCount -= 1;
 		return;
+	enemy.display_name = boss.name;
 	connectSignalToEnemy(enemy);
 	if bossHpBar != null:
 		bossHpBar.track(enemy, boss.name);

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -40,8 +40,10 @@ var _state_before_skill_cast: String = ""
 # Ref to the Staff HUD widget so _input can ask whether a click landed on the skill button.
 var _staff_widget: StaffWidget = null
 
-# Bottom-left tower stats panel (display-only selection surface).
+# Bottom-left stats panels (display-only selection surfaces). They share the
+# slot: one selection at a time - showing one always clears the other.
 var _tower_stats_panel: TowerStatsPanel = null
+var _enemy_stats_panel: EnemyStatsPanel = null
 
 func _input(event):
 	if state == "tower_placement" and event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
@@ -82,11 +84,24 @@ func _unhandled_input(event):
 			return
 		if _tower_stats_panel == null:
 			return
-		var tower := _pick_tower_at(get_global_mouse_position())
+		# Tower first: its pick box is the exact grid square; the enemy pick is
+		# a radius. A scaled boss overhanging a tower's cell selects the tower
+		# (accepted - Director 2026-07-17).
+		var world_pos := get_global_mouse_position()
+		var tower := _pick_tower_at(world_pos)
 		if tower != null:
 			_tower_stats_panel.show_tower(tower)
-		else:
+			if _enemy_stats_panel != null:
+				_enemy_stats_panel.clear()
+			return
+		var enemy := _pick_enemy_at(world_pos)
+		if enemy != null and _enemy_stats_panel != null:
+			_enemy_stats_panel.show_enemy(enemy)
 			_tower_stats_panel.clear()
+			return
+		_tower_stats_panel.clear()
+		if _enemy_stats_panel != null:
+			_enemy_stats_panel.clear()
 
 # Square pick box = the tower's own visible grid square (tower.position is the
 # square's center), so neighbor squares tile exactly with no overlap (Director
@@ -101,6 +116,33 @@ func _pick_tower_at(world_pos: Vector2) -> Tower:
 		if absf(local.x) <= half and absf(local.y) <= half:
 			return tower
 	return null
+
+# Enemies move along paths and overlap, so the pick is a radius, not a cell box:
+# nearest enemy within half a cell (scaled up for big bosses) wins; a near-tie
+# (overlapping column) prefers the one closest to the path end - matches the
+# targeting convention and reads as "the front one".
+const ENEMY_PICK_TIE_EPSILON := 32.0
+
+func _pick_enemy_at(world_pos: Vector2) -> Enemy:
+	var best: Enemy = null
+	var best_dist := INF
+	# Both the enemy root and its Area2D child sit in this group; the `as Enemy`
+	# cast nulls the Area2D so each enemy is considered once (PR #21 lesson).
+	for node in get_tree().get_nodes_in_group("enemy"):
+		var enemy := node as Enemy
+		if enemy == null or not enemy.initialized:
+			continue
+		var radius := GridHelper.CELL_SIZE / 2.0 * enemy.scale.x
+		var dist := world_pos.distance_to(enemy.global_position)
+		if dist > radius:
+			continue
+		if best == null or dist < best_dist - ENEMY_PICK_TIE_EPSILON:
+			best = enemy
+			best_dist = dist
+		elif absf(dist - best_dist) <= ENEMY_PICK_TIE_EPSILON and enemy.progress_ratio > best.progress_ratio:
+			best = enemy
+			best_dist = dist
+	return best
 
 func _process(_delta):
 	if state == "staff_skill_casting" and _skill_cast_indicator != null:
@@ -123,6 +165,7 @@ func _ready():
 	# Staff system: load data → instantiate entity → wire widget → spawn endpoint sprite.
 	setup_staff()
 	_tower_stats_panel = get_node_or_null("GameUI/TowerStatsPanel") as TowerStatsPanel
+	_enemy_stats_panel = get_node_or_null("GameUI/EnemyStatsPanel") as EnemyStatsPanel
 	var camera = get_node("Camera2D")
 	camera.make_current()
 	if(map != null):

--- a/scripts/skill/skill.gd
+++ b/scripts/skill/skill.gd
@@ -51,7 +51,14 @@ func get_display_desc(level: int, highlight_color: String = "") -> String:
 		var param_name := match_result.get_string(1)
 		var format := match_result.get_string(2)
 		var value = _get_display_parameter(param_name, level)
-		var text := _format_display_parameter(value, format)
+		var text: String
+		if value == null:
+			# Missing parameter: keep the raw {token} visible instead of an
+			# empty hole ("reduces damage by  for  seconds") so designers see
+			# the breakage in-game; _get_display_parameter already warned.
+			text = match_result.get_string()
+		else:
+			text = _format_display_parameter(value, format)
 		if highlight_color != "" and parameters.get(param_name) is Array:
 			text = "[color=" + highlight_color + "]" + text + "[/color]"
 		result = result.substr(0, match_result.get_start()) + text + result.substr(match_result.get_end())

--- a/scripts/skill/skill_context.gd
+++ b/scripts/skill/skill_context.gd
@@ -8,7 +8,15 @@ var cancel: bool = false;
 var extra: Dictionary = {}
 
 func getParameter(name: String, parameter):
-	var param = extra.get("parameter", {}).get(name, 1);
+	var params: Dictionary = extra.get("parameter", {})
+	if not params.has(name):
+		# Loud miss: a typo'd *_param used to silently resolve to 1 (e.g. a
+		# damage-reduction value_param would cap at 90% unnoticed). Behavior
+		# (return 1) unchanged - existing YAML relying on the default keeps
+		# working; the warning surfaces the breakage.
+		push_warning("SkillContext: missing skill parameter '", name, "' (", skillName, ") - defaulting to 1")
+		return 1
+	var param = params.get(name)
 	if param is Array:
 		if param.is_empty():
 			return 1

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -14,16 +14,19 @@ static func ParseSkill(skillDataList: Array) -> Array[Skill]:
 		# Same key + meaning as the tower skill-level cast_time (idle pre-cast
 		# hold); enemies additionally stand still during it (Enemy.castLocked).
 		var castTime = float(skill.get("cast_time", 0.0));
+		# Single source for balance numbers: actions bind via *_param keys and
+		# the desc renders the same values via {token} (enemy_skill.md Copy).
+		var parameters: Dictionary = skill.get("parameters", {});
 		var actions: Array[SkillAction] = [];
 		var actionList = skill.get("action", []);
 		for actionData in actionList:
-			var action = ParseAction(actionData);
+			var action = ParseAction(actionData, parameters);
 			if action != null:
 				actions.append(action);
 			else:
 				push_warning("Failed to parse action in skill ", skillName);
 
-		var s = EnemySkill.new(skillName, desc, actions, {}, oneTime, cooldown, castTime);
+		var s = EnemySkill.new(skillName, desc, actions, parameters, oneTime, cooldown, castTime);
 		# Post-cast hold (seconds); enemy default 0.0 - a 0.2 default would
 		# permanently freeze cooldown-0 every-frame recast skills (aura elites).
 		s.recoveryTime = float(skill.get("recovery", 0.0));
@@ -33,7 +36,15 @@ static func ParseSkill(skillDataList: Array) -> Array[Skill]:
 		s.passive = typeStr == "passive";
 		s.triggered = typeStr == "triggered";
 		var trigger = skill.get("trigger", {});
-		s.trigger_hp_below = float(trigger.get("hp_below", 0.0));
+		# `hp_below_param` binds the threshold to `parameters` (desc token sync);
+		# literal `hp_below` stays the fallback.
+		var hpBelowParam := str(trigger.get("hp_below_param", ""));
+		if hpBelowParam != "" and parameters.has(hpBelowParam):
+			s.trigger_hp_below = float(parameters[hpBelowParam]);
+		else:
+			if hpBelowParam != "":
+				push_warning("Triggered skill '", skillName, "': hp_below_param '", hpBelowParam, "' not in parameters - using literal hp_below.");
+			s.trigger_hp_below = float(trigger.get("hp_below", 0.0));
 		if s.triggered and s.trigger_hp_below <= 0.0:
 			push_warning("Triggered skill '", skillName, "' has no trigger condition - it will never fire.");
 		# Player-facing summary tags (same controlled registry as tower skills).
@@ -45,6 +56,21 @@ static func ParseSkill(skillDataList: Array) -> Array[Skill]:
 		else:
 			push_warning("Skill ", s, " not found");
 	return result
+
+# Parse-time scalar binding for single-level (enemy) skill numbers: `param_key`
+# (e.g. "count_param") names an entry in the skill's `parameters`. Missing name
+# warns and falls back to the literal/default - loud but not fatal (the desc
+# side shows the raw {token} for the same breakage). Convention note: these new
+# keys use the short `*_param` suffix (matching apply_effect's runtime keys);
+# the older `*_param_name` sites stay as-is (enemy_skill.md).
+static func _resolve_param(skillData: Dictionary, parameters: Dictionary, param_key: String, fallback: float) -> float:
+	var pname := str(skillData.get(param_key, ""));
+	if pname == "":
+		return fallback;
+	if parameters.has(pname):
+		return float(parameters[pname]);
+	push_warning("Skill action: ", param_key, " '", pname, "' not in skill parameters - using fallback ", fallback);
+	return fallback;
 
 static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillAction:
 	var skillType = data.get("type", "");
@@ -72,8 +98,8 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill = SkillActionEffectArea.new();
 			var skillData = data.get("data", {});
 			skill.effectId = skillData.get("effect", "");
-			skill.value = float(skillData.get("value", 0.0));
-			skill.duration = float(skillData.get("duration", 3.0));
+			skill.value = _resolve_param(skillData, parameters, "value_param", float(skillData.get("value", 0.0)));
+			skill.duration = _resolve_param(skillData, parameters, "duration_param", float(skillData.get("duration", 3.0)));
 			skill.radius = float(skillData.get("radius", 1.0));
 			skill.affects = skillData.get("affects", "enemies");
 			skill.authoredTitle = skillData.get("title", "");
@@ -82,13 +108,12 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill = SkillActionSummonEnemy.new();
 			var skillData = data.get("data", {});
 			skill.enemyId = str(skillData.get("enemy", ""));
-			skill.count = int(skillData.get("count", 1));
+			skill.count = int(_resolve_param(skillData, parameters, "count_param", float(skillData.get("count", 1))));
 			skill.interval = float(skillData.get("interval", 0.2));
 		"delay":
 			skill = SkillActionDelay.new();
 			var skillData = data.get("data", {});
-			var delay = skillData.get("delay", 1.0);
-			skill.delay = delay;
+			skill.delay = _resolve_param(skillData, parameters, "delay_param", float(skillData.get("delay", 1.0)));
 		"set_speed":
 			skill = SkillActionSetSpeed.new();
 			var skillData = data.get("data", {});
@@ -231,7 +256,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			# Path dash: slide the casting enemy forward along its path.
 			skill = SkillActionDash.new();
 			var skillData = data.get("data", {});
-			skill.cells = float(skillData.get("cells", 1.0));
+			skill.cells = _resolve_param(skillData, parameters, "cells_param", float(skillData.get("cells", 1.0)));
 			skill.duration = float(skillData.get("duration", 0.3));
 		"heal_percent_maxhp":
 			# Instant heal = target.maxHp x percent (enemy self heals).

--- a/scripts/ui/enemy_stats_panel.gd
+++ b/scripts/ui/enemy_stats_panel.gd
@@ -1,0 +1,114 @@
+class_name EnemyStatsPanel
+extends Control
+
+# Placeholder enemy stats panel (bottom-left HUD; artist design pass pending).
+# Sibling of TowerStatsPanel - both share the bottom-left slot, one selection
+# at a time (Director 2026-07-17). Skeleton cloned from tower_stats_panel.gd,
+# the shared layout convention (ui.md).
+
+@onready var _portrait: TextureRect = $Portrait
+@onready var _name_label: Label = $NameLabel
+@onready var _tier_label: Label = $TierLabel
+@onready var _ms_value: Label = $StatsGrid/MsValue
+@onready var _armor_value: Label = $StatsGrid/ArmorValue
+@onready var _mr_value: Label = $StatsGrid/MrValue
+@onready var _hp_bar: ProgressBar = $HpRow/HpBar
+@onready var _hp_text: Label = $HpRow/HpBar/HpText
+# Right-edge column: hover popups open toward the open playfield (ui.md rule).
+@onready var _skill_column: VBoxContainer = $SkillColumn
+
+const TIER_NAMES := {
+	Enemy.EnemyType.Normal: "Normal",
+	Enemy.EnemyType.Elite: "Elite",
+	Enemy.EnemyType.Boss: "Boss",
+}
+
+var _enemy: Enemy = null
+
+func _ready():
+	visible = false
+
+func show_enemy(enemy: Enemy) -> void:
+	_enemy = enemy
+	visible = true
+	# Enemy skills never change on a live enemy - build the column once per
+	# selection (unlike the tower panel's level/evolve rebuild key).
+	_rebuild_skill_column(enemy)
+	_refresh()
+
+func clear() -> void:
+	_enemy = null
+	visible = false
+
+func _process(_delta):
+	if not visible:
+		return
+	# Enemies die/leak constantly - deselect the moment the instance frees.
+	if _enemy == null or not is_instance_valid(_enemy):
+		clear()
+		return
+	_refresh()
+
+func _refresh() -> void:
+	var stats: EnemyStat = _enemy.stats
+	if stats == null:
+		clear()
+		return
+
+	_set_text(_name_label, _enemy.display_name)
+	_set_text(_tier_label, TIER_NAMES.get(_enemy.enemyType, "Normal"))
+	# No enemy portrait art exists - the walk sprite stands in (Director OK).
+	if _portrait.texture != _enemy.sprite.texture:
+		_portrait.texture = _enemy.sprite.texture
+
+	# Live getters, so buffs/debuffs show (same rule as the tower panel).
+	_set_text(_ms_value, _format_number(stats.getEffectiveMoveSpeed()))
+	_set_text(_armor_value, str(stats.getTotalArmor()))
+	_set_text(_mr_value, str(stats.getTotalMArmor()))
+
+	_hp_bar.max_value = stats.maxHp
+	_hp_bar.value = stats.currentHp
+	_set_text(_hp_text, "%d / %d" % [stats.currentHp, stats.maxHp])
+
+func _rebuild_skill_column(enemy: Enemy) -> void:
+	for child in _skill_column.get_children():
+		child.queue_free()
+	if enemy.skillController == null:
+		return
+	for skill in enemy.skillController.skills:
+		var es := skill as EnemySkill
+		if es == null:
+			continue
+		var kind := "Active"
+		if es.passive:
+			kind = "Passive"
+		elif es.triggered:
+			kind = "Triggered"
+		_skill_column.add_child(_make_skill_icon(es, kind))
+
+func _make_skill_icon(skill: Skill, kind: String) -> TowerSkillIcon:
+	var icon := TowerSkillIcon.new()
+	icon.custom_minimum_size = Vector2(56, 56)
+	icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	# Enemy skills are single-level; the hover card renders desc at level 1.
+	icon.setup(skill, kind, 1)
+
+	# Same placeholder ladder as the tower panel (no skill icon art yet).
+	var texture: Texture2D = null
+	if skill.icon != "":
+		texture = ResourceManager.loadImage("skill_icon", skill.icon, skill.icon)
+	if texture == null:
+		texture = ResourceManager.getSprite("synergy", "default")
+	icon.texture = texture
+	return icon
+
+# Skip no-op text writes so per-frame polling doesn't churn label layout (PR #20 rule).
+func _set_text(label: Label, value: String) -> void:
+	if label.text != value:
+		label.text = value
+
+func _format_number(value: float) -> String:
+	if is_equal_approx(value, round(value)):
+		return str(int(round(value)))
+	return "%.1f" % value


### PR DESCRIPTION
**Summary:** Adds a click-to-view Enemy Stats Panel (sibling of the Tower Stats Panel, shared bottom-left slot) and migrates enemy/boss skill descriptions to the `parameters` `{token}` binding so hover text can never drift from real skill values.

**How it works:** Clicking an enemy selects it via a radius pick in `_unhandled_input` (tower cell-box pick stays first; near-ties prefer the enemy closest to the path end; boss pick radius scales with spawn scale). The panel shows walk-sprite portrait, display name (new optional roster `name:` key, fallback prettified id; bosses keep their authored name, set at all 4 WaveController spawn sites), tier line, live buff-adjusted MS/Armor/MR, a red HP bar in the Energy-bar slot, and a skill icon column reusing `TowerSkillIcon` (kind line adds TRIGGERED). Skill balance numbers now live once per skill in `parameters`: `apply_effect` binds at runtime (`value_param`/`duration_param`); new parse-time bindings cover `summon_enemy` count, `dash` cells, `delay`, `effect_area` value/duration, and the `hp_below` trigger threshold; the desc renders the same values via `{token}`.

**Implementation Notes:**
- Missing-parameter failures are now loud: `SkillContext.getParameter` warns on a miss (return value unchanged), unresolved desc tokens render as the raw `{token}` instead of empty text, and every new parse-time binding warns and falls back to the literal/default.
- Elite aura value-scale fix (Director-approved): `armor_mult_up` consumes a fraction, so Armored Boar `2.5` / Flying Flower `5` actually meant +250%/+500% while their descs said 2.5%/5% (masked by 0-armor hosts). Corrected to `0.025`/`0.05` with rewritten English descs.
- Both stats panels nudged to 8px corner margins (Director request).
- Area sizes ("7x7", "5x5") stay literal in descs until the post-demo structural parameterize task.

**Touched scenes:** resources/ui_component/game_ui.tscn, resources/ui_component/tower_stats_panel.tscn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
