### PR TITLE
Spell Caster synergy - Magic Attack up and skill crit unlock

### DIFF
--- a/resources/database/effect/effects.yaml
+++ b/resources/database/effect/effects.yaml
@@ -93,6 +93,22 @@ crit_chance_up:
   kind: crit_chance
   duration: 4.0
 
+# SpellCaster synergy gate: unlocks the crit roll on the holder's SKILLS. It
+# grants no critical chance - a holder with 0 chance still never crits. mark =
+# pure flag, no stat aggregation; SkillActionAttack reads it live via
+# EffectContainer.stacks_of (NOT has_mark, which filters category == mark, and
+# NOT has_kind(MARK_ONLY), which `soul` would also satisfy).
+spellcaster_crit:
+  name: "Arcane Focus"
+  desc: "Skills can land critical hits."
+  icon: "ui_asset/effects/buff_generic.png"
+  category: buff
+  host: tower
+  kind: mark
+  stack: refresh
+  duration: 0
+  lifetime: board
+
 crit_damage_up:
   name: "Critical Damage Up"
   desc: "Critical damage increased by {value}."

--- a/resources/database/synergy/diva.yaml
+++ b/resources/database/synergy/diva.yaml
@@ -1,8 +1,0 @@
-id: diva
-name: "Diva"
-kind: class
-type: normal
-# Placeholder: thresholds carried for UI counting; effect not wired yet.
-effect: none
-thresholds: [2, 3]
-desc: "Diva synergy effect not yet defined."

--- a/resources/database/synergy/gen1.yaml
+++ b/resources/database/synergy/gen1.yaml
@@ -1,8 +1,0 @@
-id: gen1
-name: "Gen1"
-kind: generation
-type: normal
-# Placeholder: thresholds carried for UI counting; effect not wired yet.
-effect: none
-thresholds: [2, 4]
-desc: "Gen1 synergy effect not yet defined."

--- a/resources/database/synergy/spellcaster.yaml
+++ b/resources/database/synergy/spellcaster.yaml
@@ -9,12 +9,17 @@ effect: magic_up_skill_crit
 # is already a real deck commitment, and the bonus does not scale past it.
 thresholds: [2]
 parameters:
-  # Percent scale (25 = +25%), matching MAGIC_MULT. Scalar, not an array: the
-  # value does not scale by tier, so it must not render as a tier-scaling number.
-  magic_bonus: 25
+  # Percent scale (25 = +25%), matching MAGIC_MULT. Authored as a per-tier array
+  # even though there is one tier: only an array renders as a highlighted
+  # scaling value in the hover (SynergyData._render), and a second tier must not
+  # require rewriting the desc (Director 2026-07-19).
+  magic_bonus: [25]
 # Literal % after the token: the :percent format multiplies by 100 (SynergyData),
 # which would render 2500%. The crit half grants the ABILITY only - it adds no
 # critical chance, and copy must not imply one (Director 2026-07-19).
 desc: "SpellCaster units draw deeper from the arcane, gaining +{magic_bonus}% Magic Attack, and their skills can now land critical hits."
+# Per-tier table line: the scaling stat only, matching Myth. The crit ability is
+# a one-off unlock, not a per-tier value, so it lives in desc and stays out of
+# this line (Director 2026-07-19).
 tier_effects:
-  - "+{magic_bonus}% Magic Attack, skills can critically strike"
+  - "+{magic_bonus}% Magic Attack"

--- a/resources/database/synergy/spellcaster.yaml
+++ b/resources/database/synergy/spellcaster.yaml
@@ -1,11 +1,11 @@
 id: spellcaster
-# Load-bearing: UISynergy resolves the panel icon as display_name.to_lower(),
-# so "Spell Caster" would miss spellcaster.png and fall back to the grey default.
-name: "SpellCaster"
+# Player-facing wording, free to reword: id resolution and the icon filename
+# both key off TowerTrait.name_key, which strips spaces and underscores.
+name: "Spell Caster"
 kind: class
 type: normal
 effect: magic_up_skill_crit
