### PR TITLE
Implement Banzoin Hakka - Exocirst Field (new field pattern)

### DIFF
--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -46,7 +46,6 @@ skills:
     icon: ""
     tags:
       - damage
-      - attack
       - magic
       - aoe
       - persistent
@@ -69,7 +68,7 @@ skills:
         - 0.6
         - 1.0
       skillDuration: 10.0
-      slowEffect: 0.1
+      slowEffect: 0.15
       tickInterval: 1.0
     actions:
       - type: find_multi_enemy
@@ -117,7 +116,6 @@ evolution_skills:
     icon: ""
     tags:
       - damage
-      - attack
       - magic
       - aoe
       - persistent
@@ -137,9 +135,9 @@ evolution_skills:
     parameters:
       skillDamage: 1.5
       skillDuration: 10.0
-      slowEffect: 0.1
+      slowEffect: 0.15
       tickInterval: 1.0
-      energyRefund: 0.5
+      energyRefund: 0.2
     actions:
       - type: find_multi_enemy
         data:

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -1,85 +1,170 @@
 maxLevel: 3
 towerClass: warrior
 generation: tempus
-attackType: physic
+attackType: magic
 evolutionCost: 1
 
-# skill: "res://resources/database/skill/takanashi_kiara_skill.tres"
 attack_sound: "hit_hakka"
 open_sound: "debut_hakka"
 evolve_sound: "evo_hakka"
 
 stats:
   - damage: 130
-    attackRange: 2.0
-    attackSpeed: 120.0
-    mana: 80
-    initialMana: 20
+    attackRange: 1.0
+    attackSpeed: 80.0
+    mana: 120
+    initialMana: 80
     critChance: 0
     critMultiplier: 1.5
 
   - damage: 150
-    attackRange: 2.0
-    attackSpeed: 120.0
-    mana: 80
-    initialMana: 20
+    attackRange: 1.0
+    attackSpeed: 80.0
+    mana: 120
+    initialMana: 80
     critChance: 0
     critMultiplier: 1.5
 
-  - damage: 190
-    attackRange: 2.0
-    attackSpeed: 120.0
-    mana: 80
-    initialMana: 20
+  - damage: 200
+    attackRange: 1.0
+    attackSpeed: 80.0
+    mana: 120
+    initialMana: 80
     critChance: 0
     critMultiplier: 1.5
 
-skill:
-  name: "Skill"
-  desc: "Banzoin Hakka lashes out across the 3x1 line in front of him, dealing physical damage to every enemy caught in the strike."
-  target_summary:
-    target_team: enemy
-    target_type: enemy
-    target_shape: area
-  effects:
-    - name: "Line Strike Damage"
-      target:
-        target_team: enemy
-        target_type: enemy
-        target_shape: area
-  recovery: 0.2 # post-cast hold (s) before resuming attack — see default_tower.yaml
-  actions:
-    - type: find_multi_enemy
-      data:
-        width: 3
-        height: 1
-    - type: play_animation
-      data:
-        animation: "skill"
-    - type: attack
-      data:
-        damage: 100
-        damage_type: physic
-    - type: play_animation
-      data:
-        animation: "idle"
+# Active Skill - "Exocirst Field": a persistent purifying zone centered on
+# Hakka. It is the first "field" execution pattern (tower_skill.md) - planted
+# non-blocking (Hakka keeps auto-attacking) and ticks magic damage + slow to
+# enemies inside every tickInterval for skillDuration seconds. VFX is a
+# follow-up; the find action's red Hitbox rect is the interim tick visual.
+skills:
+  active:
+    name: "Exocirst Field"
+    names: ["Exocirst Field I", "Exocirst Field II", "Exocirst Field III"]
+    desc: "Banzoin Hakka conjures a purifying field in a 3x3 area around him for {skillDuration} seconds; enemies within take {skillDamage:percent} magic damage and are slowed by {slowEffect:percent} every second they remain inside."
+    icon: ""
+    tags:
+      - damage
+      - attack
+      - magic
+      - aoe
+      - persistent
+      - debuff
+      - duration
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Purifying Field"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    recovery: 0.2 # post-cast hold (s) before resuming attack - see default_tower.yaml
+    parameters:
+      skillDamage:
+        - 0.4
+        - 0.6
+        - 1.0
+      skillDuration: 10.0
+      slowEffect: 0.1
+      tickInterval: 1.0
+    actions:
+      - type: find_multi_enemy
+        data:
+          width: 3
+          height: 3
+          center_on_self: true        # cast gate: box centered on Hakka
+      - type: play_animation
+        data:
+          animation: "skill"
+          cast_time: 0.5
+      - type: field                    # plant the zone and return - Hakka keeps attacking
+        data:
+          width: 3
+          height: 3
+          duration_param_name: "skillDuration"
+          tick_interval_param_name: "tickInterval"
+          damage_multiplier_param_name: "skillDamage"
+          damage_type: magic
+          can_crit: false
+          effects:
+            - effect: move_speed_down       # per-tick slow (refresh; ~1 tick lag on leave)
+              value_param: "slowEffect"
+              duration: 1.5
+      - type: play_animation
+        data:
+          animation: "idle"
+  passive: null
 
 evolutionStat:
   damage: 280
