### PR TITLE
Skill cast_time naming unification + King's Command channel

### DIFF
--- a/resources/database/enemy/forest01/boss/king_salam.yaml
+++ b/resources/database/enemy/forest01/boss/king_salam.yaml
@@ -57,32 +57,36 @@ skill:
           duration_param: duration
   - name: King's Command
     cooldown: 30
-    cast_time: 0.5
     recovery: 0.2
     tags:
+      - channel
       - invincible
       - summon
     parameters:
-      stand_duration: 2
+      channel_time: 4
       summon_count: 10
-    desc: "King Salam stands his ground, invincible and untargetable for {stand_duration} seconds, then commands {summon_count} Armored Salam to join the battle at his side."
+    desc: "King Salam channels his royal authority for {channel_time} seconds - invincible and untargetable while {summon_count} Armored Salam march out to join the battle at his side."
     action:
+      # Channel shape: everything runs INSIDE the delay window. summon_enemy is
+      # fire-and-forget (WaveController trickles the batch), so the minions walk
+      # out while the delay holds him castLocked and invincible covers the
+      # whole window (10 x 0.4s = last summon ~3.6s, inside 4s).
       - type: target_self
       - type: apply_effect
         data:
           effect: invincible
           target: targets
-          duration_param: stand_duration
+          duration_param: channel_time
       - type: apply_effect
         data:
           effect: royal_command
           target: targets
-          duration_param: stand_duration
-      - type: delay
-        data:
-          delay_param: stand_duration
+          duration_param: channel_time
       - type: summon_enemy
         data:
           enemy: armored_salam
           count_param: summon_count
-          interval: 0.2
+          interval: 0.4
+      - type: delay
+        data:
+          delay_param: channel_time

--- a/resources/database/staffs/a_chan.yaml
+++ b/resources/database/staffs/a_chan.yaml
@@ -18,7 +18,6 @@ end_sprite_scene: staffs/a_chan/sprite/staff_a_chan_sprite.tscn
 skill:
   name: "Hard Worker Ghost Release!!!"
   desc: "A-Chan releases the spirits of hard workers, instantly killing all enemies in a 5x5 area. Boss enemies take 25% of their max HP as True Damage. Once per game."
-  cast_time: 0.0
   # MOBA-style charges: 1 = once/game, 2 = twice/game, … ; omit or -1 = unlimited.
   use_charges: 1
   aoe:

--- a/resources/database/staffs/staffs.yaml
+++ b/resources/database/staffs/staffs.yaml
@@ -55,7 +55,6 @@
 # skill:
 #   name: "<display name>"
 #   desc: "<player-facing description (English; appears on selection card + tooltip)>"
-#   cast_time: 0.0          # seconds; instant = 0
 #   use_charges: 1          # MOBA-style charge cap. 1 = once/game, 2 = twice, ... ;
 #                           # omit or -1 = unlimited. Per-charge cooldown not yet supported.
 #   aoe:                    # cast-range indicator footprint (cells)

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -61,10 +61,8 @@ skills:
           target_team: enemy
           target_type: enemy
           target_shape: area
-    # cast_time: 0.0   # DISABLED — skill/combo timing lives in play_animation `duration` (see combo template below).
-    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     # recovery = ช่วงจบ (วินาที): หลัง action สุดท้ายจบ tower ค้างท่า/ไม่กลับไปตีต่อทันที
-    # ตามโมเดล 3 จังหวะ หัว(cast_time)/ตัว(duration)/หาง(recovery) — ไม่ใส่ = default 0.2
+    # ตามโมเดล ตัว(cast_time = เวลาร่าย/เล่นท่า)/หาง(recovery) — ไม่ใส่ = default 0.2
     recovery: 0.2
     parameters:
       damageBonus:
@@ -126,13 +124,13 @@ skills:
       # ─────────────────────────────────────────────────────────────────
       # COMBO SKILL (หลายท่าใน cast เดียว) — pattern แบบ "beat"
       #