-# Single tier by design: 2 of the 3 demo SpellCasters (Gura / Ina'nis / Bettel)
+# Single tier by design: 2 of the 3 demo Spell Casters (Gura / Ina'nis / Bettel)
 # is already a real deck commitment, and the bonus does not scale past it.
 thresholds: [2]
 parameters:
@@ -17,7 +17,7 @@ parameters:
 # Literal % after the token: the :percent format multiplies by 100 (SynergyData),
 # which would render 2500%. The crit half grants the ABILITY only - it adds no
 # critical chance, and copy must not imply one (Director 2026-07-19).
-desc: "SpellCaster units draw deeper from the arcane, gaining +{magic_bonus}% Magic Attack, and their skills can now land critical hits."
+desc: "Spell Caster units draw deeper from the arcane, gaining +{magic_bonus}% Magic Attack, and their skills can now land critical hits."
 # Per-tier table line: the scaling stat only, matching Myth. The crit ability is
 # a one-off unlock, not a per-tier value, so it lives in desc and stays out of
 # this line (Director 2026-07-19).

--- a/resources/database/synergy/spellcaster.yaml
+++ b/resources/database/synergy/spellcaster.yaml
@@ -1,0 +1,20 @@
+id: spellcaster
+# Load-bearing: UISynergy resolves the panel icon as display_name.to_lower(),
+# so "Spell Caster" would miss spellcaster.png and fall back to the grey default.
+name: "SpellCaster"
+kind: class
+type: normal
+effect: magic_up_skill_crit
+# Single tier by design: 2 of the 3 demo SpellCasters (Gura / Ina'nis / Bettel)
+# is already a real deck commitment, and the bonus does not scale past it.
+thresholds: [2]
+parameters:
+  # Percent scale (25 = +25%), matching MAGIC_MULT. Scalar, not an array: the
+  # value does not scale by tier, so it must not render as a tier-scaling number.
+  magic_bonus: 25
+# Literal % after the token: the :percent format multiplies by 100 (SynergyData),
+# which would render 2500%. The crit half grants the ABILITY only - it adds no
+# critical chance, and copy must not imply one (Director 2026-07-19).
+desc: "SpellCaster units draw deeper from the arcane, gaining +{magic_bonus}% Magic Attack, and their skills can now land critical hits."
+tier_effects:
+  - "+{magic_bonus}% Magic Attack, skills can critically strike"

--- a/resources/database/synergy/synergy_list.yaml
+++ b/resources/database/synergy/synergy_list.yaml
@@ -4,7 +4,6 @@
 synergies:
   - myth
   - assassin
-  - diva
   - hero
-  - gen1
+  - spellcaster
   - tempus

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -96,9 +96,11 @@ evolutionStat:
 # Evolved Active Skill - the game's first "channel" pattern skill: Ina'nis
 # locks the 3x3 zone in front of her and strikes it 12 times over 3 seconds
 # (every 0.25s), stunning enemies caught inside on every strike. She is busy
-# for the whole channel (no auto-attack). The ticks NEVER crit by design;
-# the evolved BASE stat keeps critChance 50 for her normal attacks
-# (stat-consistency verdict, Director 2026-07-14).
+# for the whole channel (no auto-attack). The ticks do not crit on their own
+# (can_crit: false below); the evolved BASE stat keeps critChance 50 for her
+# normal attacks (stat-consistency verdict, Director 2026-07-14). Superseded in
+# part 2026-07-19: the SpellCaster synergy opens this gate for its holders, so
+# the ticks DO crit while that trait is active - intended, do not re-block it.
 evolution_skills:
   active:
     name: "Book of Ancient Ones"
@@ -141,7 +143,7 @@ evolution_skills:
           animation: "skill"
           damage_multiplier_param_name: "tickDamage"
           damage_type: magic
-          can_crit: false            # channel ticks never crit (base-stat crit stays for normal attacks)
+          can_crit: false            # ticks do not crit on their own; the SpellCaster synergy overrides this gate for holders
           effects:
             - effect: "stun"
               duration_param: "tickStun"

