### PR TITLE
Buff/debuff icon strip on stats panels with rich hover

### DIFF
--- a/resources/ui_component/enemy_stats_panel.tscn
+++ b/resources/ui_component/enemy_stats_panel.tscn
@@ -205,9 +205,9 @@ theme_override_constants/separation = 10
 
 [node name="EffectRow" type="HBoxContainer" parent="."]
 offset_left = 8.0
-offset_top = -64.0
+offset_top = -56.0
 offset_right = 560.0
-offset_bottom = -16.0
+offset_bottom = -8.0
 mouse_filter = 2
 theme_override_constants/separation = 8
 script = ExtResource("3_effrow")

--- a/resources/ui_component/enemy_stats_panel.tscn
+++ b/resources/ui_component/enemy_stats_panel.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=12 format=3]
+[gd_scene load_steps=13 format=3]
 
 [ext_resource type="Script" path="res://scripts/ui/enemy_stats_panel.gd" id="1_enstats"]
 [ext_resource type="FontFile" uid="uid://scv78fddnukv" path="res://resources/ui_component/font/Roboto-Regular.ttf" id="2_font"]
+[ext_resource type="Script" path="res://scripts/ui/effect/effect_icon_row.gd" id="3_effrow"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panelbg"]
 bg_color = Color(0.07, 0.05, 0.12, 0.94)
@@ -201,3 +202,15 @@ offset_right = 548.0
 offset_bottom = 298.0
 mouse_filter = 2
 theme_override_constants/separation = 10
+
+[node name="EffectRow" type="HBoxContainer" parent="."]
+offset_left = 8.0
+offset_top = -64.0
+offset_right = 560.0
+offset_bottom = -16.0
+mouse_filter = 2
+theme_override_constants/separation = 8
+script = ExtResource("3_effrow")
+icon_size = 48
+max_visible = 9
+rich_hover = true

--- a/resources/ui_component/tower_stats_panel.tscn
+++ b/resources/ui_component/tower_stats_panel.tscn
@@ -272,9 +272,9 @@ theme_override_constants/separation = 10
 
 [node name="EffectRow" type="HBoxContainer" parent="."]
 offset_left = 8.0
-offset_top = -64.0
+offset_top = -56.0
 offset_right = 560.0
-offset_bottom = -16.0
+offset_bottom = -8.0
 mouse_filter = 2
 theme_override_constants/separation = 8
 script = ExtResource("3_effrow")

--- a/resources/ui_component/tower_stats_panel.tscn
+++ b/resources/ui_component/tower_stats_panel.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=12 format=3]
+[gd_scene load_steps=13 format=3]
 
 [ext_resource type="Script" path="res://scripts/ui/tower_stats_panel.gd" id="1_twstats"]
 [ext_resource type="FontFile" uid="uid://scv78fddnukv" path="res://resources/ui_component/font/Roboto-Regular.ttf" id="2_font"]
