### PR TITLE
Hero synergy - Physical Attack per active trait

### DIFF
--- a/resources/database/synergy/hero.yaml
+++ b/resources/database/synergy/hero.yaml
@@ -2,7 +2,14 @@ id: hero
 name: "Hero"
 kind: class
 type: normal
-# Placeholder: thresholds carried for UI counting; effect not wired yet.
-effect: none
-thresholds: [3]
-desc: "Hero synergy effect not yet defined."
+effect: attack_per_active_trait
+# Single tier by design: one Hero unit activates the trait, and the bonus scales
+# with the rest of the board instead of with the Hero count.
+thresholds: [1]
+parameters:
+  # Percent scale (5 = +5%), per active Trait on the field. Scalar, not an array:
+  # the value does not scale by tier, so it must not render as a tier-scaling number.
+  atk_per_trait: 5
+desc: "Hero units carry a champion's resolve, growing stronger with every Trait awakened on the field - each active Trait grants them +{atk_per_trait}% Physical Attack."
+tier_effects:
+  - "+{atk_per_trait}% Physical Attack per active Trait"

--- a/scripts/synergy/synergy_controller.gd
+++ b/scripts/synergy/synergy_controller.gd
@@ -74,6 +74,16 @@ func tick(delta: float) -> void:
 func active_tier(synergy_id: int) -> int:
 	return _active_tier.get(synergy_id, -1)
 
+# How many synergies are currently active (any tier). Placeholder synergies count:
+# _active_tier is written before the no-handler return in on_synergy_updated, so a
+# declared-but-unwired trait the player sees light up in the panel is included.
+func active_synergy_count() -> int:
+	var total := 0
+	for tier in _active_tier.values():
+		if tier >= 0:
+			total += 1
+	return total
+
 # Towers currently holding a given synergy trait (factory's keyed list).
 func towers_with(synergy_id: int) -> Array:
 	if _factory == null:

--- a/scripts/synergy/synergy_effect.gd
+++ b/scripts/synergy/synergy_effect.gd
@@ -47,6 +47,8 @@ static func create(effect_key: String) -> SynergyEffect:
 			return SynergyEffectEnergyOnCast.new()
 		"quest_kill_tempus":
 			return SynergyEffectQuestTempus.new()
+		"attack_per_active_trait":
+			return SynergyEffectAttackPerTrait.new()
 		"", "none":
 			return null   # placeholder synergy: declared but no effect handler yet
 		_:

--- a/scripts/synergy/synergy_effect_attack_per_trait.gd
+++ b/scripts/synergy/synergy_effect_attack_per_trait.gd
@@ -35,7 +35,9 @@ func _recompute() -> void:
 	var per_trait = data.get_parameter("atk_per_trait", 0)
 	if per_trait == null:
 		return
-	var total := float(per_trait) * controller.active_synergy_count()
+	# Explicit type: `controller` is untyped in the base class, so the product has
+	# no inferable type and `:=` is a parser error.
+	var total: float = float(per_trait) * float(controller.active_synergy_count())
 	if total <= 0.0:
 		return
 	for tower in controller.towers_with(data.synergy_id):

--- a/scripts/synergy/synergy_effect_attack_per_trait.gd
+++ b/scripts/synergy/synergy_effect_attack_per_trait.gd
@@ -1,0 +1,48 @@
+class_name SynergyEffectAttackPerTrait
+extends SynergyEffect
+
+# Hero - the first META synergy: the bonus scales with how many OTHER traits are
+# active on the board, not with its own unit count. Every active trait (including
+# Hero itself, and including declared-but-unwired placeholder traits) grants the
+# Hero units +atk_per_trait% Physical Attack. Magic Attack is deliberately NOT
+# granted (Director 2026-07-18) - do not "fix" it to match Tempus.
+#
+# The total is recomputed and re-applied under ONE source_id: attack_mult_up is a
+# REFRESH effect, so re-applying overwrites the value (EffectContainer.apply).
+# A per-trait source_id would SUM instead and double-count.
+
+const _SOURCE := "synergy_hero"
+
+func activate() -> void:
+	_recompute()
+
+# Defensive only: every trait activation happens inside a placement that ends in
+# on_tower_added, so that hook alone is complete. Kept because _recompute is cheap
+# and idempotent - not load-bearing.
+func on_tier_changed(_new_tier: int) -> void:
+	_recompute()
+
+func on_tower_added(_tower) -> void:
+	# Fires for EVERY placement, not just Hero units: someone else's placement is
+	# what activates a new trait and raises the bonus. Traits are counted before
+	# this hook runs (TowerFactory.getTower), so the recompute sees the new state.
+	_recompute()
+
+# Apply the current total to every Hero unit. Lifetime and duration are set
+# explicitly: the registry def is WAVE with a non-zero duration, both wrong for a
+# permanent synergy buff (same trap as synergy_effect_quest_tempus.gd).
+func _recompute() -> void:
+	var per_trait = data.get_parameter("atk_per_trait", 0)
+	if per_trait == null:
+		return
+	var total := float(per_trait) * controller.active_synergy_count()
+	if total <= 0.0:
+		return
+	for tower in controller.towers_with(data.synergy_id):
+		if not is_instance_valid(tower):
+			continue
+		var inst := EffectUtility.make_instance("attack_mult_up", _SOURCE, total, 0.0)
+		if inst == null:
+			continue
+		inst.lifetime = EffectTypes.Lifetime.BOARD
+		tower.apply_effect(inst)

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -73,10 +73,21 @@ func setQuestProgress(current: int) -> void:
 	if _tooltip_label != null and is_instance_valid(_tooltip_label):
 		_tooltip_label.text = _build_hover_bbcode()
 