-      # 1 beat = play_animation(1 คลิป non-loop) + duration(วินาที) + effect ต่อท้าย
-      #   • duration ยืด/ย่อคลิปให้พอดีเวลา → ดาเมจ/effect ลงที่ ~80% ของ duration
+      # 1 beat = play_animation(1 คลิป non-loop) + cast_time(วินาที) + effect ต่อท้าย
+      #   • cast_time ยืด/ย่อคลิปให้พอดีเวลา → ดาเมจ/effect ลงที่ ~80% ของ cast_time
       #   • ชื่อคลิป: skill_1, skill_2, ... skill_N (ต้องมีใน SpriteFrames ของ .tscn, loop=false)
       #   • ท่าเชื่อม (เช่น ควงปืน) วาดไว้ "หัวคลิป" ของ beat ถัดไป — ไม่มีคลิป "pre" แยก
       #   • beat สุดท้ายปิดด้วย play_animation "idle" เสมอ (คืน speed ปกติ)
-      #   • ห้ามต่อ delay หลัง play_animation ของ beat — คุมจังหวะที่ duration พอ
-      #   • cast_time ตั้ง 0 สำหรับคอมโบ (ท่าชาร์จก่อนฟันใส่หัวคลิป beat 1)
+      #   • ห้ามต่อ delay หลัง play_animation ของ beat — คุมจังหวะที่ cast_time พอ
+      #   • ท่าชาร์จ/ง้างก่อนฟัน วาดใส่หัวคลิป beat 1 (คีย์ cast_time ระดับสกิลถูกลบแล้ว)
       #   • ใช้ได้ทั้ง skills.active และ evolution_skills.active เหมือนกัน
       #
       # ตัวอย่าง 2 beat (ฟันดาบ → ควงปืนยิง) — ของจริงดู regis_altare.yaml:
@@ -144,7 +142,7 @@ skills:
       #     - type: play_animation        # beat 1: ดาเมจฟันลง ~0.4s
       #       data:
       #         animation: "skill_1"
-      #         duration: 0.5
+      #         cast_time: 0.5
       #     - type: attack
       #       data:
       #         damage: 100
@@ -157,7 +155,7 @@ skills:
       #     - type: play_animation        # beat 2: ท่าควงปืนอยู่หัวคลิปนี้, ยิงลง ~0.8s
       #       data:
       #         animation: "skill_2"
-      #         duration: 1.0
+      #         cast_time: 1.0
       #     - type: attack
       #       data:
       #         damage: 150
@@ -194,7 +192,7 @@ skills:
       #     data:
       #       width: 3
       #       height: 3
-      #       duration_param_name: "channelDuration"      # หรือ duration: 3.0 ตรง ๆ
+      #       cast_time_param_name: "channelDuration"     # หรือ cast_time: 3.0 ตรง ๆ
       #       tick_interval_param_name: "tickInterval"    # หรือ tick_interval: 0.25 ตรง ๆ
       #       animation: "skill"                          # คลิปร่าย เล่นค้างตลอด channel
       #       damage_multiplier_param_name: "tickDamage"
@@ -237,8 +235,6 @@ evolution_skills:
           target_team: enemy
           target_type: enemy
           target_shape: area
-    # cast_time: 0.0   # DISABLED — skill/combo timing lives in play_animation `duration` (see combo template below).
-    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     recovery: 0.2 # ช่วงจบ (วินาที) — ดูคอมเมนต์ที่ skills.active
     parameters:
       damageBonus:

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -56,8 +56,6 @@ skills:
           target_team: enemy
           target_type: tower
           target_shape: area
-    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
-    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     parameters:
       damageMultiplier:
@@ -68,7 +66,7 @@ skills:
       - type: "play_animation"
         data:
           animation: "skill"
-          duration: 0.5   # cast pose only (generic clip; verify in-engine)
+          cast_time: 0.5   # cast pose only (generic clip; verify in-engine)
       - type: "play_animation"
         data:
           animation: "idle"   # return to idle BEFORE the 10s persistent storm so the cast pose doesn't hold during it
