### PR TITLE
Skill target metadata cleanup + tag order convention

### DIFF
--- a/resources/database/towers/axel_syrios.yaml
+++ b/resources/database/towers/axel_syrios.yaml
@@ -37,6 +37,16 @@ stats:
 skill:
   name: "Skill"
   desc: "Axel Syrios strikes the 3x1 line in front of him with a fierce blow, dealing physical damage to every enemy caught in it."
+  target_summary:
+    target_team: enemy
+    target_type: enemy
+    target_shape: area
+  effects:
+    - name: "Line Strike Damage"
+      target:
+        target_team: enemy
+        target_type: enemy
+        target_shape: area
   recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
   actions:
     - type: find_multi_enemy

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -37,6 +37,16 @@ stats:
 skill:
   name: "Skill"
   desc: "Banzoin Hakka lashes out across the 3x1 line in front of him, dealing physical damage to every enemy caught in the strike."
+  target_summary:
+    target_team: enemy
+    target_type: enemy
+    target_shape: area
+  effects:
+    - name: "Line Strike Damage"
+      target:
+        target_team: enemy
+        target_type: enemy
+        target_shape: area
   recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
   actions:
     - type: find_multi_enemy

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -49,12 +49,16 @@ skills:
       - attack
       - aoe
       - enemy
-    # target_summary = สรุป target ระดับสกิลไว้โชว์ UI (ความแม่นจริงอยู่ที่ effect/action)
+    # target_summary = สรุป target ระดับสกิลไว้โชว์ UI (บรรทัด AFFECTS ใน tooltip อ่าน team+shape)
+    # เป็น display-only ทั้งชั้น — พฤติกรรมจริงมาจาก actions เท่านั้น
+    # กติกาสรุป: ใช้ target ของเอฟเฟกต์เด่นที่ desc ขึ้นต้น = ตัวแรกใน effects (Director 2026-07-18)
+    # target_team = ใครโดน ไม่ใช่ร่ายจากไหน — สกิลร่ายรอบตัวที่ตีศัตรู = enemy (เคส IO Spirits)
     # ใช้ block map เท่านั้น อย่าใช้ inline {...} (custom YAML parser support flow จำกัด)
     target_summary:
       target_team: enemy # self | enemy | ally | both
-      target_type: enemy # tower | enemy | any
+      target_type: enemy # tower | enemy | any (ยังไม่ถูกแสดงผล — field สำรอง)
       target_shape: area # single | area | global
+    # effects = พิมพ์เขียวรายเอฟเฟกต์แนว Dota (เรียงเอฟเฟกต์เด่นก่อน) — ยังไม่มีโค้ดอ่าน ไว้รอ tooltip ละเอียดในอนาคต
     effects:
       - name: "Area Damage"
         target:

--- a/resources/database/towers/gavis_bettel.yaml
+++ b/resources/database/towers/gavis_bettel.yaml
@@ -37,6 +37,16 @@ stats:
 skill:
   name: "Skill"
   desc: "Gavis Bettel springs a phantom trick across the 3x1 line in front of him, dealing physical damage to every enemy caught in the act."
+  target_summary:
+    target_team: enemy
+    target_type: enemy
+    target_shape: area
+  effects:
+    - name: "Line Strike Damage"
+      target:
+        target_team: enemy
+        target_type: enemy
+        target_shape: area
   recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
   actions:
     - type: find_multi_enemy

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -42,6 +42,7 @@ skills:
     icon: ""
     tags:
       - damage
+      - magic
       - projectile
       - aoe
       - stun
@@ -107,6 +108,7 @@ evolution_skills:
     icon: ""
     tags:
       - damage
+      - magic
       - projectile
       - aoe
       - stun

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -48,13 +48,13 @@ skills:
       - persistent
     target_summary:
       target_team: enemy
-      target_type: tower
+      target_type: enemy
       target_shape: area
     effects:
       - name: "Storm Wave Damage"
         target:
           target_team: enemy
-          target_type: tower
+          target_type: enemy
           target_shape: area
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     parameters:
@@ -113,13 +113,13 @@ evolution_skills:
       - persistent
     target_summary:
       target_team: enemy
-      target_type: tower
+      target_type: enemy
       target_shape: area
     effects:
       - name: "Storm Wave Damage"
         target:
           target_team: enemy