--- a/scripts/entity/tower/tower_trait.gd
+++ b/scripts/entity/tower/tower_trait.gd
@@ -12,7 +12,7 @@ const TOWER_CLASS_NAMES := {
 	TowerClass.King: "King",
 	TowerClass.Marksman: "Marksman",
 	TowerClass.Robotic: "Robotic",
-	TowerClass.SpellCaster: "SpellCaster",
+	TowerClass.SpellCaster: "Spell Caster",
 	TowerClass.Warrior: "Warrior",
 }
 
@@ -23,6 +23,13 @@ const TOWER_GENERATION_NAMES := {
 	TowerGeneration.Gen1: "Gen1",
 	TowerGeneration.Indo1: "Indo1",
 }
+
+# Match key for a trait display name. Display names are player-facing and may
+# carry spaces or underscores ("Spell Caster"); every identity comparison - YAML
+# id resolution, icon filenames - runs through here so a copy rename never
+# breaks a lookup. Renaming a display name must NOT change this key.
+static func name_key(display_name: String) -> String:
+	return display_name.to_lower().replace(" ", "").replace("_", "")
 
 # Trait counts on the field, keyed by synergy id (TowerClass / TowerGeneration int).
 var current_counts: Dictionary = {}

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -44,12 +44,22 @@ static func loadImage(group, key, path):
 
 	return texture
 
+# Icon for a synergy display name, already falling back to the grey placeholder.
+# The cache key comes from TowerTrait.name_key (the one identity rule), so the
+# asset filename stays spellcaster.png no matter how the display name is worded.
+# Preload and lookup MUST both go through it or a rename silently drops the icon.
+static func getSynergySprite(display_name: String):
+	var sprite = getSprite("synergy", TowerTrait.name_key(display_name))
+	if sprite == null:
+		sprite = getSprite("synergy", "default")
+	return sprite
+
 static func preloadSynergy():
 	var synergyList = TowerTrait.TOWER_CLASS_NAMES.values() + TowerTrait.TOWER_GENERATION_NAMES.values();
 	var statuses = ["", "_active"];
 	for synergy in synergyList:
 		for status in statuses:
-			var key = synergy.to_lower() + status;
+			var key = TowerTrait.name_key(synergy) + status;
 			var path = "ui_asset/synergies/" + key + ".png"
 			loadImage("synergy", key, path)
 	# Fallback icon has no active state; load it once outside the status loop.

--- a/scripts/skill/skillActions/skill_action_attack.gd
+++ b/scripts/skill/skillActions/skill_action_attack.gd
@@ -80,7 +80,11 @@ func execute(context: SkillContext):
 
 	# Cache crit context (avoid recomputing per-target)
 	var stat = tower.data.getStat()
-	var critChance: float = tower.data.getCritChance() if canCrit else 0.0
+	# The authored canCrit gate can be opened from outside by the SpellCaster
+	# synergy marker (tower_synergy.md). It unlocks the roll only - the synergy
+	# grants no crit chance, so a 0-chance holder still never crits.
+	var critAllowed: bool = canCrit or tower.data.effects.stacks_of("spellcaster_crit") > 0
+	var critChance: float = tower.data.getCritChance() if critAllowed else 0.0
 	var sigmaCD: float = stat.critMultiplier + tower.data.effects.aggregate(EffectTypes.Kind.CRIT_DAMAGE_BONUS)
 
 	# Apply damage: per (hit, target) — each crit roll independent
@@ -91,7 +95,7 @@ func execute(context: SkillContext):
 				continue
 			# randi_range(1, 100) → 100 values for exact critChance/100 probability (§6.2 #1 fix)
 			# forcedCrit overrides the roll (guaranteed crit, e.g. Altare beat 2).
-			var isCrit: bool = forcedCrit or (canCrit and critChance > 0 and randi_range(1, 100) <= critChance)
+			var isCrit: bool = forcedCrit or (critAllowed and critChance > 0 and randi_range(1, 100) <= critChance)
 			var hitDamage: float = hitBase
 			if isCrit:
 				# §5: Critical Damage = 1 + (1 × (ΣCD − 1)) = ΣCD

--- a/scripts/synergy/synergy_data_loader.gd
+++ b/scripts/synergy/synergy_data_loader.gd
@@ -68,8 +68,10 @@ static func _resolve_synergy_id(kind: String, id: String) -> int:
 			push_error("SynergyDataLoader: unknown kind '" + kind + "' for id '" + id + "'")
 			return 0
 