+[ext_resource type="Script" path="res://scripts/ui/effect/effect_icon_row.gd" id="3_effrow"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panelbg"]
 bg_color = Color(0.07, 0.05, 0.12, 0.94)
@@ -268,3 +269,15 @@ offset_right = 548.0
 offset_bottom = 298.0
 mouse_filter = 2
 theme_override_constants/separation = 10
+
+[node name="EffectRow" type="HBoxContainer" parent="."]
+offset_left = 8.0
+offset_top = -64.0
+offset_right = 560.0
+offset_bottom = -16.0
+mouse_filter = 2
+theme_override_constants/separation = 8
+script = ExtResource("3_effrow")
+icon_size = 48
+max_visible = 9
+rich_hover = true

--- a/scripts/ui/effect/effect_hover_icon.gd
+++ b/scripts/ui/effect/effect_hover_icon.gd
@@ -4,8 +4,6 @@ extends TextureRect
 # One buff/debuff icon, built by EffectIconRow for both surfaces: overhead
 # rows (display-only, hover disabled) and the stats-panel strip, where hover
 # opens the shared opaque tooltip card (same pattern as TowerSkillIcon).
-# The card is built lazily at hover-open, so it reads the live instance
-# (stacks mutate in place); an already-open card does not refresh - re-hover.
 
 const CATEGORY_LINES := {
 	EffectTypes.Category.BUFF: "[color=#45C759]BUFF[/color]",
@@ -14,9 +12,19 @@ const CATEGORY_LINES := {
 }
 
 var inst: EffectInstance = null
+# Ref into the open card so stack/value ticks refresh it live (same pattern
+# as the synergy hover - ui_synergy_content.gd). Invalid once the card closes.
+var _tooltip_label: RichTextLabel = null
 
 func _make_custom_tooltip(_for_text: String) -> Object:
-	return UISynergyContent.make_tooltip_card(_build_hover_bbcode(), 320.0, self)
+	var panel := UISynergyContent.make_tooltip_card(_build_hover_bbcode(), 320.0, self)
+	_tooltip_label = panel.get_child(0) as RichTextLabel
+	return panel
+
+# Called by the row on effect_updated while this icon exists.
+func refresh_tooltip() -> void:
+	if _tooltip_label != null and is_instance_valid(_tooltip_label):
+		_tooltip_label.text = _build_hover_bbcode()
 
 func _build_hover_bbcode() -> String:
 	if inst == null:
@@ -28,6 +36,5 @@ func _build_hover_bbcode() -> String:
 		lines.append(category_line)
 	var desc := inst.display_desc()
 	if desc != "":
-		lines.append("")
 		lines.append(desc)
 	return "\n".join(lines)

--- a/scripts/ui/effect/effect_hover_icon.gd
+++ b/scripts/ui/effect/effect_hover_icon.gd
@@ -1,0 +1,33 @@
+class_name EffectHoverIcon
+extends TextureRect
+
+# One buff/debuff icon, built by EffectIconRow for both surfaces: overhead
+# rows (display-only, hover disabled) and the stats-panel strip, where hover
+# opens the shared opaque tooltip card (same pattern as TowerSkillIcon).
+# The card is built lazily at hover-open, so it reads the live instance
+# (stacks mutate in place); an already-open card does not refresh - re-hover.
+
+const CATEGORY_LINES := {
+	EffectTypes.Category.BUFF: "[color=#45C759]BUFF[/color]",
+	EffectTypes.Category.DEBUFF: "[color=#DB4545]DEBUFF[/color]",
+	EffectTypes.Category.MARK: "[color=#AB59DB]MARK[/color]",
+}
+
+var inst: EffectInstance = null
+
+func _make_custom_tooltip(_for_text: String) -> Object:
+	return UISynergyContent.make_tooltip_card(_build_hover_bbcode(), 320.0, self)
+
+func _build_hover_bbcode() -> String:
+	if inst == null:
+		return ""
+	var lines: PackedStringArray = []
+	lines.append("[b]" + inst.display_title() + "[/b]")
+	var category_line: String = CATEGORY_LINES.get(inst.def.category, "")
+	if category_line != "":
+		lines.append(category_line)
+	var desc := inst.display_desc()
+	if desc != "":
+		lines.append("")
+		lines.append(desc)
+	return "\n".join(lines)

--- a/scripts/ui/effect/effect_icon_row.gd
+++ b/scripts/ui/effect/effect_icon_row.gd
@@ -79,9 +79,11 @@ func _refresh_overflow() -> void:
 			icon.visible = i < max_visible
 
 func _on_effect_updated(inst: EffectInstance) -> void:
-	var icon: TextureRect = _icons.get(inst.key(), null)
+	var icon: EffectHoverIcon = _icons.get(inst.key(), null)
 	if icon != null:
 		_update_stack_label(icon, inst)
+		if rich_hover:
+			icon.refresh_tooltip()
 
 func _make_icon(inst: EffectInstance) -> EffectHoverIcon:
 	var icon := EffectHoverIcon.new()

--- a/scripts/ui/effect/effect_icon_row.gd
+++ b/scripts/ui/effect/effect_icon_row.gd
@@ -1,8 +1,12 @@
 class_name EffectIconRow
 extends HBoxContainer
 
-# Overhead status-icon row (towers: above the Energy bar; enemies: above the
-# HP bar). Purely signal-driven off one EffectContainer - no per-frame work.
+# Buff/debuff status-icon row, two surfaces (Director 2026-07-17):
+# - Overhead (towers: above the Energy bar; enemies: above the HP bar):
+#   display-only, hover disabled - the desc surface moved to the stats panels.
+# - Stats-panel strip (rich_hover = true): floats above the panel, icons open
+#   the shared opaque tooltip card on hover.
+# Purely signal-driven off one EffectContainer - no per-frame work.
 # Icons are built in code from the registry texture (green/red/purple
 # placeholders today; artists swap art via the icon path in effects.yaml).
 # Stack count shows bottom-right when stacks > 1. Left-aligned, oldest first;
@@ -17,6 +21,9 @@ const FALLBACK_COLORS := {
 
 @export var icon_size: int = 44
 @export var max_visible: int = 5
+# Stats-panel strips set true: icons STOP the mouse and open the rich tooltip
+# card. Default false = overhead row, display-only (icons IGNORE the mouse).
+@export var rich_hover: bool = false
 
 var _container: EffectContainer = null
 var _icons: Dictionary = {}    # EffectInstance.key() -> TextureRect
@@ -76,19 +83,15 @@ func _on_effect_updated(inst: EffectInstance) -> void:
 	if icon != null:
 		_update_stack_label(icon, inst)
 
-func _make_icon(inst: EffectInstance) -> TextureRect:
-	var icon := TextureRect.new()
+func _make_icon(inst: EffectInstance) -> EffectHoverIcon:
+	var icon := EffectHoverIcon.new()
+	icon.inst = inst
 	icon.custom_minimum_size = Vector2(icon_size, icon_size)
 	icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
 	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-	# PASS (not STOP): hover tooltip works without consuming world clicks.
-	# Interim desc surface for functional checks - the durable home is the
-	# future tower/enemy stats UI (see buff_debuff.md Plan and Status).
-	icon.mouse_filter = Control.MOUSE_FILTER_PASS
-	if EnemySkillController.DEBUG_LOG:
-		# Hover diagnosis (2026-07-07): logs whether the mouse ever reaches the
-		# icon - separates "tooltip broken" from "icon never hovered".
-		icon.mouse_entered.connect(func(): print("[EffectIcon] hover enter: ", inst.def.id))
+	# Panel strip: STOP so the icon is a hover source for the tooltip card.
+	# Overhead: IGNORE - display-only, transparent to world clicks and hover.
+	icon.mouse_filter = Control.MOUSE_FILTER_STOP if rich_hover else Control.MOUSE_FILTER_IGNORE
 	icon.texture = ResourceManager.getSprite(EffectRegistry.ICON_GROUP, inst.def.id)
 	if icon.texture == null:
 		# Registry icon missing/unloaded: flat category-colored square so the
@@ -112,11 +115,11 @@ func _make_icon(inst: EffectInstance) -> TextureRect:
 	return icon
 
 func _update_stack_label(icon: TextureRect, inst: EffectInstance) -> void:
-	var tooltip := inst.display_title()
-	var desc := inst.display_desc()
-	if desc != "":
-		tooltip += "\n" + desc
-	icon.tooltip_text = tooltip
+	if rich_hover:
+		# tooltip_text must carry REAL text or the viewport strips it and never
+		# calls _make_custom_tooltip (same trap as TowerSkillIcon).
+		var title := inst.display_title()
+		icon.tooltip_text = title if title != "" else inst.def.id
 	var label: Label = icon.get_node_or_null("StackLabel")
 	if label == null:
 		return

--- a/scripts/ui/enemy_stats_panel.gd
+++ b/scripts/ui/enemy_stats_panel.gd
@@ -16,6 +16,8 @@ extends Control
 @onready var _hp_text: Label = $HpRow/HpBar/HpText
 # Right-edge column: hover popups open toward the open playfield (ui.md rule).
 @onready var _skill_column: VBoxContainer = $SkillColumn
+# Buff/debuff strip floating above the panel's top border (rich hover).
+@onready var _effect_row: EffectIconRow = $EffectRow
 
 const TIER_NAMES := {
 	Enemy.EnemyType.Normal: "Normal",
@@ -31,6 +33,7 @@ func _ready():
 func show_enemy(enemy: Enemy) -> void:
 	_enemy = enemy
 	visible = true
+	_effect_row.setup(enemy.effects)
 	# Enemy skills never change on a live enemy - build the column once per
 	# selection (unlike the tower panel's level/evolve rebuild key).
 	_rebuild_skill_column(enemy)
@@ -39,6 +42,7 @@ func show_enemy(enemy: Enemy) -> void:
 func clear() -> void:
 	_enemy = null
 	visible = false
+	_effect_row.setup(null)
 
 func _process(_delta):
 	if not visible:

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -25,6 +25,8 @@ extends Control
 # Right-edge column: the hover popup opens toward the open playfield instead of
 # over the panel's own stat text (Director feedback 2026-07-16).
 @onready var _skill_column: VBoxContainer = $SkillColumn
+# Buff/debuff strip floating above the panel's top border (rich hover).
+@onready var _effect_row: EffectIconRow = $EffectRow
 
 var _tower: Tower = null
 # Rebuild key for the skill-icon row ("level_isEvolved"): icons/tooltips only
@@ -38,11 +40,15 @@ func show_tower(tower: Tower) -> void:
 	_tower = tower
 	_skills_key = ""
 	visible = true
+	# Container lives on TowerData, which evolve() mutates in place and which
+	# outlives the node - bind once per selection is safe.
+	_effect_row.setup(tower.data.effects if tower.data != null else null)
 	_refresh()
 
 func clear() -> void:
 	_tower = null
 	visible = false
+	_effect_row.setup(null)
 
 func _process(_delta):
 	if not visible:


### PR DESCRIPTION
**Summary:** Buff/debuff icon strip on both stats panels (tower + enemy) with the shared rich hover card; overhead icon rows become display-only. Closes the desc-surface relocation pending since PR #77/#78.

**How it works:** `EffectIconRow` gains a `rich_hover` export and now builds `EffectHoverIcon` (new tiny TextureRect subclass). Panel strips (new `EffectRow` node floating above each panel's top border, left-aligned, 48px icons, max 9 with shift-in overflow) set `rich_hover = true`: icons STOP the mouse and open the shared opaque tooltip card (`UISynergyContent.make_tooltip_card`) showing title, BUFF/DEBUFF/MARK line, and the registry desc with real applied values; an open card live-refreshes on stack/value ticks (synergy-hover `_tooltip_label` pattern). Overhead rows (default `rich_hover = false`) switch icons to IGNORE - visuals unchanged, hover disabled, zero scene edits on tower/enemy scenes. Panels bind the strip on selection (`tower.data.effects` / `enemy.effects`) and unbind on clear.

**Implementation Notes:** Synergy board buffs keep `show_icon = false` and never appear in the strip. The container is bind-once-safe per selection: `TowerData.effects` survives `evolve()` (mutates in place) and outlives the node. Removed the DEBUG_LOG hover-diagnosis connect in the row (dead under IGNORE).

**Touched scenes:** `resources/ui_component/tower_stats_panel.tscn`, `resources/ui_component/enemy_stats_panel.tscn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
