### PR TITLE
Inspect highlight: outline on selected tower/enemy

### DIFF
--- a/resources/ui_component/inspect_outline.gdshader
+++ b/resources/ui_component/inspect_outline.gdshader
@@ -20,8 +20,8 @@ shader_type canvas_item;
 // quad_center_px = the sprite's `offset` (a centered sprite's quad center).
 
 uniform vec4 line_color : source_color = vec4(0.85, 0.95, 1.0, 1.0);
-uniform float thickness_px : hint_range(1.0, 12.0) = 4.0;
-uniform float grow_px = 6.0; // keep >= thickness_px + 2 so the line never clips
+uniform float thickness_px : hint_range(1.0, 16.0) = 8.0;
+uniform float grow_px = 12.0; // keep >= thickness_px + 2 so the line never clips
 uniform vec4 region_uv = vec4(0.0, 0.0, 1.0, 1.0);
 uniform vec2 quad_center_px = vec2(0.0, 0.0);
 uniform float pulse_speed = 5.2; // rad/s (~1.2s cycle); 0.0 = static line
@@ -33,7 +33,14 @@ const vec2 DIRS[8] = {
 	vec2(-0.7071, 0.7071), vec2(-0.7071, -0.7071)
 };
 
+// Vertex color carries the node's modulate/self_modulate (per-tower placeholder
+// tint, enemy damage flash). A custom fragment must re-apply it to the art
+// itself or those tints silently vanish; the LINE deliberately skips it so the
+// highlight keeps its CI white-blue under any tint.
+varying vec4 v_modulate;
+
 void vertex() {
+	v_modulate = COLOR;
 	VERTEX += sign(VERTEX - quad_center_px) * grow_px;
 }
 
