### PR TITLE
Marksman synergy: damage scales with distance to target

### DIFF
--- a/resources/database/effect/effects.yaml
+++ b/resources/database/effect/effects.yaml
@@ -109,6 +109,22 @@ spellcaster_crit:
   duration: 0
   lifetime: board
 
+# Marksman synergy rate. The value is NOT an amplifier - it is the percent
+# granted PER CELL of distance to the target. TowerData.getDistanceAmp reads the
+# aggregate at each attack and turns it into a real amp; a per-target term cannot
+# be stored as a flat stat. Kept out of damage_amp on purpose: that kind is the
+# flat amplifier and would apply at full value regardless of range.
+marksman_range:
+  name: "Long Shot"
+  desc: "Deals more damage the farther the target."
+  icon: "ui_asset/effects/buff_generic.png"
+  category: buff
+  host: tower
+  kind: damage_amp_per_cell
+  stack: refresh
+  duration: 0
+  lifetime: board
+
 crit_damage_up:
   name: "Critical Damage Up"
   desc: "Critical damage increased by {value}."

--- a/resources/database/synergy/marksman.yaml
+++ b/resources/database/synergy/marksman.yaml
@@ -1,0 +1,20 @@
+id: marksman
+name: "Marksman"
+kind: class
+type: normal
+effect: damage_per_range
+# Single tier: both demo Marksmen (Watson Amelia / Josuiji Shinri) are needed to
+# reach it, so there is no second breakpoint to define yet.
+thresholds: [2]
+parameters:
+  # Percent granted per CELL of distance to the target, not a flat amplifier.
+  # Authored as a per-tier array even with one tier: only an array renders as a
+  # highlighted scaling value in the hover (SynergyData._render), and a second
+  # tier must not require rewriting the desc.
+  amp_per_cell: [5]
+# Literal % after the token: the :percent format multiplies by 100. Say "of
+# distance to", never "between them and" - at one cell apart there are zero
+# tiles "between" but the bonus is already +5%.
+desc: "Marksman units steady their aim across the field, dealing {amp_per_cell}% more damage for every tile of distance to their target."
+tier_effects:
+  - "+{amp_per_cell}% damage per tile of distance"

--- a/resources/database/synergy/synergy_list.yaml
+++ b/resources/database/synergy/synergy_list.yaml
@@ -5,5 +5,6 @@ synergies:
   - myth
   - assassin
   - hero
+  - marksman
   - spellcaster
   - tempus

--- a/scripts/combat/damage.gd
+++ b/scripts/combat/damage.gd
@@ -11,6 +11,20 @@ var damage: int;
 var type: DamageType
 var isCritical: bool = false;
 
+# Source-side amplifier snapshot, decimal (0.25 = +25%). Taken at FIRE time and
+# summed into ΣAmp by Enemy.recvDamage, so it rides the amplifier position of the
+# Master Formula and TRUE damage still bypasses it. Frozen on purpose: a
+# projectile carries this value through its whole flight, and every enemy a
+# piercing shot passes through takes the value derived from the ORIGINAL target
+# (Marksman synergy - tower_synergy.md).
+var sourceAmp: float = 0.0
+
+# True when a skill authored this damage. Kill attribution reads this instead of
+# inferring "not a skill" from a missing source (PassiveSoulHarvest); the old
+# inference relied on normal attacks failing to stamp their source, which was a
+# bug, not a design.
+var isSkillDamage: bool = false
+
 func _init(p_source: Node2D, amount: int, p_type: DamageType, p_isCritical: bool = false):
 	self.source = p_source;
 	self.damage = amount;

--- a/scripts/effect/effect_types.gd
+++ b/scripts/effect/effect_types.gd
@@ -10,6 +10,7 @@ class_name EffectTypes
 #   ARMOR_MULT / MARMOR_MULT            decimal (0.05 = +5%)
 #   CRIT_CHANCE                         percent points
 #   DAMAGE_AMPLIFIER / DAMAGE_REDUCTION decimal