-  attackRange: 2.0
-  attackSpeed: 120
-  mana: 80
-  initialMana: 20
+  attackRange: 1.0
+  attackSpeed: 80.0
+  mana: 120
+  initialMana: 80
   critChance: 50.0
   critMultiplier: 1.5
 
-
-# Optional (only if tower has evolution stats)
-# evolutionStat:
-#   damage: 250
-#   attackRange: 1.2
-#   attackSpeed: 110.0
-#   critChance: 25.0
-#   critMultiplier: 2.0
-#   mana: 80
-#   initialMana: 20
+# Evolved Active Skill - larger 5x5 field, stronger tick, and on natural expiry
+# Hakka recovers energyRefund of his max Energy (evolve-only refund).
+evolution_skills:
+  active:
+    name: "Obey my omen, in hymns allure"
+    desc: "Banzoin Hakka unleashes a greater purifying field across a 5x5 area for {skillDuration} seconds; enemies within take {skillDamage:percent} magic damage and are slowed by {slowEffect:percent} every second they remain, and when the field fades he recovers {energyRefund:percent} of his maximum Energy."
+    icon: ""
+    tags:
+      - damage
+      - attack
+      - magic
+      - aoe
+      - persistent
+      - debuff
+      - duration
+    target_summary:
+      target_team: enemy
+      target_type: enemy
+      target_shape: area
+    effects:
+      - name: "Purifying Field"
+        target:
+          target_team: enemy
+          target_type: enemy
+          target_shape: area
+    recovery: 0.2 # post-cast hold (s) before resuming attack - see default_tower.yaml
+    parameters:
+      skillDamage: 1.5
+      skillDuration: 10.0
+      slowEffect: 0.1
+      tickInterval: 1.0
+      energyRefund: 0.5
+    actions:
+      - type: find_multi_enemy
+        data:
+          width: 5
+          height: 5
+          center_on_self: true
+      - type: play_animation
+        data:
+          animation: "skill"
+          cast_time: 0.5
+      - type: field
+        data:
+          width: 5
+          height: 5
+          duration_param_name: "skillDuration"
+          tick_interval_param_name: "tickInterval"
+          damage_multiplier_param_name: "skillDamage"
+          damage_type: magic
+          can_crit: false
+          energy_refund_percent_param_name: "energyRefund"
+          effects:
+            - effect: move_speed_down
+              value_param: "slowEffect"
+              duration: 1.5
+      - type: play_animation
+        data:
+          animation: "idle"
+  passive: null

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -206,6 +206,30 @@ skills:
       #         - effect: "stun"
       #           duration_param: "tickStun"
       # ─────────────────────────────────────────────────────────────────
