### PR TITLE
Banzoin Hakka field skill VFX - normal Exocirst Field + evolve Burning Sutra

### DIFF
--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -147,7 +147,8 @@ evolution_skills:
         data:
           width: 5
           height: 5
-          center_on_self: true
+          center_on_self: true        # cast gate: box centered on Hakka
+          show_area: false            # zone VFX shows the area - no red debug box
       - type: play_animation
         data:
           animation: "skill"
@@ -162,8 +163,10 @@ evolution_skills:
           damage_type: magic
           can_crit: false
           energy_refund_percent_param_name: "energyRefund"
+          show_area: false            # per-tick red debug box off (VFX replaces it)
+          effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gd"
           effects:
-            - effect: move_speed_down
+            - effect: move_speed_down       # per-tick slow (refresh; ~1 tick lag on leave)
               value_param: "slowEffect"
               duration: 1.5
       - type: play_animation

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -36,8 +36,9 @@ stats:
 # Active Skill - "Exocirst Field": a persistent purifying zone centered on
 # Hakka. It is the first "field" execution pattern (tower_skill.md) - planted
 # non-blocking (Hakka keeps auto-attacking) and ticks magic damage + slow to
-# enemies inside every tickInterval for skillDuration seconds. VFX is a
-# follow-up; the find action's red Hitbox rect is the interim tick visual.
+# enemies inside every tickInterval for skillDuration seconds. Zone VFX =
+# effect_script on the field action (ofuda orbit + spirit vortex, persistent
+# for the whole duration); the red debug rects are authored off (show_area).
 skills:
   active:
     name: "Exocirst Field"
@@ -76,6 +77,7 @@ skills:
           width: 3
           height: 3
           center_on_self: true        # cast gate: box centered on Hakka
+          show_area: false            # zone VFX shows the area - no red debug box
       - type: play_animation
         data:
           animation: "skill"
@@ -89,6 +91,8 @@ skills:
           damage_multiplier_param_name: "skillDamage"
           damage_type: magic
           can_crit: false
+          show_area: false            # per-tick red debug box off (VFX replaces it)
+          effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gd"
           effects:
             - effect: move_speed_down       # per-tick slow (refresh; ~1 tick lag on leave)
               value_param: "slowEffect"

--- a/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gd
+++ b/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gd
@@ -1,0 +1,156 @@
+extends Node2D
+# ================================================================
+# Banzoin Hakka · "Exocirst Field" (normal) VFX controller — the first
+# FIELD-family effect (persistent ground zone, docs/shader.md).
+#
+# Spawned ONCE at field plant by SkillActionField (bare Node2D at
+# tower.global_position, parent = tower.get_parent()), NOT per tick:
+# a persistent zone must not respawn on the damage cadence (Director:
+# continuous territory, no interval flicker). Lifecycle:
+#
+#   plant    0->1 over PLANT_TIME (pop-in, back-eased scale_p)
+#   sustain  loop_time accumulates until the ticker ends. Driven by
+#            _process delta, NEVER shader TIME: _process freezes on
+#            pause and scales with x2 (Engine.time_scale), so the zone
+#            obeys game time for free (same rationale as ChannelTicker).
+#   expire   0->1 fade when the ticker's `finished` fires — graceful
+#            (0.6s) on natural expiry, fast (0.25s) on wave-end cancel.
+#            The ticker emits `finished` exactly once on EVERY exit
+#            path (channel's `done` once-guard), so no leak path.
+#
+# LAYER model (Director, digital-paint thinking): the zone is drawn
+# TWICE with the same shader — `fx_layer` 0 = the whole zone (ground
+# layer), 1 = front-assigned fireflies only (z_index 0, spawned after
+# towers -> draws above). No positional half-split: a seam line across
+# the tower reads wrong.
+#
+# GROUND layer placement (Director 2026-07-18, in-engine verdict): a
+# persistent field zone must render UNDER enemies, not just under the
+# tower. Enemies live under the Map's Path2D inside the z=-1 TileMap
+# subtree, so the back rect is inserted into that subtree BEFORE the
+# Path2D (a TileMap draws its own cells before its children): ground
+# cells -> zone -> enemies -> towers -> front fireflies. Fallback when
+# no Map sibling is found: child of self at z -1 (under towers only,
+# the pre-verdict behavior).
+#
+# SHADER_PATH is read by ResourceManager.warmSkillEffectShaders to
+# pre-compile the pipeline at deck load, so the first cast won't hitch.
+# ================================================================
+
+const SHADER_PATH := "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gdshader"
+const PAD := 1.35            # visual pad beyond the footprint (free: damage is code-side)
+const PLANT_TIME := 0.5
+const FADE_NATURAL := 0.6
+const FADE_CANCEL := 0.25
+
+var _mats: Array[ShaderMaterial] = []
+var _back_holder: Node2D = null   # ground-layer host inside the map subtree
+var _t := 0.0
+var _fade_time := FADE_NATURAL
+var _exp_t := -1.0           # >= 0 once expiring
+
+# Called by SkillActionField right after spawn. Footprint (cells) comes from
+# the action so the same controller serves any field size. Named setup_field
+# (not setup) so SkillActionPlayEffect's 2-arg setup(tower, context) hook can
+# never match this 3-arg signature by accident.
+func setup_field(_tower: Tower, action: SkillActionField, ticker: SkillActionChannel.ChannelTicker) -> void:
+	_build(float(action.width))
+	Utility.ConnectSignal(ticker, "finished",
+			Callable(self, "_on_field_finished").bind(ticker))
+
+func _ready() -> void:
+	call_deferred("_ensure_built")
+
+func _ensure_built() -> void:
+	# Spawned without setup_field() means no ticker `finished` will ever arrive,
+	# so a built zone would live forever - fail loud and free instead (this
+	# controller is field-only; wire it via the field action's effect_script).
+	if _mats.is_empty():
+		push_warning("hakka_field_effect: spawned without setup_field() - freeing (use the field action's effect_script, not play_effect).")
+		queue_free()
+
+func _build(cells: float) -> void:
+	var draw_size := GridHelper.CELL_SIZE * cells * PAD
+	var shader: Shader = load(SHADER_PATH)
+	var ground_map := _resolve_ground_map()
+	for side in 2:
+		var rect := ColorRect.new()
+		rect.size = Vector2(draw_size, draw_size)
+		rect.position = Vector2(-draw_size / 2.0, -draw_size / 2.0)
+		# VFX must never eat mouse input (SkillVfx rule) — and a field sits
+		# under the cursor for its whole 10s life, so this matters even more
+		# here than on burst effects.
+		rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		var mat := ShaderMaterial.new()
+		mat.shader = shader
+		mat.set_shader_parameter("fx_layer", side)
+		mat.set_shader_parameter("plant", 0.0)
+		mat.set_shader_parameter("scale_p", 0.01)
+		mat.set_shader_parameter("loop_time", 0.0)
+		mat.set_shader_parameter("expire", 0.0)
+		rect.material = mat
+		if side == 0 and ground_map != null:
+			# Ground layer: hosted inside the map subtree, ordered before the
+			# Path2D so enemies (its children) draw over the zone.
+			_back_holder = Node2D.new()
+			ground_map.add_child(_back_holder)
+			ground_map.move_child(_back_holder, ground_map.path.get_index())
+			_back_holder.global_position = global_position
+			_back_holder.add_child(rect)
+		elif side == 0:
+			rect.z_index = -1   # fallback: under towers only
+			add_child(rect)
+		else:
+			add_child(rect)     # front fireflies, above towers/enemies
+		_mats.append(mat)
+
+# The Map (a TileMap, z -1) is a sibling of this effect under the game-scene
+# root; its `path` export holds the Path2D the enemies spawn under.
+func _resolve_ground_map() -> Map:
+	var parent := get_parent()
+	if parent == null:
+		return null
+	for child in parent.get_children():
+		if child is Map and child.path != null:
+			return child
+	return null
+
+func _exit_tree() -> void:
+	# The ground holder lives in the map subtree, not under this node — free
+	# it explicitly on every exit path.
+	if is_instance_valid(_back_holder):
+		_back_holder.queue_free()
+
+func _process(delta: float) -> void:
+	if _mats.is_empty():
+		return
+	_t += delta
+	var plant_t: float = clampf(_t / PLANT_TIME, 0.0, 1.0)
+	var pop: float = maxf(0.01, _ease_out_back(plant_t))
+	var exp_v := 0.0
+	if _exp_t >= 0.0:
+		_exp_t += delta
+		exp_v = clampf(_exp_t / _fade_time, 0.0, 1.0)
+	for mat in _mats:
+		mat.set_shader_parameter("loop_time", _t)
+		mat.set_shader_parameter("plant", plant_t)
+		mat.set_shader_parameter("scale_p", pop)
+		mat.set_shader_parameter("expire", exp_v)
+	if _exp_t >= 0.0 and _exp_t >= _fade_time:
+		queue_free()
+
+# Fired exactly once per field on every exit path. Natural expiry (all ticks
+# fired) fades gracefully; a wave-end cancel / external free fades fast so no
+# zone lingers into the tower-select popup.
+func _on_field_finished(ticker: SkillActionChannel.ChannelTicker) -> void:
+	if _exp_t >= 0.0:
+		return
+	var natural: bool = is_instance_valid(ticker) \
+			and ticker.ticks_fired >= ticker.total_ticks
+	_fade_time = FADE_NATURAL if natural else FADE_CANCEL
+	_exp_t = 0.0
+
+func _ease_out_back(t: float) -> float:
+	var c1 := 1.70158
+	var c3 := c1 + 1.0
+	return 1.0 + c3 * pow(t - 1.0, 3.0) + c1 * pow(t - 1.0, 2.0)