@@ -123,8 +121,6 @@ evolution_skills:
           target_team: enemy
           target_type: tower
           target_shape: area
-    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
-    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     parameters:
       damageMultiplier:
@@ -133,7 +129,7 @@ evolution_skills:
       - type: "play_animation"
         data:
           animation: "skill"
-          duration: 0.5   # cast pose only (generic clip; verify in-engine)
+          cast_time: 0.5   # cast pose only (generic clip; verify in-engine)
       - type: "play_animation"
         data:
           animation: "idle"   # return to idle BEFORE the 10s persistent storm so the cast pose doesn't hold during it

--- a/resources/database/towers/mori_calliope.yaml
+++ b/resources/database/towers/mori_calliope.yaml
@@ -72,7 +72,7 @@ skills:
       - type: play_animation
         data:
           animation: "skill"
-          duration: 0.5
+          cast_time: 0.5
       - type: play_effect
         data:
           # Reaper's dark-energy crescent — self-centered 3x3 sweep (calliope_skill_effect.gd)
@@ -162,7 +162,7 @@ evolution_skills:
       - type: play_animation
         data:
           animation: "skill"
-          duration: 0.5
+          cast_time: 0.5
       - type: play_effect
         data:
           # Beat 1 "reap" VFX - elevated reaper crescent (phase 0). Its DURATION (0.45s)

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -70,7 +70,7 @@ skills:
       - type: play_animation
         data:
           animation: "skill"
-          duration: 0.5
+          cast_time: 0.5
       - type: attack
         data:
           damage_multiplier_param_name: "skillDamage"
@@ -134,7 +134,7 @@ evolution_skills:
         data:
           width: 3
           height: 3
-          duration_param_name: "channelDuration"
+          cast_time_param_name: "channelDuration"
           tick_interval_param_name: "tickInterval"
           animation: "skill"
           damage_multiplier_param_name: "tickDamage"

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -87,7 +87,7 @@ skills:
       - type: play_animation
         data:
           animation: "skill_1"
-          duration: 0.5
+          cast_time: 0.5
       - type: attack
         data:
           damage_multiplier_param_name: "beat1Damage"
@@ -105,7 +105,7 @@ skills:
       - type: play_animation
         data:
           animation: "skill_2"
-          duration: 1.0
+          cast_time: 1.0
       - type: attack
         data:
           damage_multiplier_param_name: "beat2Damage"
@@ -171,7 +171,7 @@ evolution_skills:
       - type: play_animation
         data:
           animation: "skill_1"
-          duration: 0.5
+          cast_time: 0.5
       - type: attack
         data:
           damage_multiplier_param_name: "beat1Damage"
@@ -189,7 +189,7 @@ evolution_skills:
       - type: play_animation
         data:
           animation: "skill_2"
-          duration: 1.0
+          cast_time: 1.0
       - type: attack
         data:
           damage_multiplier_param_name: "beat2Damage"

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -59,8 +59,6 @@ skills:
           target_team: enemy
           target_type: enemy
           target_shape: area
-    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
-    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     # Single source for balance + desc: skill actions read these via
     # damage_multiplier_param_name / *_param, and desc tokens render the
@@ -81,7 +79,7 @@ skills:
       - type: "play_animation"
         data:
           animation: "skill"
-          duration: 0.2   # skill clip scaled to 0.2s; effect lands ~0.16s (tune in-engine)
+          cast_time: 0.2   # skill clip scaled to 0.2s; effect lands ~0.16s (tune in-engine)
       - type: "play_effect"
         data:
           # Flame Slash crescent VFX — orients toward tower.enemy and lands
@@ -138,8 +136,6 @@ evolution_skills:
           target_team: enemy
           target_type: enemy
           target_shape: area
-    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
-    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     # Single source for balance + desc: actions read these (projectile damage via
     # damage_multiplier_param_name default, DOT via *_param); desc tokens