+      # ─────────────────────────────────────────────────────────────────
+      # FIELD (โซนค้างรอบตัว ไม่บล็อกการตี) — ของจริงดู banzoin_hakka.yaml
+      #
+      #   วางต่อจาก find_multi_enemy แรก: โซนวางกลางตัว tower แล้วจบ cast
+      #   ทันที (ไม่บล็อก เหมือน aftershock) tower กลับไปตีปกติต่อได้ระหว่าง
+      #   โซนทำงานเอง นาน duration วินาที แต่ละ tick หาเป้าใหม่สดในกล่องรอบตัว
+      #   ตี + ลง effect (เช่น slow) — คีย์ damage/crit/effects ชุดเดียวกับ
+      #   attack ใช้ได้หมด; energy_refund_percent = คืน Energy % ตอนโซนหมดเวลา
+      #   (จบธรรมชาติเท่านั้น); ยกเลิกกลางคัน (จบเวฟ) = หยุดทันที ไม่คืน
+      #
+      #   - type: field
+      #     data:
+      #       width: 3
+      #       height: 3
+      #       duration_param_name: "skillDuration"      # หรือ duration: 10.0 ตรง ๆ
+      #       tick_interval_param_name: "tickInterval"  # หรือ tick_interval: 1.0 ตรง ๆ
+      #       damage_multiplier_param_name: "skillDamage"
+      #       damage_type: magic
+      #       can_crit: false
+      #       energy_refund_percent_param_name: "energyRefund"   # optional (ใช้ตอน evolve)
+      #       effects:
+      #         - effect: "move_speed_down"
+      #           value_param: "slowEffect"
+      #           duration: 1.5
   passive: null
 
 # evolutionStat = stat ตอน evolve (block เดียว ไม่ใช่ array)

--- a/scripts/skill/skillActions/skill_action_field.gd
+++ b/scripts/skill/skillActions/skill_action_field.gd
@@ -1,0 +1,59 @@
+class_name SkillActionField
+extends SkillActionChannel
+
+# "field" execution pattern (tower_skill.md): a NON-BLOCKING, self-centered,
+# persistent damaging + debuffing zone. Unlike "channel" (which BLOCKS the
+# caster for the whole duration), the field is planted and execute() returns
+# immediately - the tower resumes auto-attack while the zone ticks on its own,
+# exactly like "aftershock". It reuses channel's ChannelTicker verbatim (the
+# generation / in_flight defer-free / re-entrancy guard cluster stays in ONE
+# place); the only deltas are: no await (non-blocking), no self-played cast
+# clip, and an optional Energy refund to the caster on natural expiry.
+# First user: Banzoin Hakka "Exocirst Field".
+#
+# castTime (inherited from SkillActionChannel) is reused as the field LIFETIME
+# (the tick-sequence duration). tick_interval / width / height / find_action /
+# attack_action are inherited and set by the parser (skill_utility.gd).
+#
+# YAML: width, height, duration/duration_param_name (-> castTime),
+#   tick_interval/tick_interval_param_name, energy_refund_percent/
+#   energy_refund_percent_param_name, plus the full "attack" key set
+#   (damage_multiplier_param_name, damage_type, can_crit, effects) reused each
+#   tick. Reference: resources/database/towers/banzoin_hakka.yaml.
+
+@export var energyRefundPercent: float = 0.0
+
+func execute(context: SkillContext):
+	var tower: Tower = context.user as Tower
+	if tower == null or find_action == null or attack_action == null:
+		return
+	var gen: int = tower.skill_lock_generation
+	var ticker := SkillActionChannel.ChannelTicker.new()
+	# Self-centered zone: the ticker re-queries an axis-aligned box centered on
+	# this point each tick (its target_position override), so a stationary tower
+	# keeps the field on itself with no aim snapshot.
+	ticker.setup(self, tower, gen, tower.global_position,
+			context.extra.get("parameter", {}), context.skillName)
+	tower.add_child(ticker)
+	Utility.ConnectSignal(ticker, "finished",
+			Callable(self, "_on_field_finished").bind(ticker, tower, gen))
+	# No await: the cast finishes normally while the field ticks (aftershock model).
+
+# The ticker emits "finished" exactly once (channel's `done` once-guard) on
+# EVERY exit path - natural end, wave-end generation bump, and external free.
+# Refund only on natural expiry: all ticks fired AND the tower still alive on
+# the same generation (a cancel path fails one of these checks, so no refund
+# ever leaks into the next wave). updateMana clamps at maxMana, so a refund
+# arriving after a re-cast already refilled Energy is a harmless no-op.
+func _on_field_finished(ticker: SkillActionChannel.ChannelTicker, tower: Tower, gen: int) -> void:
+	if energyRefundPercent <= 0.0:
+		return
+	if not is_instance_valid(ticker) or ticker.ticks_fired < ticker.total_ticks:
+		return
+	if not is_instance_valid(tower) or tower.skill_lock_generation != gen:
+		return
+	if tower.skillController == null:
+		return
+	var refund: int = int(round(tower.skillController.maxMana * energyRefundPercent))
+	if refund > 0:
+		tower.skillController.updateMana(refund)

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -253,6 +253,43 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			# Optional per-tick VFX, spawned each tick alongside the find.
 			if skillData.has("effect_script"):
 				skill.effect_action = ParseAction({"type": "play_effect", "data": {"effect_script": skillData["effect_script"]}}, parameters) as SkillActionPlayEffect;