--- a/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gdshader
@@ -1,0 +1,159 @@
+shader_type canvas_item;
+render_mode blend_premul_alpha;   // dark pool must survive the lit map
+                                  // (docs/shader.md Section 3, Hinotori lesson)
+
+// ================================================================
+// Banzoin Hakka · "Exocirst Field" (normal) — persistent purifying zone.
+// First FIELD-family skill VFX (persistent ground zone): 7 white ofuda
+// talismans orbit the boundary (fan out on plant, fly back to his hand
+// on expire) with violet ribbon trails, over a CONTINUOUS spirit-vortex
+// pool (spiral smoke drawn toward the exorcist - no interval flicker,
+// Karthus Defile reference) with teal soul fireflies drifting up.
+// Drawn TWICE by the controller (digital-paint layers): fx_layer 0 =
+// the whole zone behind the tower, fx_layer 1 = front-assigned
+// fireflies only. Ofuda anatomy: paper strip, ink script dashes,
+// crimson seal, gold end-band.
+//
+// NOTE: TAU / PI are BUILT-IN Godot shader constants — never redeclare
+// (a `const float TAU = ...` collides with the builtin and fails the
+//  whole compile: the effect then falls back to a plain white square).
+// ================================================================
+
+uniform int   fx_layer   = 0;                            // 0 base zone, 1 front fireflies
+uniform float plant      : hint_range(0.0, 1.0) = 1.0;  // stamp-down beat, 0->1
+uniform float loop_time  = 0.0;                          // seconds, game-time (controller delta)
+uniform float expire     : hint_range(0.0, 1.0) = 0.0;  // end-of-life fade, 0->1
+uniform float scale_p    : hint_range(0.01, 1.2) = 1.0; // plant pop
+uniform float aspect     : hint_range(1.0, 4.0) = 1.0;  // square footprint
+
+uniform vec4 body_color  : source_color = vec4(0.56, 0.36, 0.94, 1.0); // Hakka violet
+uniform vec4 ink_color   : source_color = vec4(0.12, 0.06, 0.22, 1.0); // script near-black
+uniform vec4 paper_color : source_color = vec4(0.98, 0.97, 1.00, 1.0);
+uniform vec4 gold_color  : source_color = vec4(1.00, 0.84, 0.42, 1.0);
+uniform vec4 seal_color  : source_color = vec4(0.85, 0.16, 0.22, 1.0); // crimson stamp
+uniform vec4 deep_color  : source_color = vec4(0.13, 0.06, 0.26, 1.0);
+uniform vec4 soul_color  : source_color = vec4(0.55, 0.95, 0.92, 1.0); // firefly teal (his gem)
+// 0.425 = +25% over the inscribed 0.34 (Director 2026-07-18): the circular
+// zone in the SQUARE 3x3 hitbox left corner gaps where enemies took damage
+// while looking outside the circle - the ring now overshoots the box's flat
+// edges slightly to shrink the corner gap to an accepted level. Visual frame
+// may exceed the code-side AOE (shader.md house rule).
+uniform float ring_radius : hint_range(0.2, 0.5) = 0.425;
+uniform float ellipse     : hint_range(1.0, 1.8)  = 1.22; // ground perspective
+uniform float orbit_speed : hint_range(0.0, 2.0)  = 0.55;
+uniform float pool_alpha  : hint_range(0.0, 1.0)  = 0.42;
+
+float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453); }
+float noise(vec2 p) {
+	vec2 i = floor(p); vec2 f = fract(p); f = f * f * (3.0 - 2.0 * f);
+	return mix(mix(hash(i), hash(i + vec2(1, 0)), f.x),
+	           mix(hash(i + vec2(0, 1)), hash(i + vec2(1, 1)), f.x), f.y);
+}
+float fbm(vec2 p) { float v = 0.0; float amp = 0.5; for (int i = 0; i < 4; i++) { v += amp * noise(p); p *= 2.0; amp *= 0.5; } return v; }
+mat2 rot(float a) { float s = sin(a); float c = cos(a); return mat2(vec2(c, -s), vec2(s, c)); }
+float ease_out3(float t) { return 1.0 - pow(1.0 - t, 3.0); }
+
+float rect_sdf(vec2 p, vec2 hs) {
+	vec2 d = abs(p) - hs;
+	return length(max(d, vec2(0.0))) + min(max(d.x, d.y), 0.0);
+}
+
+// Talisman anatomy in card-local space (long axis = y, half-size hs).
+// Returns: x = paper, y = ink script dashes, z = crimson seal, w = gold band.
+vec4 ofuda_masks(vec2 lp, vec2 hs) {
+	float paper = 1.0 - smoothstep(0.0, 0.006, rect_sdf(lp, hs));
+	float col_m = 1.0 - smoothstep(0.0035, 0.0055, abs(lp.x));
+	float in_body = step(abs(lp.y), hs.y * 0.55);
+	float dash = step(0.38, fract((lp.y / hs.y) * 5.5));
+	float ink = col_m * in_body * dash * paper;
+	float seal = 1.0 - smoothstep(0.0, 0.004, rect_sdf(lp - vec2(0.0, hs.y * 0.72), vec2(0.0050, 0.0050)));
+	float band = 1.0 - smoothstep(0.0, 0.004, rect_sdf(lp + vec2(0.0, hs.y * 0.92), vec2(hs.x, 0.0045)));
+	return vec4(paper, ink, seal * paper, band);
+}
+
+void fragment() {
+	vec2 uv = (UV - 0.5) * vec2(aspect, 1.0) / max(scale_p, 0.01);
+	vec2 ev = uv * vec2(1.0, ellipse);
+	float r = length(ev);
+	float ang = atan(ev.y, ev.x);
+
+	float pe = ease_out3(plant);
+	float xe = ease_out3(expire);
+	float disc = 1.0 - smoothstep(ring_radius * 0.70, ring_radius * 0.96, r);
+
+	vec3 col = vec3(0.0);
+	float a = 0.0;
+
+	if (fx_layer == 0) {
+		// ---------- base zone: everything behind the tower ----------
+		float orbit = loop_time * orbit_speed * TAU * 0.16 + (1.0 - pe) * 2.6;
+		float rad_f = ring_radius * pe * (1.0 - xe);   // fan out / fly back home
+
+		vec4 om = vec4(0.0);
+		float trail = 0.0;
+		for (int i = 0; i < 7; i++) {
+			float fi = float(i);
+			float th = orbit + fi * TAU / 7.0;
+			float bob = 0.010 * sin(loop_time * 2.2 + fi * 1.7);
+			vec2 c = vec2(cos(th), sin(th)) * (rad_f + bob);
+			vec2 lp = rot(-(th + PI * 0.5)) * (ev - c);   // card local, tangential
+			om = max(om, ofuda_masks(lp, vec2(0.013, 0.046)));
+			float behind = mod(th - ang, TAU);
+			trail = max(trail, exp(-behind * 3.2));
+		}
+
+		float band = 1.0 - smoothstep(0.0, 0.014, abs(r - rad_f));
+		float ring_a = band * (0.20 + 0.55 * trail) * step(0.05, rad_f);
+
+		// SPIRIT VORTEX pool: spiral shear (twist grows toward center) +
+		// faint rings crawling inward - souls drawn to the exorcist.
+		// Continuous living territory, no interval flicker.
+		vec2 pv = rot(loop_time * 0.30 + r * 6.5) * ev;
+		float warp = fbm(pv * 3.0 + vec2(loop_time * 0.12, -loop_time * 0.07));
+		float sm = fbm(pv * 2.6 + warp * 0.9);
+		float inflow = 0.5 + 0.5 * sin(r * 34.0 + loop_time * 1.9);
+		sm += smoothstep(0.55, 0.95, inflow) * 0.18;
+		float pool_hi = smoothstep(0.60, 0.84, sm) * disc;
+		float pool = disc * pe * (1.0 - xe) * (pool_alpha + 0.26 * sm);
+
+		// plant beat: a snap flash at Hakka's hand as the fan opens
+		float flash = pow(1.0 - pe, 2.0);
+		float snap = flash * pow(max(0.0, 1.0 - r / 0.14), 2.0);
+
+		col = deep_color.rgb * pool
+		    + body_color.rgb * (ring_a + pool * 0.55 * sm + pool_hi * 0.28)
+		    + paper_color.rgb * om.x * 0.95
+		    + gold_color.rgb * om.w * 0.95
+		    + seal_color.rgb * om.z * 0.95
+		    + paper_color.rgb * snap * 0.8;
+		col += (ink_color.rgb - paper_color.rgb) * om.y * 0.85; // ink prints ON paper
+		a = max(max(om.x * 0.95, ring_a), max(pool + pool_hi * 0.20, snap));
+	}
+
+	// ---------- fireflies: on BOTH layers, split per particle ----------
+	float glow = 0.0;
+	for (int i = 0; i < 8; i++) {
+		float fi = float(i);
+		if (int(mod(fi, 2.0)) != fx_layer) { continue; }  // even = back, odd = front
+		float cyc = fract(loop_time * (0.07 + 0.03 * hash(vec2(fi, 1.7))) + fi * 0.23);
+		vec2 gp = vec2(
+			(hash(vec2(fi, 3.1)) - 0.5) * ring_radius * 1.6
+				+ 0.05 * sin(loop_time * 0.7 + fi * 2.2),
+			(0.55 - cyc) * ring_radius * 1.5
+		);
+		float twinkle = 0.55 + 0.45 * sin(loop_time * (2.0 + hash(vec2(fi, 9.4)) * 2.5) + fi * 1.9);
+		float g = pow(max(0.0, 1.0 - length(ev - gp) / 0.026), 2.0) * sin(cyc * PI) * twinkle;
+		glow = max(glow, g);
+	}
+	glow *= disc * pe * (1.0 - xe);
+	col += soul_color.rgb * glow * 0.9 + paper_color.rgb * glow * glow * 0.5;
+	a = max(a, glow * 0.8);
+
+	// 0.47 start: the +20% ring (cards reach ~0.456 at the flat edges) must
+	// not be dimmed by the pad-edge vignette.
+	float frame = 1.0 - smoothstep(0.47, 0.499, length(uv));
+	float keep = 1.0 - smoothstep(0.75, 1.0, expire); // cards fade late in flight
+	col *= frame * keep;
+	a = clamp(a * frame * keep, 0.0, 1.0);
+	COLOR = vec4(col, a);
+}