@@ -161,7 +157,7 @@ evolution_skills:
       - type: "play_animation"
         data:
           animation: "skill"
-          duration: 0.2   # skill clip scaled to 0.2s; effect lands ~0.16s (tune in-engine)
+          cast_time: 0.2   # skill clip scaled to 0.2s; effect lands ~0.16s (tune in-engine)
       - type: "play_effect"
         data:
           # Hinotori phoenix VFX (Wingsweep, magma-violet) — orients onto the

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -64,8 +64,6 @@ skills:
           target_team: self
           target_type: tower
           target_shape: single
-    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
-    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     parameters:
       attackSpeedBuff:
@@ -76,7 +74,7 @@ skills:
       - type: "play_animation"
         data:
           animation: "skill"
-          duration: 0.5   # skill clip scaled to 0.5s; effect lands ~0.4s (tune in-engine)
+          cast_time: 0.5   # skill clip scaled to 0.5s; effect lands ~0.4s (tune in-engine)
       - type: "play_effect"
         data:
           effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_skill_effect.gd"
@@ -129,8 +127,6 @@ evolution_skills:
           target_team: self
           target_type: tower
           target_shape: single
-    # cast_time: 0.0   # DISABLED — skill timing now lives in play_animation `duration`.
-    #                  # cast_time = idle hold BEFORE the cast (no skill anim); kept for team ref / possible future use.
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     parameters:
       attackSpeedBuff:
@@ -141,7 +137,7 @@ evolution_skills:
       - type: "play_animation"
         data:
           animation: "skill"
-          duration: 0.5   # skill clip scaled to 0.5s; effect lands ~0.4s (tune in-engine)
+          cast_time: 0.5   # skill clip scaled to 0.5s; effect lands ~0.4s (tune in-engine)
       - type: "play_effect"
         data:
           effect_script: "res://resources/tower/hololive/en_branch/myth_gen/amelia/skill_effect/amelia_evo_skill_effect.gd"

--- a/scripts/entity/staff/staff_data_loader.gd
+++ b/scripts/entity/staff/staff_data_loader.gd
@@ -33,7 +33,8 @@ static func load_data(prefix: String, name: String) -> StaffData:
 		var skill := Skill.new()
 		skill.name = skill_dict.get("name", "")
 		skill.desc = skill_dict.get("desc", "")
-		skill.castTime = float(skill_dict.get("cast_time", 0.0))
+		if skill_dict.has("cast_time"):
+			push_warning("Staff skill '" + skill.name + "': skill-level 'cast_time' (idle pre-cast hold) was removed - use per-beat play_animation 'cast_time' instead.")
 		skill.parameters = skill_dict.get("parameters", {})
 
 		var actions: Array[SkillAction] = []