+#   DAMAGE_AMP_PER_CELL                 percent per cell of attacker-to-target distance
 #   *_FLAT / RANGE / MANA_REGEN / MOVE_SPEED_FLAT  flat additive
 enum Kind {
 	ATTACK_SPEED,
@@ -34,6 +35,10 @@ enum Kind {
 	MARK_ONLY,
 	INVINCIBLE,
 	HOT,
+	# Per-attack, per-target amplifier: aggregate() yields the percent granted per
+	# cell of distance; the attack site turns it into a real amp via
+	# TowerData.getDistanceAmp (Marksman synergy - tower_synergy.md).
+	DAMAGE_AMP_PER_CELL,
 }
 
 enum Category { BUFF, DEBUFF, MARK }
@@ -72,6 +77,7 @@ const KIND_FROM_STRING := {
 	"mark": Kind.MARK_ONLY,
 	"invincible": Kind.INVINCIBLE,
 	"hot": Kind.HOT,
+	"damage_amp_per_cell": Kind.DAMAGE_AMP_PER_CELL,
 }
 
 const CATEGORY_FROM_STRING := {
@@ -91,7 +97,10 @@ const LIFETIME_FROM_STRING := {
 }
 
 static func is_stat_kind(kind: int) -> bool:
-	return kind < Kind.STUN
+	# The `< STUN` range test only works for kinds declared before the behavior
+	# block; kinds appended after HOT must be listed explicitly (the enum is
+	# append-only, so the block cannot be re-sorted).
+	return kind < Kind.STUN or kind == Kind.DAMAGE_AMP_PER_CELL
 
 # Decimal-scale kinds display as percent (0.5 -> "50%"); percent-scale kinds
 # append % directly; flats show the plain number. Used by the {value} desc

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -174,11 +174,14 @@ func recvDamage(damage: Damage) -> int:
 				defense_factor = stats.getArmorFactor()
 
 		# Master Formula §2 final pipeline: × armor_factor × (1 + ΣAmp) × (1 − ΣRed)
-		var sigmaAmp: float = 0.0
+		# Two additive sources: the attacker's flat DAMAGE_AMPLIFIER stat, plus any
+		# per-attack amp the source snapshotted at fire time (e.g. Marksman's
+		# distance bonus, which cannot be a stored stat because it differs per target).
+		var sigmaAmp: float = damage.sourceAmp
 		if damage.source != null and damage.source is Tower:
 			var towerData: TowerData = (damage.source as Tower).data
 			if towerData != null:
-				sigmaAmp = towerData.effects.aggregate(EffectTypes.Kind.DAMAGE_AMPLIFIER)
+				sigmaAmp += towerData.effects.aggregate(EffectTypes.Kind.DAMAGE_AMPLIFIER)
 
 		var sigmaRed: float = stats.getDamageReduction()  # already clamped; blocks consumed above
 		damageVal = int(damage.damage * defense_factor * (1.0 + sigmaAmp) * (1.0 - sigmaRed))

--- a/scripts/entity/tower/tower_data.gd
+++ b/scripts/entity/tower/tower_data.gd
@@ -79,10 +79,10 @@ func getDamage(enemy: Enemy, source: Node2D) -> Damage:
 	if(enemy == null):
 		return Damage.new(source, getTotalAttack(), attackType);
 
-	var finalDamage = calculateFinalDamage(getTotalAttack(), enemy);
+	var finalDamage = calculateFinalDamage(getTotalAttack(), enemy, source);
 	return finalDamage;
 
-func calculateFinalDamage(baseDamage: float, enemy: Enemy) -> Damage:
+func calculateFinalDamage(baseDamage: float, enemy: Enemy, source: Node2D = null) -> Damage:
 	var finalDamage = baseDamage
 
 	# Apply each modifier in the array
@@ -96,7 +96,33 @@ func calculateFinalDamage(baseDamage: float, enemy: Enemy) -> Damage:
 	var critCheck: float = 1.0 if isCrit else 0.0
 	finalDamage *= 1.0 + (critCheck * (sigmaCD - 1.0))
 
-	return Damage.new(null, int(finalDamage), attackType, isCrit)
+	# `source` used to be dropped here, which left ΣAmp unreachable for normal
+	# attacks (Enemy.recvDamage resolves the attacker through it). Keep it stamped.
+	var dmg := Damage.new(source, int(finalDamage), attackType, isCrit)
+	dmg.sourceAmp = getDistanceAmp(source, enemy)
+	return dmg
+
+# Per-attack amplifier that scales with how far the target is (Marksman synergy).
+# Distance is measured at FIRE time against the enemy being aimed at (Director
+# 2026-07-20) - a projectile then carries the result unchanged through its
+# flight, and a piercing shot gives every enemy it passes through the value
+# derived from the original target.
+#
+# Rounded to the nearest whole cell: round() maps a centre-to-centre distance
+# onto the ring the enemy is standing in almost exactly, which is what makes
+# "per tile" honest. Returns a decimal amp (0.25 = +25%) that Enemy.recvDamage
+# sums into ΣAmp, so TRUE damage stays exempt.
+func getDistanceAmp(attacker: Node2D, enemy: Enemy) -> float:
+	var perCell: float = effects.aggregate(EffectTypes.Kind.DAMAGE_AMP_PER_CELL)
+	if perCell <= 0.0:
+		return 0.0
+	if attacker == null or enemy == null:
+		return 0.0
+	if not is_instance_valid(attacker) or not is_instance_valid(enemy):
+		return 0.0
+	var px: float = attacker.global_position.distance_to(enemy.global_position)
+	var cells: float = round(px / float(GridHelper.CELL_SIZE))
+	return cells * perCell / 100.0
 
 func getAttackRange():
 	return getStat().attackRange + effects.aggregate(EffectTypes.Kind.RANGE)

--- a/scripts/skill/passive/passive_crit_pierce.gd
+++ b/scripts/skill/passive/passive_crit_pierce.gd
@@ -85,6 +85,10 @@ func _fire_arrow(target: Enemy) -> void:
 	var crit_damage: float = tower.data.getCritDamage() + _bonus_for_level()
 	var value: int = int(tower.data.getTotalAttack() * crit_damage)
 	var dmg := Damage.new(tower, value, tower.data.attackType, true)
+	# One Damage is shared by every enemy the arrow pierces, so the distance amp is
+	# taken once from the locked target - all victims take the same number by design.
+	# isSkillDamage stays false: this replaces a normal attack, it is not a skill.
+	dmg.sourceAmp = tower.data.getDistanceAmp(tower, target)
 
 	var direction: Vector2 = (target.global_position - tower.global_position).normalized()
 	var lifetime: float = arrow_range / arrow_speed if arrow_speed > 0.0 else 1.0

--- a/scripts/skill/passive/passive_soul_harvest.gd
+++ b/scripts/skill/passive/passive_soul_harvest.gd
@@ -2,10 +2,11 @@ class_name PassiveSoulHarvest
 extends RefCounted
 
 # Soul-harvest passive (Mori Calliope): +soulsPerKill Soul per enemy KILLED BY
-# HER SKILLS. Attribution: skill attacks (including the aftershock's inner
-# attack) stamp Damage.source = the casting tower, while normal hitscan
-# attacks stamp null (tower_data.calculateFinalDamage), so
-# cause.source == tower is exact skill-kill attribution for this kit.
+# HER SKILLS. Attribution needs BOTH gates: cause.source == tower (this tower
+# landed it) AND cause.isSkillDamage (a skill authored it, including the
+# aftershock's inner attack). Do not drop the isSkillDamage half - normal attacks
+# used to be excluded only because they failed to stamp a source at all, which
+# was a bug; once that was fixed they would otherwise start granting Souls.
 #
 # Souls are run-permanent by design (Director 2026-07-12): board lifetime, no
 # cap, kept across wave end AND evolve - reset() is deliberately a no-op (do
@@ -30,6 +31,8 @@ func _init(owner: Tower, params: Dictionary) -> void:
 
 func _on_enemy_dead(_enemy, cause: Damage, _reward) -> void:
 	if cause == null or not is_instance_valid(tower) or cause.source != tower:
+		return
+	if not cause.isSkillDamage:
 		return
 	for i in souls_per_kill:
 		var inst := EffectUtility.make_instance(SOUL_EFFECT, SOUL_SOURCE, 1.0, 0.0)

--- a/scripts/skill/skillActions/skill_action_attack.gd
+++ b/scripts/skill/skillActions/skill_action_attack.gd
@@ -100,7 +100,12 @@ func execute(context: SkillContext):
 			if isCrit:
 				# §5: Critical Damage = 1 + (1 × (ΣCD − 1)) = ΣCD
 				hitDamage *= sigmaCD
-			target.recvDamage(Damage.new(tower, int(hitDamage), dmgType, isCrit))
+			var dmg := Damage.new(tower, int(hitDamage), dmgType, isCrit)
+			dmg.isSkillDamage = true
+			# Each target is damaged through its own Damage, so each gets the amp
+			# for its own distance (the shared-value rule is a projectile concern).
+			dmg.sourceAmp = tower.data.getDistanceAmp(tower, target as Enemy)
+			target.recvDamage(dmg)
 
 	# Apply registry effects once per target after all hits land. instantiate()
 	# builds a fresh isolated instance and snapshots caster-side stats (e.g.

--- a/scripts/skill/skillActions/skill_action_attack_with_parameter.gd
+++ b/scripts/skill/skillActions/skill_action_attack_with_parameter.gd
@@ -11,5 +11,6 @@ func execute(context: SkillContext):
 	for target in context.target:
 		if is_instance_valid(target) && target.has_method("recvDamage"):
 			var finalDamage = tower.data.getDamage(target, context.user);
+			finalDamage.isSkillDamage = true;
 			finalDamage.damage *= damageMultiplier;
 			target.recvDamage(finalDamage);

--- a/scripts/skill/skillActions/skill_action_damage_percent_maxhp.gd
+++ b/scripts/skill/skillActions/skill_action_damage_percent_maxhp.gd
@@ -35,4 +35,6 @@ func execute(context: SkillContext):
 		if damage_amount <= 0:
 			continue
 
-		enemy.recvDamage(Damage.new(damage_source, damage_amount, Damage.DamageType.TRUE))
+		var dmg := Damage.new(damage_source, damage_amount, Damage.DamageType.TRUE)
+		dmg.isSkillDamage = true
+		enemy.recvDamage(dmg)

--- a/scripts/skill/skillActions/skill_create_circle_projectile.gd
+++ b/scripts/skill/skillActions/skill_create_circle_projectile.gd
@@ -14,5 +14,9 @@ func setupProjectile(projectile: Projectile, i: int, context: SkillContext):
 	var tower: Tower = context.user as Tower;
 	var multi = getDamageMultiplier(context)
 	projectile.scale = Vector2(projectile_size_w, projectile_size_h)
-	projectile.setup_circle(tower, Damage.new(tower, int(multi * tower.data.getDamage(null, null).damage), damageType), circle_radius, angular_speed, initial_angle + (angle_offset * i), lifetime, ProjectileCallback.new(Callable(self, "onHit"), Callable(), Callable()))
+	var damage := Damage.new(tower, int(multi * tower.data.getDamage(null, null).damage), damageType)
+	damage.isSkillDamage = true
+	# No sourceAmp: getDamage(null, null) has no target to measure against, so
+	# skill projectiles carry no distance bonus (gap noted in tower_synergy.md).
+	projectile.setup_circle(tower, damage, circle_radius, angular_speed, initial_angle + (angle_offset * i), lifetime, ProjectileCallback.new(Callable(self, "onHit"), Callable(), Callable()))
 	super.setupProjectile(projectile, i, context)

--- a/scripts/skill/skillActions/skill_create_directional_projectile.gd
+++ b/scripts/skill/skillActions/skill_create_directional_projectile.gd
@@ -20,6 +20,9 @@ func setupProjectile(projectile: Projectile, i: int, context: SkillContext):
 	var tower: Tower = context.user as Tower
 	var multi: float = getDamageMultiplier(context)
 	var damage: Damage = Damage.new(tower, int(multi * tower.data.getDamage(null, null).damage), damageType)
+	damage.isSkillDamage = true
+	# No sourceAmp: getDamage(null, null) has no target to measure against, so
+	# skill projectiles carry no distance bonus (gap noted in tower_synergy.md).
 
 	# Direction = from tower toward primary target. Prefer the first target
 	# picked by find_multi_enemy (closest-to-path-end after sorting). Fall

--- a/scripts/synergy/synergy_effect.gd
+++ b/scripts/synergy/synergy_effect.gd
@@ -51,6 +51,8 @@ static func create(effect_key: String) -> SynergyEffect:
 			return SynergyEffectAttackPerTrait.new()
 		"magic_up_skill_crit":
 			return SynergyEffectSpellcaster.new()
+		"damage_per_range":
+			return SynergyEffectMarksman.new()
 		"", "none":
 			return null   # placeholder synergy: declared but no effect handler yet
 		_:

--- a/scripts/synergy/synergy_effect_marksman.gd
+++ b/scripts/synergy/synergy_effect_marksman.gd
@@ -1,0 +1,45 @@
+class_name SynergyEffectMarksman
+extends SynergyEffect
+
+# Marksman - the first synergy whose bonus depends on the TARGET, not on the
+# board: holders deal amp_per_cell% extra damage per cell between them and what
+# they are shooting.
+#
+# It cannot be a plain stat buff. EffectContainer.aggregate() is one flat number
+# per tower with no target context, so what this effect grants is the RATE
+# (percent per cell); TowerData.getDistanceAmp turns that rate into a real
+# amplifier at each attack, and Enemy.recvDamage sums it into ΣAmp. That keeps
+# the bonus in the amplifier position of the Master Formula, so TRUE damage
+# still bypasses it (damage_formula.md).
+#
+# Distance is measured at fire time and rounded to the nearest whole cell
+# (Director 2026-07-20) - detail and rationale in tower_synergy.md Notes.
+
+const _SOURCE := "synergy_marksman"
+
+func activate() -> void:
+	_apply_all()
+
+# Fires for every placement: a Marksman placed after the trait activates must
+# still be tagged, and re-applying to existing holders is idempotent (REFRESH).
+func on_tower_added(_tower) -> void:
+	_apply_all()
+
+func _apply_all() -> void:
+	var per_cell = data.get_parameter("amp_per_cell", 0)
+	if per_cell == null:
+		return
+	for tower in controller.towers_with(data.synergy_id):
+		if not is_instance_valid(tower):
+			continue
+		_apply(tower, "marksman_range", float(per_cell))
+
+# Lifetime and duration are set explicitly: a registry def is WAVE with a
+# non-zero duration by default, both wrong for a permanent synergy buff (same
+# trap as synergy_effect_spellcaster.gd / synergy_effect_attack_per_trait.gd).
+func _apply(tower, effect_id: String, value: float) -> void:
+	var inst := EffectUtility.make_instance(effect_id, _SOURCE, value, 0.0)
+	if inst == null:
+		return
+	inst.lifetime = EffectTypes.Lifetime.BOARD
+	tower.apply_effect(inst)


### PR DESCRIPTION
**Summary:** Wires the Marksman trait (threshold 2 - Watson Amelia + Josuiji Shinri). Holders deal +5% damage per cell of distance to their target: the first synergy whose bonus depends on the target rather than the board, and the first live user of the damage formula's amplifier term.

**How it works:** The bonus cannot be a stored stat - `aggregate()` is one flat number per tower with no target context. So `marksman_range` carries the RATE (percent per cell) under a new `DAMAGE_AMP_PER_CELL` kind; `TowerData.getDistanceAmp` converts it per attack onto `Damage.sourceAmp`, and `Enemy.recvDamage` sums it into the amplifier term - which is what keeps TRUE damage exempt. Distance is centre-to-centre cells, rounded to nearest, snapshotted at fire time, so a projectile keeps one value for its whole flight and every enemy a piercing shot passes through takes the original target's number. Covers normal attacks, skill attacks (`attack`/`channel`/`aftershock`/`field`), and Shinri's pierce arrow.

**Findings:**
- Normal attacks were dropping the attacker reference, leaving the amplifier term dead on exactly the path this feature needs. Pre-existing, found while tracing. Director: fix here rather than split.
- Mori Calliope depended on that bug - Soul Harvest used "damage has no attacker" as its skill-vs-normal test, so fixing the reference alone would have silently granted Souls on normal-attack kills. Attribution moved to an explicit `isSkillDamage` flag; her behavior is unchanged and was regression-tested in engine. Highest-risk part of this PR.
- Tower detection reaches half a cell past the authored `attackRange` and triggers on the enemy's hitbox edge, so a thin outer band rounds up one tile (Amelia 30% against a nominal 25%). Assessed as a deliberate boundary guard, not a bug. Director: leave it, ship with no cap.
- Skill projectile actions get no distance bonus - they build damage with no target to measure. No Marksman owns one, and those actions already cannot crit. Left alone; recorded in `tower_synergy.md` so both are fixed together.

**Implementation Notes:** `DAMAGE_AMP_PER_CELL` is appended to `EffectTypes.Kind`, which put it outside the `is_stat_kind` range test - dead code today, corrected rather than left silently wrong. Director decisions (rounding, fire-time, no cap) are in `tower_synergy.md` Notes; the attribution lesson in `damage_formula.md` Problems; the rate-kind pattern in `buff_debuff.md`. `skill_action_attack_with_parameter.gd` is dead code (no factory arm, no YAML reference) - kept consistent here, worth deleting separately.