--- a/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gd
+++ b/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gd
@@ -1,0 +1,151 @@
+extends Node2D
+# ================================================================
+# Banzoin Hakka · "Obey my omen, in hymns allure" (EVOLVE) VFX
+# controller — the FIELD-family effect for the 5x5 evolved zone.
+# Structurally identical to the normal hakka_field_effect.gd (read
+# its header for the full field lifecycle + layer model); only the
+# deltas below differ.
+#
+# Deltas vs the normal controller:
+#   - SHADER_PATH -> the evolve shader (black-fire cyclone "Burning
+#     Sutra": E3c, Director-approved 2026-07-18).
+#   - FADE_NATURAL 0.6 -> 0.9: the natural-expiry fade doubles as the
+#     +20% Energy REFUND beat (white feather rises, script sung
+#     skyward, bead overload). The refund is granted on the SAME
+#     `finished` signal (SkillActionField._on_field_finished), so the
+#     Energy jump and the VFX beat share one event.
+#   - refund_beat uniform: the shader gates its entire refund
+#     choreography on `expire`, but `expire` sweeps on BOTH exit paths
+#     (natural AND wave-end cancel). Without a gate a cancel would flash
+#     the feather with no refund granted. So refund_beat starts 1.0 and
+#     is forced to 0.0 on the cancel path — the feather/overload/skyward
+#     play ONLY on natural expiry, matching the refund.
+#
+# LAYER model (same as normal): drawn TWICE — fx_layer 0 = ground zone
+# (flame sea + beads) under enemies via the map subtree, 1 = front
+# (script columns + the rising feather) above towers/enemies.
+#
+# SHADER_PATH is read by ResourceManager.warmSkillEffectShaders (it
+# scans evolutionSkill field actions too) to pre-compile at deck load.
+# ================================================================
+
+const SHADER_PATH := "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gdshader"
+const PAD := 1.35            # visual pad beyond the footprint (free: damage is code-side)
+const PLANT_TIME := 0.5
+const FADE_NATURAL := 0.9    # longer than normal's 0.6: the refund beat lives in this fade
+const FADE_CANCEL := 0.25
+
+var _mats: Array[ShaderMaterial] = []
+var _back_holder: Node2D = null   # ground-layer host inside the map subtree
+var _t := 0.0
+var _fade_time := FADE_NATURAL
+var _exp_t := -1.0           # >= 0 once expiring
+
+# Called by SkillActionField right after spawn. Footprint (cells) comes from
+# the action so the same controller serves any field size (evolve = 5x5).
+func setup_field(_tower: Tower, action: SkillActionField, ticker: SkillActionChannel.ChannelTicker) -> void:
+	_build(float(action.width))
+	Utility.ConnectSignal(ticker, "finished",
+			Callable(self, "_on_field_finished").bind(ticker))
+
+func _ready() -> void:
+	call_deferred("_ensure_built")
+
+func _ensure_built() -> void:
+	# Spawned without setup_field() means no ticker `finished` will ever arrive,
+	# so a built zone would live forever - fail loud and free instead (this
+	# controller is field-only; wire it via the field action's effect_script).
+	if _mats.is_empty():
+		push_warning("hakka_field_evo_effect: spawned without setup_field() - freeing (use the field action's effect_script, not play_effect).")
+		queue_free()
+
+func _build(cells: float) -> void:
+	var draw_size := GridHelper.CELL_SIZE * cells * PAD
+	var shader: Shader = load(SHADER_PATH)
+	var ground_map := _resolve_ground_map()
+	for side in 2:
+		var rect := ColorRect.new()
+		rect.size = Vector2(draw_size, draw_size)
+		rect.position = Vector2(-draw_size / 2.0, -draw_size / 2.0)
+		# VFX must never eat mouse input (SkillVfx rule) — and a field sits
+		# under the cursor for its whole 10s life, so this matters even more
+		# here than on burst effects.
+		rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		var mat := ShaderMaterial.new()
+		mat.shader = shader
+		mat.set_shader_parameter("fx_layer", side)
+		mat.set_shader_parameter("plant", 0.0)
+		mat.set_shader_parameter("scale_p", 0.01)
+		mat.set_shader_parameter("loop_time", 0.0)
+		mat.set_shader_parameter("expire", 0.0)
+		mat.set_shader_parameter("refund_beat", 1.0)  # 1 = play the refund beat; 0 on cancel
+		rect.material = mat
+		if side == 0 and ground_map != null:
+			# Ground layer: hosted inside the map subtree, ordered before the
+			# Path2D so enemies (its children) draw over the zone.
+			_back_holder = Node2D.new()
+			ground_map.add_child(_back_holder)
+			ground_map.move_child(_back_holder, ground_map.path.get_index())
+			_back_holder.global_position = global_position
+			_back_holder.add_child(rect)
+		elif side == 0:
+			rect.z_index = -1   # fallback: under towers only
+			add_child(rect)
+		else:
+			add_child(rect)     # front script + feather, above towers/enemies
+		_mats.append(mat)
+
+# The Map (a TileMap, z -1) is a sibling of this effect under the game-scene
+# root; its `path` export holds the Path2D the enemies spawn under.
+func _resolve_ground_map() -> Map:
+	var parent := get_parent()
+	if parent == null:
+		return null
+	for child in parent.get_children():
+		if child is Map and child.path != null:
+			return child
+	return null
+
+func _exit_tree() -> void:
+	# The ground holder lives in the map subtree, not under this node — free
+	# it explicitly on every exit path.
+	if is_instance_valid(_back_holder):
+		_back_holder.queue_free()
+
+func _process(delta: float) -> void:
+	if _mats.is_empty():
+		return
+	_t += delta
+	var plant_t: float = clampf(_t / PLANT_TIME, 0.0, 1.0)
+	var pop: float = maxf(0.01, _ease_out_back(plant_t))
+	var exp_v := 0.0
+	if _exp_t >= 0.0:
+		_exp_t += delta
+		exp_v = clampf(_exp_t / _fade_time, 0.0, 1.0)
+	for mat in _mats:
+		mat.set_shader_parameter("loop_time", _t)
+		mat.set_shader_parameter("plant", plant_t)
+		mat.set_shader_parameter("scale_p", pop)
+		mat.set_shader_parameter("expire", exp_v)
+	if _exp_t >= 0.0 and _exp_t >= _fade_time:
+		queue_free()
+
+# Fired exactly once per field on every exit path. Natural expiry (all ticks
+# fired) fades gracefully AND plays the refund beat; a wave-end cancel /
+# external free fades fast and gates the refund beat OFF (no Energy refunded on
+# that path, so the celebratory feather must not play).
+func _on_field_finished(ticker: SkillActionChannel.ChannelTicker) -> void:
+	if _exp_t >= 0.0:
+		return
+	var natural: bool = is_instance_valid(ticker) \
+			and ticker.ticks_fired >= ticker.total_ticks
+	_fade_time = FADE_NATURAL if natural else FADE_CANCEL
+	if not natural:
+		for mat in _mats:
+			mat.set_shader_parameter("refund_beat", 0.0)
+	_exp_t = 0.0
+
+func _ease_out_back(t: float) -> float:
+	var c1 := 1.70158
+	var c3 := c1 + 1.0
+	return 1.0 + c3 * pow(t - 1.0, 3.0) + c1 * pow(t - 1.0, 2.0)