-	var target := id.to_lower()
+	# Compare through TowerTrait.name_key so a display-name rename ("SpellCaster"
+	# -> "Spell Caster") cannot break id resolution.
+	var target := TowerTrait.name_key(id)
 	for key in table.keys():
-		if str(table[key]).to_lower() == target:
+		if TowerTrait.name_key(str(table[key])) == target:
 			return key
 	return 0

--- a/scripts/synergy/synergy_effect.gd
+++ b/scripts/synergy/synergy_effect.gd
@@ -49,6 +49,8 @@ static func create(effect_key: String) -> SynergyEffect:
 			return SynergyEffectQuestTempus.new()
 		"attack_per_active_trait":
 			return SynergyEffectAttackPerTrait.new()
+		"magic_up_skill_crit":
+			return SynergyEffectSpellcaster.new()
 		"", "none":
 			return null   # placeholder synergy: declared but no effect handler yet
 		_:

--- a/scripts/synergy/synergy_effect_spellcaster.gd
+++ b/scripts/synergy/synergy_effect_spellcaster.gd
@@ -1,0 +1,42 @@
+class_name SynergyEffectSpellcaster
+extends SynergyEffect
+
+# SpellCaster - the first synergy that grants an ABILITY, not only a number:
+# holders get +magic_bonus% Magic Attack AND their skills are allowed to roll
+# critical hits. It deliberately grants NO critical chance (Director 2026-07-19),
+# so a holder sitting at 0 chance still never crits; the gate only stops being
+# the limiting factor. Do not "fix" this by adding crit_chance_up.
+#
+# Two effects share one source_id: EffectInstance.key() is source_id + "/" + id,
+# so the keys stay distinct. Both are REFRESH, so the per-placement re-apply
+# overwrites instead of stacking.
+
+const _SOURCE := "synergy_spellcaster"
+
+func activate() -> void:
+	_apply_all()
+
+# Fires for every placement. A SpellCaster placed after the trait activates must
+# still receive both effects, and re-applying to existing holders is idempotent.
+func on_tower_added(_tower) -> void:
+	_apply_all()
+
+func _apply_all() -> void:
+	var bonus = data.get_parameter("magic_bonus", 0)
+	if bonus == null:
+		return
+	for tower in controller.towers_with(data.synergy_id):
+		if not is_instance_valid(tower):
+			continue
+		_apply(tower, "magic_mult_up", float(bonus))
+		_apply(tower, "spellcaster_crit", 1.0)
+
+# Lifetime and duration are set explicitly: a registry def is WAVE with a
+# non-zero duration by default, both wrong for a permanent synergy buff (same
+# trap as synergy_effect_attack_per_trait.gd / synergy_effect_quest_tempus.gd).
+func _apply(tower, effect_id: String, value: float) -> void:
+	var inst := EffectUtility.make_instance(effect_id, _SOURCE, value, 0.0)
+	if inst == null:
+		return
+	inst.lifetime = EffectTypes.Lifetime.BOARD
+	tower.apply_effect(inst)

--- a/scripts/ui/synergy/ui_synergy.gd
+++ b/scripts/ui/synergy/ui_synergy.gd
@@ -30,9 +30,7 @@ func updateSynergy(synergyName: String, count: int, tier: int, synergy_id: int) 
 		add_child(content)
 		content.setOrder(_nextOrder)   # frozen once at creation; never rewritten
 		_nextOrder += 1
-	var icon = ResourceManager.getSprite("synergy", synergyName.to_lower());
-	if(icon == null):
-		icon = ResourceManager.getSprite("synergy", "default");
+	var icon = ResourceManager.getSynergySprite(synergyName);
 	content.setup(synergyName, count, tier, icon, ResourceManager.getSynergyData(synergy_id))
 	_reflow()
 