+		"field":
+			# Non-blocking persistent damage+debuff zone ("field" pattern -
+			# tower_skill.md). Reuses channel's inner find/attack build and its
+			# ChannelTicker; castTime holds the field LIFETIME (not a cast hold).
+			# First user: Banzoin Hakka "Exocirst Field".
+			skill = SkillActionField.new();
+			var skillData = data.get("data", {});
+			skill.width = int(skillData.get("width", 3));
+			skill.height = int(skillData.get("height", 3));
+			# Field lifetime -> castTime (duration / duration_param_name).
+			var durationParam = skillData.get("duration_param_name", "");
+			if durationParam != "" and parameters.has(durationParam):
+				skill.castTime = float(parameters[durationParam]);
+			else:
+				skill.castTime = float(skillData.get("duration", 10.0));
+			var intervalParam = skillData.get("tick_interval_param_name", "");
+			if intervalParam != "" and parameters.has(intervalParam):
+				skill.tick_interval = float(parameters[intervalParam]);
+			else:
+				skill.tick_interval = float(skillData.get("tick_interval", 1.0));
+			if skill.tick_interval <= 0.0:
+				push_warning("field: tick_interval must be > 0; falling back to 1.0.");
+				skill.tick_interval = 1.0;
+			var refundParam = skillData.get("energy_refund_percent_param_name", "");
+			if refundParam != "" and parameters.has(refundParam):
+				skill.energyRefundPercent = float(parameters[refundParam]);
+			else:
+				skill.energyRefundPercent = float(skillData.get("energy_refund_percent", 0.0));
+			var fieldFind := SkillActionFindMultipleInRange.new();
+			fieldFind.width = skill.width;
+			fieldFind.height = skill.height;
+			fieldFind.cancel_when_empty = false;
+			skill.find_action = fieldFind;
+			skill.attack_action = ParseAction({"type": "attack", "data": skillData}, parameters) as SkillActionAttack;
+			# Optional per-tick VFX hook (unset today - VFX is a follow-up task).
+			if skillData.has("effect_script"):
+				skill.effect_action = ParseAction({"type": "play_effect", "data": {"effect_script": skillData["effect_script"]}}, parameters) as SkillActionPlayEffect;
 		"clear_enemy":
 			skill = SkillActionClearEnemy.new();
 		"find_multi_enemy":


### PR DESCRIPTION
**Summary:** Implement Banzoin Hakka's full kit and add the `field` execution pattern - a non-blocking, self-centered, persistent damage + debuff zone.

**How it works:** Hakka's active "Exocirst Field" plants a zone centered on him and returns immediately, so the tower keeps auto-attacking; the zone re-strikes an axis-aligned box around him every tick for its lifetime, dealing magic damage and applying slow to enemies inside. `SkillActionField extends SkillActionChannel` and reuses `ChannelTicker`, so the generation / pause / re-entrancy guard cluster stays in one place; the only deltas are the non-blocking plant (no await), a separate cast-anim beat, and an evolve-only Energy refund on natural expiry. Slow is an APPLIED on-hit effect refreshed each tick (lapses ~1 tick after an enemy leaves the box). The parser gains a `field` branch mirroring `channel`.

**Implementation Notes:**
- No VFX yet - interim visual is the find action's red Hitbox tick flash + the base skill anim.
- Warrior class synergy is not implemented, so Hakka's Warrior chip grants no bonus yet (Tempus works fully) - separate task.
- `tower.evolve()` does not bump `skill_lock_generation`, so a base-form field keeps ticking after evolve; harmless here (base refund = 0), same exposure as channel/aftershock.
- Crit at evolve set to 50 (the design sheet's `0.5` was a typo).
- Design + model documented in `.claude/docs/tower_skill.md` "Field model".