--- a/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gdshader
@@ -1,0 +1,279 @@
+shader_type canvas_item;
+render_mode blend_premul_alpha;   // dark body must survive the lit map
+                                  // (docs/shader.md Section 3, Hinotori lesson)
+
+// ================================================================
+// Banzoin Hakka · "Obey my omen, in hymns allure" (EVOLVE) —
+// "Burning Sutra" (E3c, Director-approved 2026-07-18, 4 design rounds).
+// The FIELD-family evolve zone: a roaring cyclone of value-INVERTED
+// black flame (near-black body, brightness only at the tongue lips)
+// over the 5x5 ward, garnished with the exorcist's rite —
+//   - GARNISH: white glowing juzu prayer beads counting the perimeter
+//     + white script columns ("in hymns allure") rising and charring
+//     away as they climb. Crow feathers ride the storm.
+//   - COLOUR (round-3 verdict): smooth value-inverted ramp (cel bands
+//     were TRIED AND REJECTED for Hakka), refined by colour theory —
+//     analogous hue FLOW indigo -> violet -> hot-pink (#ff06c2) bridge
+//     -> lavender -> white lip (no dead jumps), faint warm ember in the
+//     depths for richness.
+//   - REFUND BEAT: on NATURAL expiry only, the ward overloads — beads
+//     flash/snap, script is sung skyward, ONE white feather rises. This
+//     is gated by `refund_beat` (see below), NOT by `expire` alone.
+//
+// LAYER model (drawn twice by the controller): fx_layer 0 = flame sea +
+// beads (ground, under enemies), 1 = script columns + rising feather
+// (front, above towers/enemies).
+//
+// refund_beat: `expire` sweeps on BOTH exit paths (natural AND wave-end
+// cancel). The refund is granted only on natural expiry, so the
+// controller forces refund_beat=0 on cancel — the celebratory beat
+// (overload, skyward accel, feather) then plays ONLY when Energy is
+// actually refunded. Default 1.0 keeps the natural path faithful.
+//
+// NOTE: TAU / PI / E are BUILT-IN Godot shader constants — never
+// redeclare (a `const float TAU = ...` collides with the builtin and
+// fails the whole compile: the effect falls back to a plain white
+// square, no crash — check the Output panel if the zone renders blank).
+// ================================================================
+
+uniform int   fx_layer   = 0;
+uniform float plant      : hint_range(0.0, 1.0) = 1.0;
+uniform float loop_time  = 0.0;
+uniform float expire     : hint_range(0.0, 1.0) = 0.0;
+uniform float refund_beat : hint_range(0.0, 1.0) = 1.0; // 1 = natural expiry (play refund beat), 0 = cancel
+uniform float scale_p    : hint_range(0.01, 1.2) = 1.0;
+uniform float aspect     : hint_range(1.0, 4.0) = 1.0;
+
+uniform vec4 black_color    : source_color = vec4(0.05, 0.02, 0.09, 1.0);
+uniform vec4 deep_color     : source_color = vec4(0.22, 0.08, 0.40, 1.0);
+uniform vec4 violet_color   : source_color = vec4(0.56, 0.36, 0.94, 1.0); // Hakka DNA
+uniform vec4 lavender_color : source_color = vec4(0.80, 0.64, 1.00, 1.0);
+uniform vec4 white_color    : source_color = vec4(1.00, 0.97, 1.00, 1.0);
+uniform vec4 seal_color     : source_color = vec4(0.85, 0.16, 0.22, 1.0);
+uniform vec4 ember_color    : source_color = vec4(0.48, 0.08, 0.12, 1.0); // smoulder depths
+uniform vec4 teal_color     : source_color = vec4(0.55, 0.95, 0.92, 1.0); // gem glint
+uniform vec4 pink_color     : source_color = vec4(1.00, 0.02, 0.76, 1.0); // #ff06c2 hot-pink accent (Director sample)
+
+uniform float ring_radius : hint_range(0.2, 0.5) = 0.425;
+uniform float ellipse     : hint_range(1.0, 1.8) = 1.22;
+uniform float storm_speed : hint_range(0.0, 2.0) = 0.55;
+uniform float pool_alpha  : hint_range(0.0, 1.0) = 0.62;
+
+float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453); }
+float noise(vec2 p) {
+	vec2 i = floor(p); vec2 f = fract(p); f = f * f * (3.0 - 2.0 * f);
+	return mix(mix(hash(i), hash(i + vec2(1, 0)), f.x),
+	           mix(hash(i + vec2(0, 1)), hash(i + vec2(1, 1)), f.x), f.y);
+}
+float fbm(vec2 p) { float v = 0.0; float amp = 0.5; for (int i = 0; i < 4; i++) { v += amp * noise(p); p *= 2.0; amp *= 0.5; } return v; }
+// ridged fbm: sharp creases - the metal-jagged flame-tongue profile (rock register)
+float rfbm(vec2 p) {
+	float v = 0.0; float amp = 0.5;
+	for (int i = 0; i < 4; i++) {
+		v += amp * (1.0 - abs(2.0 * noise(p) - 1.0));
+		p *= 2.1; amp *= 0.5;
+	}
+	return v;
+}
+mat2 rot(float a) { float s = sin(a); float c = cos(a); return mat2(vec2(c, -s), vec2(s, c)); }
+float ease_out3(float t) { return 1.0 - pow(1.0 - t, 3.0); }
+
+// Smooth value-INVERTED flame ramp (NOT cel-quantized — cel bands were dropped
+// round 2 for Hakka). h = flame intensity; smoulder = warm ember undertone in
+// the darkest band only. Analogous hue flow with a #ff06c2 pink bridge; clean
+// near-white lip at the crests.
+vec3 flame_ramp(float h, float smoulder) {
+	vec3 c = mix(black_color.rgb, ember_color.rgb * 0.55, smoulder * (1.0 - smoothstep(0.40, 0.55, h)));
+	c = mix(c, deep_color.rgb,     smoothstep(0.45, 0.60, h) - smoothstep(0.72, 0.84, h));
+	c = mix(c, violet_color.rgb,   smoothstep(0.72, 0.84, h) - smoothstep(0.90, 0.96, h));
+	c = mix(c, pink_color.rgb, smoothstep(0.84, 0.92, h) - smoothstep(0.94, 0.98, h)); // hot-pink bridge (#ff06c2)
+	c = mix(c, lavender_color.rgb, smoothstep(0.90, 0.96, h));
+	c += white_color.rgb * smoothstep(0.965, 1.0, h) * 0.8;
+	return c;
+}
+
+// feather: leaf silhouette with rachis, local frame (+y = tip)
+vec2 feather_mask(vec2 lp, vec2 hs) {
+	float t = clamp(lp.y / hs.y * 0.5 + 0.5, 0.0, 1.0);
+	float w = hs.x * (smoothstep(0.0, 0.30, t) - smoothstep(0.30, 1.0, t) * 0.75);
+	float body = (1.0 - smoothstep(w * 0.7, max(w, 1e-4), abs(lp.x))) * step(abs(lp.y), hs.y);
+	float rachis = (1.0 - smoothstep(0.0008, 0.0022, abs(lp.x))) * body;
+	return vec2(body, rachis);
+}
+
+// pseudo-kanji column: stacked dashes of varying width in a narrow frame.
+// Returns glyph mask; seedv varies the "characters" per column.
+float script_column(vec2 lp, vec2 hs, float seedv) {
+	float frame_m = step(abs(lp.x), hs.x) * step(abs(lp.y), hs.y);
+	float row = floor((lp.y / hs.y * 0.5 + 0.5) * 6.0);
+	float rw = 0.35 + 0.65 * hash(vec2(row, seedv));                // per-row width
+	float dash = step(abs(lp.x), hs.x * rw);
+	float gap = step(0.25, fract((lp.y / hs.y * 0.5 + 0.5) * 6.0)); // row separation
+	return frame_m * dash * gap;
+}
+
+void fragment() {
+	vec2 uv = (UV - 0.5) * vec2(aspect, 1.0) / max(scale_p, 0.01);
+	vec2 ev = uv * vec2(1.0, ellipse);
+	float r = length(ev);
+	float ang = atan(ev.y, ev.x);
+
+	float pe = ease_out3(plant);
+	float xe = ease_out3(expire);
+	float tighten = 1.0 - 0.6 * smoothstep(0.0, 0.6, xe);
+	float rad_live = ring_radius * tighten;
+	float disc = 1.0 - smoothstep(rad_live * 0.66, rad_live * 0.96, r);
+	float live = pe * (1.0 - smoothstep(0.45, 0.75, xe));
+
+	vec3 col = vec3(0.0);
+	float a = 0.0;
+
+	// spin ramps UP as the ward dies — but the skyward accel is a REFUND beat,
+	// so gate the accel term with refund_beat (base spin unchanged on cancel).
+	float spin = loop_time * storm_speed * (1.0 + 1.5 * smoothstep(0.0, 0.6, xe) * refund_beat);
+	// refund overload: beads flash + snap — natural expiry only.
+	float overload = smoothstep(0.15, 0.45, xe) * (1.0 - smoothstep(0.5, 0.75, xe)) * refund_beat;
+
+	if (fx_layer == 0) {
+		// ---------- flame sea: E3 cyclone motion, smooth value-inverted ramp ----------
+		vec2 sv = rot(spin + r * 5.5) * ev;
+		float warp = fbm(sv * 2.6 + vec2(loop_time * 0.20, -loop_time * 0.14));
+		float ridge = rfbm(sv * 3.2 + warp * 1.3 + vec2(0.0, -loop_time * 0.5));
+		float erupt = 1.0 + 0.8 * pow(1.0 - pe, 1.5);
+		float h = clamp(ridge * 1.15 * erupt, 0.0, 1.0) * disc;
+
+		float smoulder = (0.35 + 0.30 * sin(loop_time * 0.7 + r * 7.0))
+		               * smoothstep(0.3, 0.7, warp);
+		vec3 fc = flame_ramp(h, smoulder);
+
+		float sea = disc * live * (pool_alpha + 0.30 * ridge);
+		col += fc * sea;
+		a = sea;
+
+		// perimeter flame wall: tongues thrown outward past the rim
+		float wall = rfbm(vec2(ang * 3.0 - spin * 0.8, r * 7.0 - loop_time * 1.6));
+		float wzone = smoothstep(rad_live * 0.85, rad_live * 1.0, r)
+		            * (1.0 - smoothstep(rad_live * 1.0, rad_live * 1.24, r));
+		float tongues = wzone * smoothstep(0.55, 0.9, wall) * live;
+		col += mix(black_color.rgb, violet_color.rgb, wall * wall) * tongues;
+		col += lavender_color.rgb * smoothstep(0.88, 0.98, wall) * wzone * live * 0.6;
+		a = max(a, tongues * 0.9);
+
+		// ---------- GARNISH half 1: juzu prayer-bead ring, slow count ----------
+		// White + glow halo, at the perimeter radius so they read as the boundary
+		// over the dark wall tongues (Director round-3 fix).
+		float rr = rad_live * 0.98;
+		float bead_ring = 0.0;
+		float bead_glow = 0.0;
+		float bead_hi = 0.0;
+		float bead_th = -loop_time * 0.12 - overload * 2.0;         // refund: snaps around
+		for (int i = 0; i < 14; i++) {
+			float fi = float(i);
+			float th = bead_th + fi * TAU / 14.0;
+			vec2 bp = vec2(cos(th), sin(th)) * rr;
+			float d = length(ev - bp);
+			float bead = 1.0 - smoothstep(0.012, 0.017, d);   // x2 size (Director round 4)
+			bead_ring = max(bead_ring, bead);
+			bead_glow = max(bead_glow, pow(max(0.0, 1.0 - d / 0.048), 2.0));
+			// one "mother bead" counts: brightest where the count is now
+			float lead = exp(-mod(fi * TAU / 14.0 - loop_time * 0.5, TAU) * 2.0);
+			bead_hi = max(bead_hi, bead * lead);
+		}
+		float cord = 1.0 - smoothstep(0.0012, 0.0028, abs(r - rr));
+		col = mix(col, white_color.rgb, max(bead_ring, cord * 0.45) * live);
+		col += lavender_color.rgb * bead_glow * live * 0.75;        // bright halo
+		col += white_color.rgb * bead_hi * live * 0.9;              // counting pulse
+		col += white_color.rgb * bead_ring * overload;              // refund flash
+		a = max(a, max(max(bead_ring, bead_glow * 0.6), cord * 0.5) * live);
+
+		// plant stamp: crimson seal flash (exorcist identity)
+		float flash = pow(1.0 - pe, 2.0);
+		float snap = flash * pow(max(0.0, 1.0 - r / 0.16), 2.0);
+		col += seal_color.rgb * snap * 0.9 + white_color.rgb * snap * snap * 0.6;
+		a = max(a, snap);
+	} else {
+		// ---------- GARNISH half 2: rising script columns (front) ----------
+		// rise accel ("sung skyward") is a REFUND beat — gate with refund_beat.
+		float rise_speed = 1.0 + 3.0 * smoothstep(0.15, 0.5, xe) * refund_beat;
+		vec3 scol = vec3(0.0);
+		float sa2 = 0.0;
+		for (int i = 0; i < 5; i++) {
+			float fi = float(i);
+			float cyc = fract(loop_time * (0.16 + 0.05 * hash(vec2(fi, 5.1))) * rise_speed + fi * 0.21);
+			float th = fi * 2.51 + hash(vec2(fi, 3.7)) * TAU + loop_time * 0.10;
+			float rad = rad_live * (0.35 + 0.35 * hash(vec2(fi, 9.9)));
+			vec2 base = vec2(cos(th), sin(th)) * rad;
+			vec2 gp = base + vec2(0.012 * sin(loop_time * 1.1 + fi), -cyc * 0.16); // climbs
+			vec2 lp = ev - gp;
+			float glyph = script_column(lp, vec2(0.0075, 0.036), fi * 7.0 + floor(cyc * 3.0));
+			float lifef = sin(cyc * PI);                            // fade in, burn out high
+			float burn = smoothstep(0.55, 1.0, cyc);                // chars away as it climbs
+			// WHITE script with a soft glow halo behind each column
+			float halo = pow(max(0.0, 1.0 - length(lp) / 0.055), 2.0);
+			scol = mix(scol, white_color.rgb, glyph * lifef);
+			scol += lavender_color.rgb * halo * lifef * 0.7;
+			sa2 = max(sa2, max(glyph, halo * 0.55) * lifef * (1.0 - burn * 0.4));
+		}
+		sa2 *= pe * (1.0 - smoothstep(0.5, 0.7, xe));
+		col = mix(col, scol, min(sa2, 1.0) * 0.95);
+		a = max(a, sa2 * 0.9);
+
+		// ---------- REFUND signature: ONE white feather rises (front) ----------
+		// Gated by refund_beat so it plays ONLY on natural expiry (= refund).
+		if (expire > 0.0) {
+			float ft = smoothstep(0.45, 1.0, xe);
+			vec2 fp = ev - vec2(0.0, 0.02 - ft * 0.14);
+			vec2 lp = rot(0.25 * sin(ft * 6.0)) * fp;
+			vec2 fm = feather_mask(lp, vec2(0.016, 0.052));
+			float fglow = pow(max(0.0, 1.0 - length(fp) / 0.10), 2.0);
+			float fa = ft * (1.0 - smoothstep(0.92, 1.0, xe)) * refund_beat;
+			col += white_color.rgb * fm.x * fa * 1.1;
+			col += violet_color.rgb * fm.y * fa * 0.7;
+			col += lavender_color.rgb * fglow * fa * 0.6;
+			a = max(a, max(fm.x, fglow * 0.6) * fa);
+		}
+	}
+
+	// ---------- spark flecks off the crests: both layers, split ----------
+	float spark = 0.0;
+	for (int i = 0; i < 8; i++) {
+		float fi = float(i);
+		if (int(mod(fi, 2.0)) != fx_layer) { continue; }
+		float cyc = fract(loop_time * (0.55 + 0.35 * hash(vec2(fi, 6.1))) + fi * 0.13);
+		float sa = hash(vec2(fi, 2.9)) * TAU + loop_time * storm_speed * 0.8;
+		float sr = rad_live * (0.45 + 0.45 * hash(vec2(fi, 7.7)) + cyc * 0.25);
+		vec2 sp2 = vec2(cos(sa), sin(sa)) * sr;
+		float g = pow(max(0.0, 1.0 - length(ev - sp2) / 0.013), 2.0) * sin(cyc * PI);
+		spark = max(spark, g);
+	}
+	spark *= live;
+	col += mix(white_color.rgb, lavender_color.rgb, 0.4) * spark * 0.9;
+	a = max(a, spark * 0.8);
+
+	// ---------- feathers riding the storm + teal rachis glint ----------
+	float fglow2 = 0.0;
+	vec3 fcol = vec3(0.0);
+	for (int i = 0; i < 10; i++) {
+		float fi = float(i);
+		if (int(mod(fi, 2.0)) != fx_layer) { continue; }
+		float ph = fi * 2.4 + hash(vec2(fi, 8.8)) * TAU;
+		float sp = loop_time * (0.5 + 0.35 * hash(vec2(fi, 4.4))) + ph;
+		float rad = rad_live * (0.30 + 0.55 * (0.5 + 0.5 * sin(loop_time * 0.35 + ph)));
+		vec2 gp = vec2(cos(sp), sin(sp)) * rad;
+		float spin2 = loop_time * (2.0 + hash(vec2(fi, 5.5))) + fi;
+		vec2 lp = rot(spin2) * (ev - gp);
+		vec2 fm = feather_mask(lp, vec2(0.010, 0.028));
+		fcol = mix(fcol, black_color.rgb, fm.x);
+		float glint = 0.4 + 0.4 * sin(spin2 * 1.7);        // iridescence turns with the feather
+		fcol += mix(lavender_color.rgb, teal_color.rgb, glint) * fm.y * 0.8;
+		fglow2 = max(fglow2, fm.x);
+	}
+	fglow2 *= disc * live;
+	col = mix(col, fcol, min(fglow2, 1.0) * 0.85);
+	a = max(a, fglow2 * 0.85);
+
+	float frame = 1.0 - smoothstep(0.47, 0.499, length(uv));
+	col *= frame;
+	a = clamp(a * frame, 0.0, 1.0);
+	COLOR = vec4(col, a);
+}

