### PR TITLE
Remove unused synergy traits and realign a stale asset UID

### DIFF
--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -1,6 +1,6 @@
 maxLevel: 3 # tower max level
-towerClass: diva # tower class (Assassin, Diva, Hero, King, Marksman, Robotic, SpellCaster, Warrior)
-generation: tempus # tower generation (Myth, Tempus, Gen0, Gen1, Indo1)
+towerClass: warrior # tower class (Assassin, Hero, Marksman, Robotic, SpellCaster, Warrior)
+generation: tempus # tower generation (Myth, Tempus)
 attackType: physic # physic | magic (1 tower 1 type ตาม design)
 evolutionCost: 1 # ค่า evolution
 

--- a/resources/ui_component/tower_select/ui_tower_choice.tscn
+++ b/resources/ui_component/tower_select/ui_tower_choice.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="FontFile" uid="uid://scv78fddnukv" path="res://resources/ui_component/font/Roboto-Regular.ttf" id="2_oispt"]
 [ext_resource type="Texture2D" uid="uid://tp6ecjda00qg" path="res://resources/currency/evo_token.png" id="3_lbarx"]
 [ext_resource type="Shader" path="res://resources/ui_component/tower_select/ui_tower_choice_trait.gdshader" id="5_kba5i"]
-[ext_resource type="Texture2D" uid="uid://6gly0rw52dyf" path="res://resources/ui_asset/synergies/assassin.png" id="7_681fe"]
+[ext_resource type="Texture2D" uid="uid://c0jbigvnx7ja4" path="res://resources/ui_asset/synergies/assassin.png" id="7_681fe"]
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_wd61a"]
 resource_name = "tower_buttons"

--- a/scripts/entity/tower/tower_trait.gd
+++ b/scripts/entity/tower/tower_trait.gd
@@ -1,15 +1,13 @@
 class_name TowerTrait
 
 # Enums with offset to avoid collision
-enum TowerClass { Assassin = 100, Diva, Hero, King, Marksman, Robotic, SpellCaster, Warrior }
-enum TowerGeneration { Myth = 200, Tempus, Gen0, Gen1, Indo1 }
+enum TowerClass { Assassin = 100, Hero, Marksman, Robotic, SpellCaster, Warrior }
+enum TowerGeneration { Myth = 200, Tempus }
 
 # Display Names
 const TOWER_CLASS_NAMES := {
 	TowerClass.Assassin: "Assassin",
-	TowerClass.Diva: "Diva",
 	TowerClass.Hero: "Hero",
-	TowerClass.King: "King",
 	TowerClass.Marksman: "Marksman",
 	TowerClass.Robotic: "Robotic",
 	TowerClass.SpellCaster: "Spell Caster",
@@ -19,9 +17,6 @@ const TOWER_CLASS_NAMES := {
 const TOWER_GENERATION_NAMES := {
 	TowerGeneration.Myth: "Myth",
 	TowerGeneration.Tempus: "Tempus",
-	TowerGeneration.Gen0: "Gen0",
-	TowerGeneration.Gen1: "Gen1",
-	TowerGeneration.Indo1: "Indo1",
 }
 
 # Match key for a trait display name. Display names are player-facing and may


### PR DESCRIPTION
**Summary:** Clears the two sources of load-time log noise around trait icons: the trait taxonomy no longer declares members with no demo content, and one scene's stale asset UID is realigned. No player-facing behaviour changes.

**How it works:** `ResourceManager.preloadSynergy` builds its icon request list from the `TowerTrait` display-name tables, not from the synergy manifest or the loaded deck, so every declared trait is requested whether or not art exists. `Gen0`, `Gen1`, and `Indo1` were never drawn, producing 6 `Missing texture` warnings per `addDeck` call. Shrinking the tables fixes it at the source - no new gating branch, and the fail-loud loader policy stays intact. `Diva` and `King` go with them: no tower carries either, neither has synergy data, and a dead taxonomy entry misleads. Their artist icons stay in the repo, so re-adding either when the trait is really built is a one-line change. The second commit points `ui_tower_choice.tscn` at the current `assassin.png` UID.

**Implementation Notes:**
- Removing enum members shifts the implicit ints (`Hero` 102->101 ... `Warrior` 107->105). Nothing persists them on a live path: tower traits resolve from YAML strings via `Utility.parse_string_to_enum`, synergy ids resolve by name through `TowerTrait.name_key`, and icon cache keys are name-derived. The only raw ints live in `resources/tower/data/takanashi_kiara_data.tres` and `gawr_gura_data.tres`, both unreferenced and already awaiting your confirmation to delete - they are now doubly stale (`101` reads as Hero, `107` is out of range). Delete them, do not revive.
- `default_tower.yaml` carried `towerClass: diva` and IS loaded every run (`game_scene.gd`), so it moves to `warrior`; leaving it would have traded 6 warnings for a fresh parse error.
- UID cause: `3ac5b35` re-imported the synergy icons and minted fresh UIDs in the `.import` sidecars, but this scene hardcodes `assassin.png` and kept the old one. Same churn PR #69 fixed at the root; sidecars are tracked, so `.import` is the source of truth and the scene follows it. All 109 `ext_resource` UID references were swept - this was the only mismatch.
- The sweep also surfaced two dangling resource paths, both inside files already logged as dead and pending your confirmation (`map_generator.tscn` -> a missing tile png, `gawr_gura_data.tres` -> a missing skill `.tres`). Left untouched.
- Tested in Godot against a tree identical to current `main` plus these two commits (this branch was cut from the PR #110 tip, which has since merged unchanged), so the test pass still stands.

**Touched scenes:** `resources/ui_component/tower_select/ui_tower_choice.tscn`