--- a/scripts/ui/tower_select/tower_select_button.gd
+++ b/scripts/ui/tower_select/tower_select_button.gd
@@ -35,16 +35,12 @@ func Setup(p_name: String, sprite, towerClass: TowerTrait.TowerClass, towerGen: 
 	synergiesNode.visible = TowerTrait.TOWER_CLASS_NAMES.has(towerClass) or TowerTrait.TOWER_GENERATION_NAMES.has(towerGen)
 	if !synergiesNode.visible:
 		return
-	# Display names feed both the sprite key (lowered) and the hover fallback,
-	# which must stay player-facing case ("SpellCaster", not "spellcaster").
+	# Display names stay player-facing and may contain spaces ("Spell Caster");
+	# the sprite key is normalised by ResourceManager, never by the caller.
 	var classDisplayName = TowerTrait.TOWER_CLASS_NAMES.get(towerClass, "default");
 	var genDisplayName = TowerTrait.TOWER_GENERATION_NAMES.get(towerGen, "default");
-	var classSprite = ResourceManager.getSprite("synergy", classDisplayName.to_lower());
-	if(classSprite == null):
-		classSprite = ResourceManager.getSprite("synergy", "default");
-	var genSprite = ResourceManager.getSprite("synergy", genDisplayName.to_lower());
-	if(genSprite == null):
-		genSprite = ResourceManager.getSprite("synergy", "default");
+	var classSprite = ResourceManager.getSynergySprite(classDisplayName);
+	var genSprite = ResourceManager.getSynergySprite(genDisplayName);
 	if(towerClassImage):
 		towerClassImage.texture = classSprite
 		towerClassImage.set_synergy(towerClass, classDisplayName)

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -189,10 +189,7 @@ func _make_skill_icon(skill: Skill, kind: String, level: int) -> TowerSkillIcon:
 	return icon
 
 func _trait_sprite(trait_display: String) -> Texture2D:
-	var sprite = ResourceManager.getSprite("synergy", trait_display.to_lower())
-	if sprite == null:
-		sprite = ResourceManager.getSprite("synergy", "default")
-	return sprite
+	return ResourceManager.getSynergySprite(trait_display)
 
 # Skip no-op text writes so per-frame polling doesn't churn label layout (PR #20 rule).
 func _set_text(label: Label, value: String) -> void:


### PR DESCRIPTION
**Summary:** Adds the Spell Caster trait synergy (threshold 2, single tier): holders gain +25% Magic Attack and their skills are unlocked to roll critical hits. Also removes two dead placeholder synergies and fixes a display-name trap that silently dropped trait icons.

**How it works:** Data-driven like the existing synergies - `spellcaster.yaml` plus one `SynergyEffect` subclass registered in the factory. The effect applies two BOARD-lifetime effects under one `source_id`: `magic_mult_up` for the stat, and a new `spellcaster_crit` mark that acts as a capability flag. `SkillActionAttack` ORs that flag with its authored `can_crit`, which covers the `attack`, `channel`, `aftershock`, and `field` patterns at once since each builds an inner attack action.

Extension point: any future synergy that needs to unlock a skill capability can reuse the mark-as-flag shape rather than adding a stat kind.

**Implementation Notes:**
- The crit half is a GATE, not a chance (Director decision). It grants no critical chance, so a holder at 0 chance still never crits. Decided with the numbers in hand: every unit sits at `critChance: 0` until evolution, so in the demo this is visible only on Ina'nis's evolved channel. Director will retune after the demo - please do not "fix" it by adding `crit_chance_up`.
- Two structural gaps were found and deliberately left out of scope: `can_crit` defaults to `true` (inverting the Director's opt-in rule), and skill projectile actions never roll crit at all (Gura, Kiara's Hinotori). Both are recorded for a follow-up session; the second is also noted in the damage-formula doc.
- The icon fix is the reason for the wider diff. Renaming the trait to "Spell Caster" silently dropped its icon, because the icon cache key was the display name lowercased. There is now one identity rule (`TowerTrait.name_key`, strips spaces and underscores) shared by icon preload, every icon lookup, and synergy YAML id resolution, so player-facing wording can change freely. The repeated null-then-default icon fallback folded into `ResourceManager.getSynergySprite`.
- `diva.yaml` and `gen1.yaml` are deleted as dead data - no tower carries either trait, so their panel rows could never render. This does NOT reduce the existing missing-icon warnings: that preload iterates the trait enum, not the synergy manifest.

**Touched scenes:** none