--- a/scripts/entity/tower/tower_data_loader.gd
+++ b/scripts/entity/tower/tower_data_loader.gd
@@ -175,7 +175,8 @@ static func _apply_skill_data(skill: Skill, skill_data: Dictionary, default_name
 		push_warning("Skill '" + skill.name + "': 'desc_template' was merged into 'desc' - rename the key (its tokenized text is used).")
 		skill.desc = str(skill_data.get("desc_template", "")).replace("\\n", "\n")
 	skill.parameters = skill_data.get("parameters", {})
-	skill.castTime = skill_data.get("cast_time", 0.0)
+	if skill_data.has("cast_time"):
+		push_warning("Skill '" + skill.name + "': skill-level 'cast_time' (idle pre-cast hold) was removed - draw the windup into the clip; per-beat timing is play_animation 'cast_time'.")
 	skill.recoveryTime = skill_data.get("recovery", 0.2)
 	skill.tags = _parse_string_array(skill_data.get("tags", []))
 	skill.target_summary = _parse_dictionary(skill_data.get("target_summary", {}))

--- a/scripts/skill/base_skill_controller.gd
+++ b/scripts/skill/base_skill_controller.gd
@@ -38,6 +38,10 @@ func execute_skill_actions(skill: Skill, context: SkillContext):
 
 	skill.using = true;
 
+	# Enemy-only telegraph window (skill-level cast_time): the caster stands
+	# still before actions. Tower/staff loaders no longer set castTime (per-beat
+	# play_animation cast_time replaced the idle hold), so this waits only for
+	# enemy casts.
 	if skill.castTime > 0:
 		await user.get_tree().create_timer(skill.castTime, false).timeout
 		if not is_instance_valid(user):

--- a/scripts/skill/skill.gd
+++ b/scripts/skill/skill.gd
@@ -9,6 +9,9 @@ enum TARGET_TYPE {ENEMY, FRIENDLY}
 @export var desc:String = ""
 @export var names: Array[String] = []
 @export var oneTimeUse: bool = false
+# Enemy-only telegraph window: the caster stands still before actions (plays a
+# cast clip once enemy animation lands). Towers/staff author per-beat
+# play_animation cast_time instead; their loaders no longer set this.
 @export var castTime: float = 0.0
 @export var recoveryTime: float = 0.0
 @export var actions: Array[SkillAction] = []

--- a/scripts/skill/skillActions/skill_action_channel.gd
+++ b/scripts/skill/skillActions/skill_action_channel.gd
@@ -2,14 +2,14 @@ class_name SkillActionChannel
 extends SkillAction
 
 # "channel" execution pattern (tower_skill.md): the cast locks the aimed zone
-# and holds the tower busy for `duration` seconds while re-striking that zone
+# and holds the tower busy for `cast_time` seconds while re-striking that zone
 # every `tick_interval`. BLOCKING - execute() awaits until the channel ends, so
 # the controller keeps usingSkill true and Energy drains only at onSuccess
 # (a wave-end cancel keeps Energy). Each tick resolves fresh: live target
 # query at the locked center, live Total Attack, effects re-applied (REFRESH).
 # First user: Ninomae Ina'nis evolved skill.
 
-@export var duration: float = 3.0
+@export var castTime: float = 3.0
 @export var tick_interval: float = 0.25
 @export var width: int = 3
 @export var height: int = 3
@@ -80,7 +80,7 @@ class ChannelTicker:
 		center = p_center
 		params = p_params
 		skill_name = p_skill_name
-		total_ticks = int(round(action.duration / action.tick_interval))
+		total_ticks = int(round(action.castTime / action.tick_interval))
 
 	func _process(delta: float) -> void:
 		if done:

--- a/scripts/skill/skillActions/skill_action_play_anim.gd
+++ b/scripts/skill/skillActions/skill_action_play_anim.gd
@@ -3,7 +3,7 @@ class_name SkillActionPlayAnimation
 
 @export var animationName: String = ""
 @export var animationSpeed: float = 1.0
-@export var duration: float = 0.0
+@export var castTime: float = 0.0
 
 func execute(context: SkillContext):
 	if animationName == "":
@@ -22,13 +22,13 @@ func execute(context: SkillContext):
 		push_warning("SkillActionPlayAnimation: missing animation '" + animationName + "' - skipping beat");
 		return
 
-	# duration (seconds) stretches/compresses the clip to fit; falls back to
+	# cast_time (seconds) stretches/compresses the clip to fit; falls back to
 	# animationSpeed when unset. The ~80% impact point scales automatically.
 	var speed: float = animationSpeed
-	if duration > 0.0 and context.user.has_method("get_animation_duration"):
+	if castTime > 0.0 and context.user.has_method("get_animation_duration"):
 		var native: float = context.user.get_animation_duration(animationName)
 		if native > 0.0:
-			speed = native / duration
+			speed = native / castTime
 
 	if !context.user.play_animation(animationName, speed):
 		context.cancel = true;

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -11,8 +11,9 @@ static func ParseSkill(skillDataList: Array) -> Array[Skill]:
 		var skillName = skill.get("name", "Unnamed Skill");
 		var desc = skill.get("desc", "");
 		var oneTime = skill.get("oneTime", false);
-		# Same key + meaning as the tower skill-level cast_time (idle pre-cast
-		# hold); enemies additionally stand still during it (Enemy.castLocked).
+		# Enemy-only telegraph window: the caster stands still (castLocked) before
+		# actions; plays a cast clip once enemy animation lands. Towers/staff
+		# author per-beat play_animation cast_time instead (idle-hold key removed).
 		var castTime = float(skill.get("cast_time", 0.0));
 		# Single source for balance numbers: actions bind via *_param keys and
 		# the desc renders the same values via {token} (enemy_skill.md Copy).
@@ -131,7 +132,10 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill = SkillActionPlayAnimation.new();
 			var skillData = data.get("data", {});
 			skill.animationName = skillData.get("animation", "");
-			skill.duration = float(skillData.get("duration", 0.0));
+			skill.castTime = float(skillData.get("cast_time", 0.0));
+			if skillData.has("duration"):
+				push_warning("play_animation: 'duration' was renamed to 'cast_time' - rename the key (its value is used).");
+				skill.castTime = float(skillData.get("duration", 0.0));
 		"attack":
 			skill = SkillActionAttack.new();
 			var skillData = data.get("data", {});
@@ -219,11 +223,18 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			var skillData = data.get("data", {});
 			skill.width = int(skillData.get("width", 3));
 			skill.height = int(skillData.get("height", 3));
-			var durationParam = skillData.get("duration_param_name", "");
-			if durationParam != "" and parameters.has(durationParam):
-				skill.duration = float(parameters[durationParam]);
+			var castTimeParam = skillData.get("cast_time_param_name", "");
+			if castTimeParam != "" and parameters.has(castTimeParam):
+				skill.castTime = float(parameters[castTimeParam]);
 			else:
-				skill.duration = float(skillData.get("duration", 3.0));
+				skill.castTime = float(skillData.get("cast_time", 3.0));
+			if skillData.has("duration_param_name") or skillData.has("duration"):
+				push_warning("channel: 'duration'/'duration_param_name' was renamed to 'cast_time'/'cast_time_param_name' - rename the key (its value is used).");
+				var durationParam = skillData.get("duration_param_name", "");
+				if durationParam != "" and parameters.has(durationParam):
+					skill.castTime = float(parameters[durationParam]);
+				elif skillData.has("duration"):
+					skill.castTime = float(skillData.get("duration", 3.0));
 			var intervalParam = skillData.get("tick_interval_param_name", "");
 			if intervalParam != "" and parameters.has(intervalParam):
 				skill.tick_interval = float(parameters[intervalParam]);


### PR DESCRIPTION
**Summary:** Renames the caster-side skill timing key `duration` -> `cast_time` across the skill DSL (per-beat `play_animation`, `channel` action), removes the legacy skill-level `cast_time` (idle pre-cast hold) from tower/staff, and redesigns King's Command into a 4s channel.

**How it works:** Naming rule after this PR: `cast_time` = caster-side time (beat clip scaling, channel length, enemy telegraph stand); `duration` = effect-side time only (buff/debuff/stun lifetimes). Tower/staff loaders push_warning on the stale skill-level key; `play_animation`/`channel` parse warns-and-honors legacy `duration` keys so missed content stays visible, never silently mistimed. King's Command is YAML-only action recomposition: `summon_enemy` (fire-and-forget trickle, 10 x 0.4s) moved BEFORE the 4s `delay` hold, with `invincible` + `royal_command` covering the whole window - boss stands untargetable while the minions march out.

**Implementation Notes:** Enemy skills KEEP skill-level `cast_time` as their telegraph window (stand still; will host a cast clip once enemy animation exists) - the 4 existing enemy telegraphs are behavior-identical. Effect-side `duration` keys (e.g. Gura's projectile stun 0.1s, Amelia's 4s buffs) intentionally not renamed. System docs updated in the same change (tower_skill / enemy_skill / boss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
