### PR TITLE
fix(pause): gameplay timers and frame loops now freeze with game pause

### DIFF
--- a/scripts/combat/hitbox.gd
+++ b/scripts/combat/hitbox.gd
@@ -45,6 +45,13 @@ static func create(width: float, height: float, callback: Callable, spawn_pos: V
 	# Force redraw and physics frame update
 	hitbox.queue_redraw()
 	await hitbox.get_tree().process_frame
+	# process_frame keeps emitting while the tree is paused (same trap the dash
+	# action guards) - hold the strike until unpause so a pause landing on this
+	# exact frame can't let damage through mid-pause.
+	while is_instance_valid(hitbox) and hitbox.get_tree().paused:
+		await hitbox.get_tree().process_frame
+	if not is_instance_valid(hitbox):
+		return null
 	hitbox._detect()
 
 	return hitbox
@@ -103,7 +110,7 @@ func _detect():
 
 	# Wait so player can see the hitbox
 	if hide_delay > 0:
-		await get_tree().create_timer(hide_delay).timeout
+		await get_tree().create_timer(hide_delay, false).timeout
 
 	# Cleanup
 	queue_free()

--- a/scripts/entity/attack_controller.gd
+++ b/scripts/entity/attack_controller.gd
@@ -107,7 +107,7 @@ func _spawnBullet(target: Enemy, cfg: TowerAttackConfig, dmg: Damage, saved_gen:
 
 func _spawnBurstRemainder(target: Enemy, cfg: TowerAttackConfig, saved_gen: int) -> void:
 	for i in range(1, cfg.burst):
-		await tower.get_tree().create_timer(0.07).timeout
+		await tower.get_tree().create_timer(0.07, false).timeout
 		if not is_instance_valid(tower) or tower.skill_lock_generation != saved_gen:
 			return   # wave reset mid-burst (tower survives waves; only gen bumps)
 		if not is_instance_valid(target):

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -154,7 +154,7 @@ func recvDamage(damage: Damage) -> int:
 	sprite.modulate = Color.RED
 
 	# Create a one-shot timer to reset the color
-	var timer := get_tree().create_timer(0.3)
+	var timer := get_tree().create_timer(0.3, false)
 	timer.timeout.connect(_on_damage_flash_timeout)
 
 	# TRUE damage bypasses armor/MR + ΣAmp + ΣRed — raw value applied straight to HP.

--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -148,7 +148,7 @@ func spawnEnemyTask(groupIndex: int):
 	# delayed group keeps remain > 0 and _allGroupsSpawned() can't end the wave early.
 	if groupData.startAt > 0:
 		var gen := currWave
-		await get_tree().create_timer(groupData.startAt).timeout
+		await get_tree().create_timer(groupData.startAt, false).timeout
 		# Wave may have ended / advanced during the delay - bail if so (await guard).
 		if not is_instance_valid(self) or currWave != gen or endWaveCalled:
 			return
@@ -178,7 +178,7 @@ func spawnEnemyTask(groupIndex: int):
 		if remain == 0:
 			isSpawnAllEnemy = _allGroupsSpawned()
 		else:
-			await get_tree().create_timer(interval).timeout
+			await get_tree().create_timer(interval, false).timeout
 
 func spawnEnemy(groupIndex: int):
 	if(groupIndex >= waveData.groupList.size()):
@@ -318,7 +318,7 @@ func summon(enemyId: String, count: int, interval: float, pathProgress: float):
 			connectSignalToEnemy(enemy)
 
 		if i < count - 1:
-			await get_tree().create_timer(interval).timeout
+			await get_tree().create_timer(interval, false).timeout
 			# Wave advanced during the trickle: its counters were already reset by
 			# startNextWave, so the remaining reservations are void - do NOT
 			# decrement (that would corrupt the new wave's count). Just stop.

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -286,7 +286,7 @@ func on_wave_ended():
 	# Pacing beat before the popup so wave-clear effects land first. Boss waves hold
 	# longer (token-drop visual); regular waves get the short feel beat.
 	var popup_delay: float = BOSS_WAVE_END_POPUP_DELAY if (waveController != null and waveController.isBossWave) else wave_end_popup_delay
-	await get_tree().create_timer(popup_delay).timeout
+	await get_tree().create_timer(popup_delay, false).timeout
 	# Re-entry guard: scene may have been freed mid-wait (e.g. game-over) OR the staff
 	# may have died during the await window leaving the scene alive but the game over.
 	if !is_instance_valid(self):

--- a/scripts/skill/base_skill_controller.gd
+++ b/scripts/skill/base_skill_controller.gd
@@ -39,7 +39,7 @@ func execute_skill_actions(skill: Skill, context: SkillContext):
 	skill.using = true;
 
 	if skill.castTime > 0:
-		await user.get_tree().create_timer(skill.castTime).timeout
+		await user.get_tree().create_timer(skill.castTime, false).timeout
 		if not is_instance_valid(user):
 			return
 		if context.cancel || cancelled:
@@ -69,7 +69,7 @@ func execute_skill_actions(skill: Skill, context: SkillContext):
 	if skill.recoveryTime > 0:
 		if not is_instance_valid(user):
 			return
-		await user.get_tree().create_timer(skill.recoveryTime).timeout
+		await user.get_tree().create_timer(skill.recoveryTime, false).timeout
 		if not is_instance_valid(user):
 			return
 		if(cancelled):

--- a/scripts/skill/skillActions/skill_action_delay.gd
+++ b/scripts/skill/skillActions/skill_action_delay.gd
@@ -7,7 +7,7 @@ func execute(context: SkillContext):
 	if(context.user == null):
 		return;
 
-	await context.user.get_tree().create_timer(delay).timeout
+	await context.user.get_tree().create_timer(delay, false).timeout
 	if not is_instance_valid(context.user):
 		context.cancel = true
 		return

--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -23,6 +23,10 @@ func execute(context: SkillContext):
 		if context.target.is_empty():
 			attempt += 1
 			await context.user.get_tree().process_frame
+			# process_frame keeps emitting while paused (dash-guard pattern) -
+			# don't let the empty-find cancel / skill chain advance mid-pause.
+			while is_instance_valid(context.user) and context.user.get_tree().paused:
+				await context.user.get_tree().process_frame
 
 	if attempt >= max_attempt && context.target.is_empty() && cancel_when_empty:
 		context.cancel = true

--- a/scripts/skill/skillActions/skill_action_find_target.gd
+++ b/scripts/skill/skillActions/skill_action_find_target.gd
@@ -16,6 +16,10 @@ func execute(context: SkillContext):
 		if(context.target == null):
 			attemp += 1;
 			await context.user.get_tree().process_frame;
+			# process_frame keeps emitting while paused (dash-guard pattern) -
+			# don't burn retries or let the skill chain advance mid-pause.
+			while is_instance_valid(context.user) and context.user.get_tree().paused:
+				await context.user.get_tree().process_frame
 	
 	if(attemp >= maxAttemp && context.target == null):
 		context.cancel = true;

--- a/scripts/skill/skillActions/skill_action_projectile.gd
+++ b/scripts/skill/skillActions/skill_action_projectile.gd
@@ -27,7 +27,7 @@ func execute(context: SkillContext):
 			tower.skillController.currentMana = 0;
 			gen = tower.skill_lock_generation
 
-		await context.user.get_tree().create_timer(lifetime).timeout
+		await context.user.get_tree().create_timer(lifetime, false).timeout
 		# Only re-enable regen if this cast is still the live one. resetForWave() bumps
 		# skill_lock_generation so a stale timer can't unblock energy during a fresh
 		# skill cast on the next wave.

--- a/scripts/skill/skillActions/skill_create_directional_projectile.gd
+++ b/scripts/skill/skillActions/skill_create_directional_projectile.gd
@@ -93,6 +93,6 @@ func execute(context: SkillContext):
 # effective travel time. Skipped if a wave-end resetForWave has bumped the
 # skill_lock_generation since this cast started (stale callback guard).
 func _unlock_mana_after_delay(tower: Tower, saved_gen: int, delay: float) -> void:
-	await tower.get_tree().create_timer(delay).timeout
+	await tower.get_tree().create_timer(delay, false).timeout
 	if is_instance_valid(tower) and tower.skill_lock_generation == saved_gen:
 		tower.enableRegenMana = true


### PR DESCRIPTION
**Problem:** Pausing the game did not stop enemy spawning - the spawn loop (and 9 other gameplay waits) run on SceneTreeTimers, whose Godot default (`process_always = true`) keeps counting while the tree is paused. Skill find/hitbox beats had the same leak through `process_frame`, which also keeps emitting during pause.

**Impact:** During pause, enemies kept spawning (wave groups and boss summons), a mid-cast tower could finish its cast and deal damage on a frozen screen, burst shots kept firing, projectile lifetimes expired, and the wave-end popup could open.

**Fix:** One pause-leak sweep, two mechanical patterns:
- All 12 gameplay `create_timer(x)` sites -> `create_timer(x, false)` so the timer freezes with `SceneTree.paused` (wave spawn startAt/interval, boss summon trickle, skill castTime/recoveryTime, wave-end popup beat, burst gap, hitbox hide delay, damage flash, projectile lifetime, delay action, mana-unlock delay). x2 game speed is untouched (`ignore_time_scale` stays default).
- 3 `process_frame` waits (Hitbox.create, find_target / find_multiple_in_range retry loops) get the same paused-guard the dash action already uses, so a skill's strike/find beat cannot land or advance the chain mid-pause.

All existing post-await validity/generation guards are unchanged; they still cover wave-reset races. Known residual (accepted): an enemy whose async creation is already in flight at the pause instant still finishes instantiating and appears frozen - no further spawns occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