@@ -53,7 +60,7 @@ void fragment() {
 	vec2 cell_px = region_uv.zw / TEXTURE_PIXEL_SIZE;
 	vec2 sample_uv = cell_center + (UV - cell_center) * (cell_px + 2.0 * grow_px) / cell_px;
 
-	vec4 base = texture(TEXTURE, sample_uv);
+	vec4 base = texture(TEXTURE, sample_uv) * v_modulate;
 	// Outside the frame rect the sprite contributes nothing.
 	vec2 rmin = region_uv.xy;
 	vec2 rmax = region_uv.xy + region_uv.zw;
@@ -61,10 +68,13 @@ void fragment() {
 		base = vec4(0.0);
 	}
 
+	// Two rings (full + 0.55x radius) so a thick band stays solid instead of
+	// scalloping between the 8 directions.
 	float neighbor = 0.0;
 	vec2 t = thickness_px * TEXTURE_PIXEL_SIZE;
 	for (int i = 0; i < 8; i++) {
 		neighbor = max(neighbor, frame_alpha(TEXTURE, sample_uv + DIRS[i] * t));
+		neighbor = max(neighbor, frame_alpha(TEXTURE, sample_uv + DIRS[i] * t * 0.55));
 	}
 
 	float pulse = 1.0;

--- a/resources/ui_component/inspect_outline.gdshader
+++ b/resources/ui_component/inspect_outline.gdshader
@@ -1,0 +1,80 @@
+shader_type canvas_item;
+
+// Inspect-highlight outline (ui.md): silhouette border drawn on the sprite of
+// the tower/enemy currently selected into a stats panel. First character-sprite
+// shader in the project - assigned/removed at runtime by the two stats panels.
+//
+// Works on BOTH sprite kinds with no hardcoded asset dimensions:
+// - AnimatedSprite2D whose frames are AtlasTexture regions on a packed sheet
+//   (region_uv = current frame rect, script-fed on frame/animation change), and
+// - plain Sprite2D full textures (region_uv = 0,0,1,1).
+// The quad is grown by grow_px so the line survives art that touches the frame
+// edge (Altare idle sheet, all enemy PNGs); sampling is contracted back around
+// the frame center per-axis, which reproduces the un-grown mapping exactly, so
+// the art keeps its original on-screen size and position. Samples outside the
+// frame rect read as transparent - both the cross-frame bleed guard and the
+// clamp-to-edge smear guard.
+//
+// Grow direction comes from vertex positions, NOT UV: flip_h swaps UVs, so a
+// UV-derived direction would invert the grow on flipped (right-facing) enemies.
+// quad_center_px = the sprite's `offset` (a centered sprite's quad center).
+
+uniform vec4 line_color : source_color = vec4(0.85, 0.95, 1.0, 1.0);
+uniform float thickness_px : hint_range(1.0, 12.0) = 4.0;
+uniform float grow_px = 6.0; // keep >= thickness_px + 2 so the line never clips
+uniform vec4 region_uv = vec4(0.0, 0.0, 1.0, 1.0);
+uniform vec2 quad_center_px = vec2(0.0, 0.0);
+uniform float pulse_speed = 5.2; // rad/s (~1.2s cycle); 0.0 = static line
+uniform float pulse_min : hint_range(0.0, 1.0) = 0.65;
+
+const vec2 DIRS[8] = {
+	vec2(1.0, 0.0), vec2(-1.0, 0.0), vec2(0.0, 1.0), vec2(0.0, -1.0),
+	vec2(0.7071, 0.7071), vec2(0.7071, -0.7071),
+	vec2(-0.7071, 0.7071), vec2(-0.7071, -0.7071)
+};
+
+void vertex() {
+	VERTEX += sign(VERTEX - quad_center_px) * grow_px;
+}
+
+float frame_alpha(sampler2D tex, vec2 uv) {
+	vec2 rmin = region_uv.xy;
+	vec2 rmax = region_uv.xy + region_uv.zw;
+	if (uv.x < rmin.x || uv.y < rmin.y || uv.x > rmax.x || uv.y > rmax.y) {
+		return 0.0;
+	}
+	return texture(tex, uv).a;
+}
+
+void fragment() {
+	// Contract sampling around the frame center to undo the vertex growth
+	// (per-axis: enemy textures are non-square).
+	vec2 cell_center = region_uv.xy + region_uv.zw * 0.5;
+	vec2 cell_px = region_uv.zw / TEXTURE_PIXEL_SIZE;
+	vec2 sample_uv = cell_center + (UV - cell_center) * (cell_px + 2.0 * grow_px) / cell_px;
+
+	vec4 base = texture(TEXTURE, sample_uv);
+	// Outside the frame rect the sprite contributes nothing.
+	vec2 rmin = region_uv.xy;
+	vec2 rmax = region_uv.xy + region_uv.zw;
+	if (sample_uv.x < rmin.x || sample_uv.y < rmin.y || sample_uv.x > rmax.x || sample_uv.y > rmax.y) {
+		base = vec4(0.0);
+	}
+
+	float neighbor = 0.0;
+	vec2 t = thickness_px * TEXTURE_PIXEL_SIZE;
+	for (int i = 0; i < 8; i++) {
+		neighbor = max(neighbor, frame_alpha(TEXTURE, sample_uv + DIRS[i] * t));
+	}
+
+	float pulse = 1.0;
+	if (pulse_speed > 0.0) {
+		pulse = mix(pulse_min, 1.0, 0.5 + 0.5 * sin(TIME * pulse_speed));
+	}
+	// Line only where the sprite itself is (mostly) transparent; smoothstep
+	// keeps the edge soft against semi-transparent art pixels.
+	float line_mask = smoothstep(0.3, 0.6, neighbor) * (1.0 - smoothstep(0.3, 0.6, base.a));
+	vec4 line = vec4(line_color.rgb, line_color.a * line_mask * pulse);
+
+	COLOR = mix(line, base, base.a);
+}

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -175,6 +175,10 @@ static func warmSkillEffectShaders(host: Node) -> void:
 		if data.attack_config != null and data.attack_config.vfx_shader != "":
 			shaderPaths[data.attack_config.vfx_shader] = true
 
+	# Inspect-highlight outline (tower/enemy click-select, ui.md): assigned to a
+	# character sprite on first selection, so warm it here with the rest.
+	shaderPaths["res://resources/ui_component/inspect_outline.gdshader"] = true
+
 	# Skip shaders already warmed this process; only compile genuinely-new ones.
 	var toWarm: Array = []
 	for sp in shaderPaths.keys():

--- a/scripts/ui/enemy_stats_panel.gd
+++ b/scripts/ui/enemy_stats_panel.gd
@@ -25,10 +25,20 @@ const TIER_NAMES := {
 	Enemy.EnemyType.Boss: "Boss",
 }
 
+const OUTLINE_SHADER := preload("res://resources/ui_component/inspect_outline.gdshader")
+
 var _enemy: Enemy = null
+# Inspect-highlight outline on the selected enemy's sprite (ui.md). Enemies are
+# single full textures, so no frame-region feed is needed (unlike the tower
+# panel): the shader reads texture dimensions itself and region stays the
+# default whole-texture rect.
+var _outline_mat: ShaderMaterial
+var _hl_sprite: Sprite2D = null
 
 func _ready():
 	visible = false
+	_outline_mat = ShaderMaterial.new()
+	_outline_mat.shader = OUTLINE_SHADER
 
 func show_enemy(enemy: Enemy) -> void:
 	_enemy = enemy
@@ -37,12 +47,29 @@ func show_enemy(enemy: Enemy) -> void:
 	# Enemy skills never change on a live enemy - build the column once per
 	# selection (unlike the tower panel's level/evolve rebuild key).
 	_rebuild_skill_column(enemy)
+	_apply_highlight(enemy.sprite)
 	_refresh()
 
 func clear() -> void:
 	_enemy = null
 	visible = false
 	_effect_row.setup(null)
+	_remove_highlight()
+
+func _apply_highlight(spr: Sprite2D) -> void:
+	_remove_highlight()
+	if spr == null:
+		return
+	_hl_sprite = spr
+	# Quad center in local vertex space = the sprite's offset (flip-proof grow
+	# direction; see the shader header).
+	_outline_mat.set_shader_parameter("quad_center_px", spr.offset)
+	spr.material = _outline_mat
+
+func _remove_highlight() -> void:
+	if _hl_sprite != null and is_instance_valid(_hl_sprite):
+		_hl_sprite.material = null
+	_hl_sprite = null
 
 func _process(_delta):
 	if not visible:

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -28,13 +28,21 @@ extends Control
 # Buff/debuff strip floating above the panel's top border (rich hover).
 @onready var _effect_row: EffectIconRow = $EffectRow
 
+const OUTLINE_SHADER := preload("res://resources/ui_component/inspect_outline.gdshader")
+
 var _tower: Tower = null
 # Rebuild key for the skill-icon row ("level_isEvolved"): icons/tooltips only
 # change on level-up or evolve, so the per-frame poll skips the rebuild.
 var _skills_key: String = ""
+# Inspect-highlight outline on the selected tower's sprite (ui.md). One material
+# is enough: only one unit is ever selected (panels mutually clear).
+var _outline_mat: ShaderMaterial
+var _hl_sprite: AnimatedSprite2D = null
 
 func _ready():
 	visible = false
+	_outline_mat = ShaderMaterial.new()
+	_outline_mat.shader = OUTLINE_SHADER
 
 func show_tower(tower: Tower) -> void:
 	_tower = tower
@@ -43,12 +51,55 @@ func show_tower(tower: Tower) -> void:
 	# Container lives on TowerData, which evolve() mutates in place and which
 	# outlives the node - bind once per selection is safe.
 	_effect_row.setup(tower.data.effects if tower.data != null else null)
+	_apply_highlight(tower.spr)
 	_refresh()
 
 func clear() -> void:
 	_tower = null
 	visible = false
 	_effect_row.setup(null)
+	_remove_highlight()
+
+# The shader needs the CURRENT frame's rect inside the sheet (its cell clamp +
+# grow contraction). Feeding it live from the sprite - instead of hardcoding any
+# frame/sheet size - keeps the highlight correct through future asset resizes
+# or repacks (Director requirement 2026-07-17).
+func _apply_highlight(spr: AnimatedSprite2D) -> void:
+	_remove_highlight()
+	if spr == null:
+		return
+	_hl_sprite = spr
+	# A centered sprite's quad center in local vertex space is its offset; the
+	# shader grows vertices away from it (flip-proof, unlike UV-derived growth).
+	_outline_mat.set_shader_parameter("quad_center_px", spr.offset)
+	_update_highlight_region()
+	spr.material = _outline_mat
+	spr.frame_changed.connect(_update_highlight_region)
+	spr.animation_changed.connect(_update_highlight_region)
+
+func _remove_highlight() -> void:
+	if _hl_sprite != null and is_instance_valid(_hl_sprite):
+		_hl_sprite.material = null
+		if _hl_sprite.frame_changed.is_connected(_update_highlight_region):
+			_hl_sprite.frame_changed.disconnect(_update_highlight_region)
+		if _hl_sprite.animation_changed.is_connected(_update_highlight_region):
+			_hl_sprite.animation_changed.disconnect(_update_highlight_region)
+	_hl_sprite = null
+
+func _update_highlight_region() -> void:
+	if _hl_sprite == null or not is_instance_valid(_hl_sprite):
+		return
+	# Default = whole texture (non-atlas frames need no cell clamp).
+	var region := Vector4(0.0, 0.0, 1.0, 1.0)
+	var frames := _hl_sprite.sprite_frames
+	if frames != null and frames.has_animation(_hl_sprite.animation) \
+			and _hl_sprite.frame < frames.get_frame_count(_hl_sprite.animation):
+		var atlas := frames.get_frame_texture(_hl_sprite.animation, _hl_sprite.frame) as AtlasTexture
+		if atlas != null and atlas.atlas != null:
+			var sheet: Vector2 = atlas.atlas.get_size()
+			region = Vector4(atlas.region.position.x / sheet.x, atlas.region.position.y / sheet.y,
+					atlas.region.size.x / sheet.x, atlas.region.size.y / sheet.y)
+	_outline_mat.set_shader_parameter("region_uv", region)
 
 func _process(_delta):
 	if not visible:


### PR DESCRIPTION
**Summary:** Click-to-inspect highlight: a pulsing white-blue silhouette outline on the tower/enemy currently selected into a stats panel, so the inspected unit is visible on the field.

**How it works:** One canvas_item shader (`resources/ui_component/inspect_outline.gdshader`) assigned to the selected sprite only. Frame-rect clamp stops cross-frame sample bleed on packed tower spritesheets; vertex grow + per-axis UV contraction lets edge-touching art (Altare idle sheet, enemy PNGs) carry an unclipped outline while keeping its exact on-screen size; grow direction comes from vertex space so enemy flip_h cannot invert it. The current frame rect is script-fed live from the selected sprite (no hardcoded asset dimensions - survives future art resizes/repacks). The two stats panels own apply/remove on their existing show/clear paths (covers death/leak via their validity polls); the shader is warmed at load through the existing skill-effect warm pass.

**Implementation Notes:** Builds on the #102 stats-panel code (now on main). First shader on a character sprite in the project: a custom fragment drops the node's modulate unless re-applied, which erased the per-tower placeholder tints in test round 1 - fixed by re-applying vertex color to the art only, so the outline deliberately keeps its CI white-blue under any tint (incl. the enemy damage flash). Line thickness/color/pulse are single-point defaults in the shader file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