--- a/scripts/combat/hitbox.gd
+++ b/scripts/combat/hitbox.gd
@@ -59,6 +59,10 @@ static func create(width: float, height: float, callback: Callable, spawn_pos: V
 func _draw():
 	if _size == Vector2.ZERO:
 		return
+	# Alpha 0 = caller asked for no debug visual (the border below would
+	# otherwise still draw at forced alpha 1).
+	if _visual_color.a <= 0.0:
+		return
 
 	var rect = Rect2(-_size * 0.5 + _local_offset, _size)
 	draw_rect(rect, _visual_color, true)

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -154,7 +154,11 @@ static func warmSkillEffectShaders(host: Node) -> void:
 			if skill == null:
 				continue
 			for action in skill.actions:
-				if action is SkillActionPlayEffect and action.effectScriptPath != "":
+				# SkillActionField carries its persistent-zone controller in its own
+				# effectScriptPath export (spawned at plant, not a play_effect action),
+				# so it must be matched here too or its shader never warms.
+				if (action is SkillActionPlayEffect or action is SkillActionField) \
+						and action.effectScriptPath != "":
 					var sp := _shaderPathFromEffectScript(action.effectScriptPath)
 					if sp != "":
 						shaderPaths[sp] = true

--- a/scripts/skill/skillActions/skill_action_field.gd
+++ b/scripts/skill/skillActions/skill_action_field.gd
@@ -22,6 +22,10 @@ extends SkillActionChannel
 #   tick. Reference: resources/database/towers/banzoin_hakka.yaml.
 
 @export var energyRefundPercent: float = 0.0
+# Persistent-lifetime zone VFX controller (YAML `effect_script`): spawned ONCE
+# at plant and living until the ticker ends — deliberately NOT the inherited
+# per-tick `effect_action` path (a field zone must not respawn per tick).
+@export var effectScriptPath: String = ""
 
 func execute(context: SkillContext):
 	var tower: Tower = context.user as Tower
@@ -37,7 +41,28 @@ func execute(context: SkillContext):
 	tower.add_child(ticker)
 	Utility.ConnectSignal(ticker, "finished",
 			Callable(self, "_on_field_finished").bind(ticker, tower, gen))
+	_spawn_field_effect(tower, ticker)
 	# No await: the cast finishes normally while the field ticks (aftershock model).
+
+# Same spawn shape as SkillActionPlayEffect (bare Node2D + script at the tower,
+# parent = tower's parent), plus the field-specific setup_field(tower, action,
+# ticker) so the controller can size itself and fade on the ticker's `finished`.
+func _spawn_field_effect(tower: Tower, ticker: Node) -> void:
+	if effectScriptPath == "":
+		return
+	var script = load(effectScriptPath)
+	if script == null:
+		push_error("SkillActionField: effect script not found at ", effectScriptPath)
+		return
+	var parent := tower.get_parent()
+	if parent == null:
+		return
+	var effect := Node2D.new()
+	effect.set_script(script)
+	effect.global_position = tower.global_position
+	parent.add_child(effect)
+	if effect.has_method("setup_field"):
+		effect.setup_field(tower, self, ticker)
 
 # The ticker emits "finished" exactly once (channel's `done` once-guard) on
 # EVERY exit path - natural end, wave-end generation bump, and external free.

--- a/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
+++ b/scripts/skill/skillActions/skill_action_find_multiple_in_range.gd
@@ -8,6 +8,9 @@ var cancel_when_empty: bool = true
 # the caster, no aim rotation or forward extend. A target_position override
 # in context.extra still wins (it re-centers the same box elsewhere).
 var center_on_self: bool = false
+# YAML `show_area` (default true): false suppresses the red debug rect for
+# this find only (e.g. Hakka's field, whose zone VFX already shows the area).
+var show_area: bool = true
 
 var target_group: String = "enemy" # Group name for potential targets
 var max_attempt := 1
@@ -94,7 +97,9 @@ func find_targets_in_rotated_range(context: SkillContext):
 	var parent_node = context.user.get_parent() if context.user.get_parent() else context.user.get_tree().current_scene
 
 	var callback = Callable(self, "_on_hitbox_detected").bind(context, user_position)
-	await Hitbox.create(actual_width, actual_height, callback, hitbox_position, parent_node, user_rotation, local_offset)
+	# show_area false -> fully transparent visual (Hitbox._draw skips alpha 0).
+	var vis_color := Color(1, 0, 0, 0.25) if show_area else Color(0, 0, 0, 0)
+	await Hitbox.create(actual_width, actual_height, callback, hitbox_position, parent_node, user_rotation, local_offset, vis_color)
 
 func _on_hitbox_detected(enemies: Array, context: SkillContext, user_position: Vector2):
 	if not context:

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -285,11 +285,15 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			fieldFind.width = skill.width;
 			fieldFind.height = skill.height;
 			fieldFind.cancel_when_empty = false;
+			# The zone VFX already shows the area, so the per-tick debug box can
+			# be authored off (this inner find redraws it EVERY tick otherwise).
+			fieldFind.show_area = skillData.get("show_area", true);
 			skill.find_action = fieldFind;
 			skill.attack_action = ParseAction({"type": "attack", "data": skillData}, parameters) as SkillActionAttack;
-			# Optional per-tick VFX hook (unset today - VFX is a follow-up task).
-			if skillData.has("effect_script"):
-				skill.effect_action = ParseAction({"type": "play_effect", "data": {"effect_script": skillData["effect_script"]}}, parameters) as SkillActionPlayEffect;
+			# Persistent-lifetime zone VFX: ONE controller spawned at plant by
+			# SkillActionField (NOT the channel/aftershock per-tick effect_action
+			# path - a field zone must not respawn on the damage cadence).
+			skill.effectScriptPath = str(skillData.get("effect_script", ""));
 		"clear_enemy":
 			skill = SkillActionClearEnemy.new();
 		"find_multi_enemy":
@@ -300,6 +304,8 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill.cancel_when_empty = skillData.get("cancel_when_empty", true);
 			# Self-centered axis-aligned box (no aim rotation/forward extend).
 			skill.center_on_self = skillData.get("center_on_self", false);
+			# Debug-area visibility (same key as apply_effect's show_area).
+			skill.show_area = skillData.get("show_area", true);
 		"dash":
 			# Path dash: slide the casting enemy forward along its path.
 			skill = SkillActionDash.new();


### PR DESCRIPTION
**Summary:** Skill VFX for Banzoin Hakka's field skill, both tiers, in one PR. Normal "Exocirst Field" (3x3 ofuda orbit + spirit-vortex pool) and evolve "Obey my omen, in hymns allure" (5x5 "Burning Sutra" black-fire cyclone). Establishes the FIELD family of skill VFX: a persistent ground zone that lives for the skill's whole duration instead of a sub-second burst.

**How it works:** One effect controller is spawned per field at plant time (never per damage tick - a persistent zone must not respawn on the damage cadence) and lives until the skill's ticker reports `finished`. Animation runs on phase uniforms - `plant` / `loop_time` / `expire` - driven by `_process` delta rather than shader `TIME`, so the zone freezes on pause and scales with x2 speed for free. Each zone draws its shader twice: `fx_layer` 0 is the ground layer, inserted into the map subtree ahead of the enemy Path2D so it renders under enemies, and `fx_layer` 1 is a front layer holding only discrete particles, split per-particle rather than by screen position (a positional split puts a visible seam across the tower). The evolve controller mirrors the normal one; the only deltas are its shader path, a longer natural fade, and the refund gate below.

Extension points: any future field skill reuses this pair by copying the controller and pointing `SHADER_PATH` at a new shader - `setup_field` sizes the zone from the action's `width`, so footprint is automatic. Zone VFX is wired purely from YAML (`effect_script` on the `field` action), which is also the single switch that makes `ResourceManager.warmSkillEffectShaders` pre-compile the shader at deck load.

**Implementation Notes:**
- **Refund-beat gate (caught by a scrutinize pass on the plan, not in testing).** The evolve zone's natural expiry doubles as the +20% Energy refund beat: the ward overloads and one white feather rises. That choreography was gated on the `expire` uniform - but `expire` sweeps on *both* exit paths, natural and wave-end cancel, differing only in ramp speed. A wave-end cancel would therefore have flashed the celebratory feather while the refund was (correctly) withheld. Fixed with a `refund_beat` uniform that the controller forces to 0 on the cancel path; it defaults to 1 so the natural path is unchanged.
- **Performance, flagged not fixed.** The evolve fragment is the heaviest shader in the project so far (two 4-octave noise fields plus four in-fragment particle loops, on a 5x5-plus-pad rect drawn twice, sustained ~10s). Measured as acceptable on the test machine and shipped as the Director approved it. If it becomes a problem on weaker GPUs, two provably look-identical levers are ready: early-out on the corner vignette (~22% of pixels currently pay full cost for nothing) and radius-band gates on the garnish loops, which are already exactly zero outside those bands. Reducing noise octaves or trimming the pad are *not* safe - both visibly change the approved look.
- **Known pre-existing gap (not fixed here):** the shader warm scan does not reach `effect_action` shaders nested inside aftershock/channel actions. Calliope works around it today by sharing one shader across its beats. Out of scope for this PR; worth a dedicated fix if a future skill hits it.
- Colour direction is Director-authored across four rounds; every colour and tunable is exposed as a uniform for in-engine hand-tuning. The evolve palette deliberately keeps the violet family and tier-shifts it into value-inverted black flame with a hot-pink accent.