+# Colour by tier RANK, not absolute index: a synergy's highest tier always reads
+# gold, whatever its tier count. Hero defines a single tier, so an absolute index
+# left it permanently bronze - the lowest rank while fully maxed.
+# 3 tiers -> bronze/silver/gold (unchanged); 2 -> bronze/gold; 1 -> gold.
 func _tier_color(tier: int) -> String:
 	if tier < 0:
 		return INACTIVE_COLOR
-	return TIER_COLORS[clampi(tier, 0, TIER_COLORS.size() - 1)]
+	var last := TIER_COLORS.size() - 1
+	var top_tier := 0
+	if _data != null:
+		top_tier = _data.tier_count() - 1
+	if top_tier <= 0:
+		return TIER_COLORS[last]
+	var idx := int(round(float(clampi(tier, 0, top_tier)) / float(top_tier) * float(last)))
+	return TIER_COLORS[clampi(idx, 0, last)]
 
 # "3 4 5" with the active tier's threshold bracketed.
 func _breakpoints_text(tier: int) -> String:


### PR DESCRIPTION
**Summary:** Wires the Hero class synergy, previously a declared placeholder. Hero is the first *meta* synergy: its bonus scales with how many traits are active on the board rather than with its own unit count. Hero units gain +5% Physical Attack per active trait.

**How it works:** `hero.yaml` moves to `effect: attack_per_active_trait` with a single tier (`thresholds: [1]`) and a scalar `atk_per_trait: 5`. A new `SynergyEffectAttackPerTrait` recomputes the total on `activate` / `on_tier_changed` / `on_tower_added` and re-applies it to every Hero holder. `SynergyController.active_synergy_count()` is the new accessor it counts through. Extension point is unchanged: a new synergy behaviour = one subclass plus one arm in `SynergyEffect.create`.

**Implementation Notes:**
- *Counting rule (Director 2026-07-18):* a trait counts as active once its lowest threshold is met - tier level is irrelevant, Hero counts itself, and placeholder (`effect: none`) traits count because the player sees them light up in the panel. `_active_tier` is written before the no-handler return in `on_synergy_updated`, so placeholders are already tracked.
- *Physical only (Director 2026-07-18):* deliberately unlike Tempus tier 0, which grants both Physical and Magic. Not an oversight.
- *Single `source_id`:* `attack_mult_up` has no `stack` key so it defaults to REFRESH, and `EffectContainer.apply` overwrites `existing.value` on refresh. Recomputing the full total and re-applying is therefore correct; a per-trait `source_id` would SUM and double-count.
- *Trigger completeness:* `on_tower_added` alone is sufficient - a trait can only activate during a placement, and `TowerFactory.getTower` counts traits before calling that hook. The other two recomputes are cheap idempotent defense and are commented as such.
- *Tier colour:* row colour now derives from tier RANK, not absolute index, so a synergy's highest tier always reads gold. Hero defines one tier and was permanently bronze under the old mapping. Side effect: 2-tier synergies (Diva, Gen1) now read bronze -> gold and skip silver.
- *Accepted:* every future synergy silently strengthens Hero. Retune `atk_per_trait` if that becomes a balance problem rather than changing the rule.
- Plan was scrutinized by a second agent before implementation; it caught an inline-flow-mapping YAML notation the project parser cannot read, which would have null-crashed Hero on first activation.
- Docs updated: `tower_synergy.md` (Hero section, effect registry, Director rulings), `game_copy.md` (player-facing term "Trait").