-          target_type: tower
+          target_type: enemy
           target_shape: area
     recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
     parameters:

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -53,10 +53,11 @@ skills:
     desc: "Josuiji Shinri steadies his aim with every shot: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent}, then loses all Bull Eyes stacks."
     icon: ""
     tags:
+      - damage
+      - attack
       - crit_rate
       - projectile
       - aoe
-      - damage
     target_summary:
       target_team: self
       target_type: tower
@@ -98,10 +99,11 @@ evolution_skills:
     desc: "Josuiji Shinri's aim turns lethal: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent} — and critical hits no longer consume his Bull Eyes stacks."
     icon: ""
     tags:
+      - damage
+      - attack
       - crit_rate
       - projectile
       - aoe
-      - damage
     target_summary:
       target_team: self
       target_type: tower

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -58,9 +58,9 @@ skills:
       - aoe
       - damage
     target_summary:
-      target_team: enemy
-      target_type: enemy
-      target_shape: area
+      target_team: self
+      target_type: tower
+      target_shape: single
     effects:
       - name: "Bull Eyes Crit Stacking"
         target:
@@ -103,9 +103,9 @@ evolution_skills:
       - aoe
       - damage
     target_summary:
-      target_team: enemy
-      target_type: enemy
-      target_shape: area
+      target_team: self
+      target_type: tower
+      target_shape: single
     effects:
       - name: "Bull Eyes Crit Stacking"
         target:

--- a/resources/database/towers/machina_x_flayon.yaml
+++ b/resources/database/towers/machina_x_flayon.yaml
@@ -37,6 +37,16 @@ stats:
 skill:
   name: "Skill"
   desc: "Machina X Flayon drives a mecha strike through the 3x1 line in front of him, dealing physical damage to every enemy caught in it."
+  target_summary:
+    target_team: enemy
+    target_type: enemy
+    target_shape: area
+  effects:
+    - name: "Line Strike Damage"
+      target:
+        target_team: enemy
+        target_type: enemy
+        target_shape: area
   recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
   actions:
     - type: find_multi_enemy

--- a/resources/database/towers/mori_calliope.yaml
+++ b/resources/database/towers/mori_calliope.yaml
@@ -46,6 +46,7 @@ skills:
       - damage
       - attack
       - aoe
+      - stack
     target_summary:
       target_team: enemy
       target_type: enemy
@@ -95,6 +96,7 @@ skills:
     tags:
       - buff
       - self
+      - stack
     target_summary:
       target_team: self
       target_type: tower
@@ -131,6 +133,7 @@ evolution_skills:
       - damage
       - attack
       - aoe
+      - stack
     target_summary:
       target_team: enemy
       target_type: enemy

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -42,6 +42,7 @@ skills:
     icon: ""
     tags:
       - damage
+      - magic
       - aoe
       - stun
       - duration
@@ -105,6 +106,7 @@ evolution_skills:
     icon: ""
     tags:
       - damage
+      - magic
       - aoe
       - stun
       - channel


### PR DESCRIPTION
**Summary:** Skill target metadata cleanup: documented the display-only target model with a headline rule, fixed the two towers whose metadata contradicted their real mechanics, backfilled the 4 Holostars towers, and standardized tag order (category first, damage-type second) with new `magic` / `stack` registry tags.

**How it works:** `target_summary` / `effects:` in tower YAML are display/authoring layers only - runtime behavior stays in `actions`. The tooltip AFFECTS line now follows the headline rule (summary = the effect the desc leads with = first entry in `effects:`). Shinri's both passives now summarize as SELF - SINGLE (crit stacking) instead of ENEMY - AREA; Axel/Hakka/Bettel/Flayon gain AFFECTS lines (enemy/area). Tags: category tag first (damage/buff), damage-type tag second (`attack`/`magic` - `magic` is new), `stack` added for Calliope's Soul mechanic (passive + both scythe skills).

**Implementation Notes:** YAML-only, no script changes (loader already parses both legacy and slot skill shapes). Gura's `target_type: tower` -> `enemy` at 4 sites is hygiene only - `target_type` is parsed but not displayed yet (reserved field). The annotated authoring rules live in `default_tower.yaml` comments. All changes user-tested in Godot.
