### PR TITLE
Synergy panel row order + unique rarity axis

### DIFF
--- a/resources/database/synergy/assassin.yaml
+++ b/resources/database/synergy/assassin.yaml
@@ -1,7 +1,7 @@
 id: assassin
 name: "Assassin"
 kind: class
-type: normal
+type: standard
 rarity: common
 # Placeholder: thresholds carried from the old hardcoded table for UI counting.
 # Effect not wired yet - Director defines it when Assassin enters scope.

--- a/resources/database/synergy/assassin.yaml
+++ b/resources/database/synergy/assassin.yaml
@@ -2,6 +2,7 @@ id: assassin
 name: "Assassin"
 kind: class
 type: normal
+rarity: common
 # Placeholder: thresholds carried from the old hardcoded table for UI counting.
 # Effect not wired yet - Director defines it when Assassin enters scope.
 effect: none

--- a/resources/database/synergy/hero.yaml
+++ b/resources/database/synergy/hero.yaml
@@ -1,7 +1,7 @@
 id: hero
 name: "Hero"
 kind: class
-type: normal
+type: standard
 # Only Regis Altare carries the Hero class, so the trait is unique: the panel
 # gives it its own colour and floats it above every common synergy.
 rarity: unique

--- a/resources/database/synergy/hero.yaml
+++ b/resources/database/synergy/hero.yaml
@@ -2,6 +2,9 @@ id: hero
 name: "Hero"
 kind: class
 type: normal
+# Only Regis Altare carries the Hero class, so the trait is unique: the panel
+# gives it its own colour and floats it above every common synergy.
+rarity: unique
 effect: attack_per_active_trait
 # Single tier by design: one Hero unit activates the trait, and the bonus scales
 # with the rest of the board instead of with the Hero count.

--- a/resources/database/synergy/marksman.yaml
+++ b/resources/database/synergy/marksman.yaml
@@ -1,7 +1,7 @@
 id: marksman
 name: "Marksman"
 kind: class
-type: normal
+type: standard
 rarity: common
 effect: damage_per_range
 # Single tier: both demo Marksmen (Watson Amelia / Josuiji Shinri) are needed to

--- a/resources/database/synergy/marksman.yaml
+++ b/resources/database/synergy/marksman.yaml
@@ -2,6 +2,7 @@ id: marksman
 name: "Marksman"
 kind: class
 type: normal
+rarity: common
 effect: damage_per_range
 # Single tier: both demo Marksmen (Watson Amelia / Josuiji Shinri) are needed to
 # reach it, so there is no second breakpoint to define yet.

--- a/resources/database/synergy/myth.yaml
+++ b/resources/database/synergy/myth.yaml
@@ -2,6 +2,7 @@ id: myth
 name: "Myth"
 kind: generation
 type: normal
+rarity: common
 effect: energy_on_skill_cast
 # Proc count required for tier 1 / 2 / 3.
 thresholds: [3, 4, 5]

--- a/resources/database/synergy/myth.yaml
+++ b/resources/database/synergy/myth.yaml
@@ -1,7 +1,7 @@
 id: myth
 name: "Myth"
 kind: generation
-type: normal
+type: standard
 rarity: common
 effect: energy_on_skill_cast
 # Proc count required for tier 1 / 2 / 3.

--- a/resources/database/synergy/spellcaster.yaml
+++ b/resources/database/synergy/spellcaster.yaml
@@ -4,6 +4,7 @@ id: spellcaster
 name: "Spell Caster"
 kind: class
 type: normal
+rarity: common
 effect: magic_up_skill_crit
 # Single tier by design: 2 of the 3 demo Spell Casters (Gura / Ina'nis / Bettel)
 # is already a real deck commitment, and the bonus does not scale past it.

--- a/resources/database/synergy/spellcaster.yaml
+++ b/resources/database/synergy/spellcaster.yaml
@@ -3,7 +3,7 @@ id: spellcaster
 # both key off TowerTrait.name_key, which strips spaces and underscores.
 name: "Spell Caster"
 kind: class
-type: normal
+type: standard
 rarity: common
 effect: magic_up_skill_crit
 # Single tier by design: 2 of the 3 demo Spell Casters (Gura / Ina'nis / Bettel)

--- a/resources/database/synergy/tempus.yaml
+++ b/resources/database/synergy/tempus.yaml
@@ -6,8 +6,8 @@ rarity: common
 # First mission-type synergy: reaching a unit threshold opens a Guild Mission
 # (cumulative kill goal); completing it unlocks a reward that STACKS with the
 # lower tiers. Kill count starts when Tempus first activates (2 units) and
-# persists across waves. Behaviour: SynergyEffectQuestTempus.
-effect: quest_kill_tempus
+# persists across waves. Behaviour: SynergyEffectMissionTempus.
+effect: mission_kill_tempus
 thresholds: [2, 4, 6]
 parameters:
   # Cumulative kills required for each tier's Guild Mission (per-tier, scaling).

--- a/resources/database/synergy/tempus.yaml
+++ b/resources/database/synergy/tempus.yaml
@@ -1,9 +1,9 @@
 id: tempus
 name: "Tempus"
 kind: generation
-type: quest
+type: mission
 rarity: common
-# First quest-type synergy: reaching a unit threshold opens a Guild Mission
+# First mission-type synergy: reaching a unit threshold opens a Guild Mission
 # (cumulative kill goal); completing it unlocks a reward that STACKS with the
 # lower tiers. Kill count starts when Tempus first activates (2 units) and
 # persists across waves. Behaviour: SynergyEffectQuestTempus.

--- a/resources/database/synergy/tempus.yaml
+++ b/resources/database/synergy/tempus.yaml
@@ -2,6 +2,7 @@ id: tempus
 name: "Tempus"
 kind: generation
 type: quest
+rarity: common
 # First quest-type synergy: reaching a unit threshold opens a Guild Mission
 # (cumulative kill goal); completing it unlocks a reward that STACKS with the
 # lower tiers. Kill count starts when Tempus first activates (2 units) and

--- a/scripts/entity/tower/tower_factory.gd
+++ b/scripts/entity/tower/tower_factory.gd
@@ -26,7 +26,7 @@ func setup(p_onPlace: Callable, p_onRemove: Callable):
 	synergyController.setup(self)
 	Utility.ConnectSignal(towerTrait, "synergy_updated", Callable(self, "_on_synergy_updated"));
 	if uiSynergy != null:
-		Utility.ConnectSignal(synergyController, "quest_progress_changed", Callable(uiSynergy, "setQuestProgress"));
+		Utility.ConnectSignal(synergyController, "mission_progress_changed", Callable(uiSynergy, "setMissionProgress"));
 
 func getTower(p_name: String, evoToken: int = 0) -> GetTowerResult:
 	var resource = ResourceManager.getTower(p_name);
@@ -135,7 +135,7 @@ func evolutionTower(p_name: String):
 
 func _on_synergy_updated(synergy_id: int, count: int, tier: int):
 	# Draw/refresh the panel row BEFORE the controller updates the effect, so a
-	# quest effect's activate() (which emits quest_progress_changed) lands on a
+	# mission effect's activate() (which emits mission_progress_changed) lands on a
 	# row that already exists. Only show synergies defined in YAML; an undefined
 	# trait (no data) can never activate, so it is not a meaningful panel row.
 	if uiSynergy != null:
@@ -160,7 +160,7 @@ func _process(delta: float) -> void:
 	if _wave_active and synergyController != null:
 		synergyController.tick(delta)
 
-# Wired to WaveController.onEnemyDead (real kills only) -> quest synergies.
+# Wired to WaveController.onEnemyDead (real kills only) -> mission synergies.
 func onEnemyKilled(enemy, cause, reward) -> void:
 	if synergyController != null:
 		synergyController.on_enemy_killed(enemy, cause, reward)

--- a/scripts/synergy/synergy_controller.gd
+++ b/scripts/synergy/synergy_controller.gd
@@ -10,16 +10,16 @@ var _factory                       # TowerFactory (tower lists)
 var _active_tier: Dictionary = {}  # synergy_id -> int (highest tier, -1 none)
 var _effects: Dictionary = {}      # synergy_id -> SynergyEffect
 
-# Emitted when a quest-type synergy's cumulative progress changes (drives that
+# Emitted when a mission-type synergy's cumulative progress changes (drives that
 # synergy's hover progress line). Carries synergy_id so the UI routes it to the
 # right panel row.
-signal quest_progress_changed(synergy_id: int, current: int)
+signal mission_progress_changed(synergy_id: int, current: int)
 
-# Quest effects report progress through this method so the emit lives in the
+# Mission effects report progress through this method so the emit lives in the
 # declaring script (the UNUSED_SIGNAL check is per-script; cross-script emits
 # do not count - see agent_lessons.md).
-func report_quest_progress(synergy_id: int, current: int) -> void:
-	quest_progress_changed.emit(synergy_id, current)
+func report_mission_progress(synergy_id: int, current: int) -> void:
+	mission_progress_changed.emit(synergy_id, current)
 
 func setup(factory) -> void:
 	_factory = factory

--- a/scripts/synergy/synergy_data.gd
+++ b/scripts/synergy/synergy_data.gd
@@ -5,11 +5,22 @@ class_name SynergyData
 # Numbers are read through get_parameter so the displayed text and the applied
 # effect share one source (mirrors Skill.parameters / tokenized desc).
 
+# Legal `rarity` values - shared with the loader so an unknown string is caught
+# at load instead of silently reading as common.
+const RARITY_COMMON := "common"
+const RARITY_UNIQUE := "unique"
+const RARITIES := [RARITY_COMMON, RARITY_UNIQUE]
+
 var id: String = ""                # file/data key, e.g. "myth"
 var synergy_id: int = 0            # TowerTrait enum int (resolved at load)
 var display_name: String = ""
 var kind: String = ""             # "class" | "generation"
-var type: String = "normal"       # UI category: normal | quest | special
+var type: String = "normal"       # how the effect unlocks: normal (on threshold) | quest (on a mission)
+# Who may hold the trait - a separate axis from `type`, so a synergy can be both
+# unique and quest-unlocked. unique = exactly one tower in the whole game carries
+# it (Hero/Regis Altare today), which is why every threshold of a unique synergy
+# must be 1; the panel gives those rows their own colour and floats them on top.
+var rarity: String = RARITY_COMMON
 var effect: String = ""           # SynergyEffect handler key ("" = placeholder)
 var thresholds: Array = []        # proc count per tier (untyped: YamlParser yields untyped Array)
 var parameters: Dictionary = {}   # name -> per-tier array (or scalar)
@@ -18,6 +29,9 @@ var desc: String = ""             # flavour line (hover header), may hold {param
 # for every tier (pure scaling, e.g. Myth); size == tier_count -> one line per
 # tier (qualitative tiers, e.g. a Tempus-style "unlock" at a higher tier).
 var tier_effects: Array = []
+
+func is_unique() -> bool:
+	return rarity == RARITY_UNIQUE
 
 func max_count() -> int:
 	return int(thresholds[-1]) if not thresholds.is_empty() else 0

--- a/scripts/synergy/synergy_data.gd
+++ b/scripts/synergy/synergy_data.gd
@@ -28,6 +28,20 @@ func min_requirement() -> int:
 func tier_count() -> int:
 	return thresholds.size()
 
+# How far this synergy has climbed toward its OWN top tier: 0.0 = lowest active
+# tier, 1.0 = maxed, -1.0 = not active. A single-tier synergy is maxed the moment
+# it activates, so it reads 1.0 at tier 0 while a 3-tier synergy at tier 0 reads
+# 0.0. The panel's row COLOUR and row ORDER both read this one number - they used
+# to disagree (colour by rank, sort by the raw tier index), which sorted a bronze
+# 3-tier row level with maxed gold rows.
+func tier_rank(tier: int) -> float:
+	if tier < 0:
+		return -1.0
+	var top := tier_count() - 1
+	if top <= 0:
+		return 1.0
+	return float(clampi(tier, 0, top)) / float(top)
+
 func threshold_at(tier: int) -> int:
 	if thresholds.is_empty():
 		return 0

--- a/scripts/synergy/synergy_data.gd
+++ b/scripts/synergy/synergy_data.gd
@@ -24,7 +24,7 @@ var display_name: String = ""
 var kind: String = ""             # "class" | "generation"
 var type: String = TYPE_STANDARD   # how the effect unlocks: standard (on threshold) | mission (on a kill goal)
 # Who may hold the trait - a separate axis from `type`, so a synergy can be both
-# unique and quest-unlocked. unique = exactly one tower in the whole game carries
+# unique and mission-unlocked. unique = exactly one tower in the whole game carries
 # it (Hero/Regis Altare today), which is why every threshold of a unique synergy
 # must be 1; the panel gives those rows their own colour and floats them on top.
 var rarity: String = RARITY_COMMON
@@ -39,6 +39,9 @@ var tier_effects: Array = []
 
 func is_unique() -> bool:
 	return rarity == RARITY_UNIQUE
+
+func is_generation() -> bool:
+	return kind == "generation"
 
 # Hover subtitle. The authored key doubles as the copy, so there is no mapping
 # table to fall out of sync; "Trait" is appended because the Tempus hover also

--- a/scripts/synergy/synergy_data.gd
+++ b/scripts/synergy/synergy_data.gd
@@ -5,6 +5,13 @@ class_name SynergyData
 # Numbers are read through get_parameter so the displayed text and the applied
 # effect share one source (mirrors Skill.parameters / tokenized desc).
 
+# Legal `type` values. The authored key IS the player-facing word (rendered by
+# type_label), so a new value must be a word a player can read - no code-only
+# jargon, and no separate display mapping to drift from.
+const TYPE_STANDARD := "standard"
+const TYPE_MISSION := "mission"
+const TYPES := [TYPE_STANDARD, TYPE_MISSION]
+
 # Legal `rarity` values - shared with the loader so an unknown string is caught
 # at load instead of silently reading as common.
 const RARITY_COMMON := "common"
@@ -15,7 +22,7 @@ var id: String = ""                # file/data key, e.g. "myth"
 var synergy_id: int = 0            # TowerTrait enum int (resolved at load)
 var display_name: String = ""
 var kind: String = ""             # "class" | "generation"
-var type: String = "normal"       # how the effect unlocks: normal (on threshold) | quest (on a mission)
+var type: String = TYPE_STANDARD   # how the effect unlocks: standard (on threshold) | mission (on a kill goal)
 # Who may hold the trait - a separate axis from `type`, so a synergy can be both
 # unique and quest-unlocked. unique = exactly one tower in the whole game carries
 # it (Hero/Regis Altare today), which is why every threshold of a unique synergy
@@ -32,6 +39,12 @@ var tier_effects: Array = []
 
 func is_unique() -> bool:
 	return rarity == RARITY_UNIQUE
+
+# Hover subtitle. The authored key doubles as the copy, so there is no mapping
+# table to fall out of sync; "Trait" is appended because the Tempus hover also
+# carries a mission progress line, and a bare "Mission" would read as its header.
+func type_label() -> String:
+	return type.capitalize() + " Trait"
 
 func max_count() -> int:
 	return int(thresholds[-1]) if not thresholds.is_empty() else 0

--- a/scripts/synergy/synergy_data_loader.gd
+++ b/scripts/synergy/synergy_data_loader.gd
@@ -57,8 +57,8 @@ static func _build(raw: Dictionary, path: String) -> SynergyData:
 	if not SynergyData.RARITIES.has(d.rarity):
 		push_warning("Synergy '" + d.id + "': unknown rarity '" + d.rarity + "' - expected one of " + str(SynergyData.RARITIES) + "; treated as common.")
 	# A unique trait is carried by exactly one tower in the game, so no unit gate
-	# can ever exceed 1. Several tiers stay legal ([1, 1, 1]) for a unique quest
-	# whose tiers gate on the mission instead of the count.
+	# can ever exceed 1. Several tiers stay legal ([1, 1, 1]) for a unique mission
+	# synergy whose tiers gate on the kill goal instead of the count.
 	if d.is_unique():
 		for t in d.thresholds:
 			if int(t) != 1:

--- a/scripts/synergy/synergy_data_loader.gd
+++ b/scripts/synergy/synergy_data_loader.gd
@@ -32,6 +32,7 @@ static func _build(raw: Dictionary, path: String) -> SynergyData:
 	d.display_name = str(raw.get("name", d.id))
 	d.kind = str(raw.get("kind", ""))
 	d.type = str(raw.get("type", "normal"))
+	d.rarity = str(raw.get("rarity", SynergyData.RARITY_COMMON))
 	d.effect = str(raw.get("effect", ""))
 	# YamlParser does not process escapes; translate \n loader-side, only for the
 	# text fields that want it (data_pipeline.md Problem #1).
@@ -45,6 +46,19 @@ static func _build(raw: Dictionary, path: String) -> SynergyData:
 
 	for t in raw.get("thresholds", []):
 		d.thresholds.append(int(t))
+
+	# Fail loud on rarity authoring: a typo would otherwise read as common and the
+	# synergy would silently lose its colour and its top slot in the panel.
+	if not SynergyData.RARITIES.has(d.rarity):
+		push_warning("Synergy '" + d.id + "': unknown rarity '" + d.rarity + "' - expected one of " + str(SynergyData.RARITIES) + "; treated as common.")
+	# A unique trait is carried by exactly one tower in the game, so no unit gate
+	# can ever exceed 1. Several tiers stay legal ([1, 1, 1]) for a unique quest
+	# whose tiers gate on the mission instead of the count.
+	if d.is_unique():
+		for t in d.thresholds:
+			if int(t) != 1:
+				push_warning("Synergy '" + d.id + "': rarity is unique but a threshold is " + str(t) + " - a unique trait has at most one holder, so every threshold must be 1.")
+				break
 
 	var params = raw.get("parameters", {})
 	if params is Dictionary:

--- a/scripts/synergy/synergy_data_loader.gd
+++ b/scripts/synergy/synergy_data_loader.gd
@@ -31,7 +31,7 @@ static func _build(raw: Dictionary, path: String) -> SynergyData:
 	d.id = str(raw.get("id", ""))
 	d.display_name = str(raw.get("name", d.id))
 	d.kind = str(raw.get("kind", ""))
-	d.type = str(raw.get("type", "normal"))
+	d.type = str(raw.get("type", SynergyData.TYPE_STANDARD))
 	d.rarity = str(raw.get("rarity", SynergyData.RARITY_COMMON))
 	d.effect = str(raw.get("effect", ""))
 	# YamlParser does not process escapes; translate \n loader-side, only for the
@@ -47,8 +47,13 @@ static func _build(raw: Dictionary, path: String) -> SynergyData:
 	for t in raw.get("thresholds", []):
 		d.thresholds.append(int(t))
 
-	# Fail loud on rarity authoring: a typo would otherwise read as common and the
-	# synergy would silently lose its colour and its top slot in the panel.
+	# Fail loud on category authoring. `type` is doubly load-bearing: a typo would
+	# both drop the mission hover behaviour and print the typo into the player's
+	# tooltip, since the key is the copy.
+	if not SynergyData.TYPES.has(d.type):
+		push_warning("Synergy '" + d.id + "': unknown type '" + d.type + "' - expected one of " + str(SynergyData.TYPES) + ".")
+	# A rarity typo would otherwise read as common and the synergy would silently
+	# lose its colour and its top slot in the panel.
 	if not SynergyData.RARITIES.has(d.rarity):
 		push_warning("Synergy '" + d.id + "': unknown rarity '" + d.rarity + "' - expected one of " + str(SynergyData.RARITIES) + "; treated as common.")
 	# A unique trait is carried by exactly one tower in the game, so no unit gate

--- a/scripts/synergy/synergy_effect.gd
+++ b/scripts/synergy/synergy_effect.gd
@@ -45,8 +45,8 @@ static func create(effect_key: String) -> SynergyEffect:
 	match effect_key:
 		"energy_on_skill_cast":
 			return SynergyEffectEnergyOnCast.new()
-		"quest_kill_tempus":
-			return SynergyEffectQuestTempus.new()
+		"mission_kill_tempus":
+			return SynergyEffectMissionTempus.new()
 		"attack_per_active_trait":
 			return SynergyEffectAttackPerTrait.new()
 		"magic_up_skill_crit":

--- a/scripts/synergy/synergy_effect_attack_per_trait.gd
+++ b/scripts/synergy/synergy_effect_attack_per_trait.gd
@@ -30,7 +30,7 @@ func on_tower_added(_tower) -> void:
 
 # Apply the current total to every Hero unit. Lifetime and duration are set
 # explicitly: the registry def is WAVE with a non-zero duration, both wrong for a
-# permanent synergy buff (same trap as synergy_effect_quest_tempus.gd).
+# permanent synergy buff (same trap as synergy_effect_mission_tempus.gd).
 func _recompute() -> void:
 	var per_trait = data.get_parameter("atk_per_trait", 0)
 	if per_trait == null:

--- a/scripts/synergy/synergy_effect_mission_tempus.gd
+++ b/scripts/synergy/synergy_effect_mission_tempus.gd
@@ -1,7 +1,7 @@
-class_name SynergyEffectQuestTempus
+class_name SynergyEffectMissionTempus
 extends SynergyEffect
 
-# Tempus - the first quest-type synergy. Reaching a unit threshold (2/4/6) opens a
+# Tempus - the first mission-type synergy. Reaching a unit threshold (2/4/6) opens a
 # Guild Mission (cumulative kill goal 100/200/400); completing it unlocks a reward
 # that STACKS on the lower tiers (each tier = its own effect source_id, so they
 # SUM rather than replace). Kill count starts when Tempus first activates (2 units)
@@ -22,11 +22,11 @@ var _energy_timer: float = 0.0
 
 func activate() -> void:
 	# Guild formed (2 Tempus units): start the tracker at 0.
-	controller.report_quest_progress(data.synergy_id, _kills)
+	controller.report_mission_progress(data.synergy_id, _kills)
 
 func on_enemy_killed(_enemy, _cause, _reward) -> void:
 	_kills += 1
-	controller.report_quest_progress(data.synergy_id, _kills)
+	controller.report_mission_progress(data.synergy_id, _kills)
 	_check_rewards()
 
 func on_tier_changed(_new_tier: int) -> void:

--- a/scripts/synergy/synergy_effect_spellcaster.gd
+++ b/scripts/synergy/synergy_effect_spellcaster.gd
@@ -33,7 +33,7 @@ func _apply_all() -> void:
 
 # Lifetime and duration are set explicitly: a registry def is WAVE with a
 # non-zero duration by default, both wrong for a permanent synergy buff (same
-# trap as synergy_effect_attack_per_trait.gd / synergy_effect_quest_tempus.gd).
+# trap as synergy_effect_attack_per_trait.gd / synergy_effect_mission_tempus.gd).
 func _apply(tower, effect_id: String, value: float) -> void:
 	var inst := EffectUtility.make_instance(effect_id, _SOURCE, value, 0.0)
 	if inst == null:

--- a/scripts/ui/synergy/ui_synergy.gd
+++ b/scripts/ui/synergy/ui_synergy.gd
@@ -34,8 +34,9 @@ func updateSynergy(synergyName: String, count: int, tier: int, synergy_id: int) 
 	content.setup(synergyName, count, tier, icon, ResourceManager.getSynergyData(synergy_id))
 	_reflow()
 
-# Re-order rows on every update: tier RANK desc, then count desc, then creation
-# order. Rank - how far a synergy climbed toward its OWN top tier - is the same
+# Re-order rows on every update: active first, then unique, then tier RANK desc,
+# then count desc, then creation order.
+# Rank - how far a synergy climbed toward its OWN top tier - is the same
 # number the row colour reads (SynergyData.tier_rank), so order and colour cannot
 # contradict each other. The raw tier index used to drive this and did contradict
 # it: a 3-tier synergy on its first step tied with maxed single-tier ones, which
@@ -50,6 +51,14 @@ func _reflow() -> void:
 		rows[i].position.y = i * ROW_HEIGHT
 
 func _compare_rows(a: UISynergyContent, b: UISynergyContent) -> bool:
+	# Active before inactive is checked on its own so the unique key below can be
+	# limited to active rows: a grey unique row must not outrank a lit one.
+	var a_active := a.getTierRank() >= 0.0
+	var b_active := b.getTierRank() >= 0.0
+	if a_active != b_active:
+		return a_active
+	if a_active and a.isUnique() != b.isUnique():
+		return a.isUnique()
 	if not is_equal_approx(a.getTierRank(), b.getTierRank()):
 		return a.getTierRank() > b.getTierRank()
 	if a.getCount() != b.getCount():

--- a/scripts/ui/synergy/ui_synergy.gd
+++ b/scripts/ui/synergy/ui_synergy.gd
@@ -34,10 +34,15 @@ func updateSynergy(synergyName: String, count: int, tier: int, synergy_id: int) 
 	content.setup(synergyName, count, tier, icon, ResourceManager.getSynergyData(synergy_id))
 	_reflow()
 
-# Re-order rows on every update: tier desc, then count desc, then creation order.
-# Active rows (tier >= 0) float above inactive (tier -1) because -1 sorts lowest.
+# Re-order rows on every update: tier RANK desc, then count desc, then creation
+# order. Rank - how far a synergy climbed toward its OWN top tier - is the same
+# number the row colour reads (SynergyData.tier_rank), so order and colour cannot
+# contradict each other. The raw tier index used to drive this and did contradict
+# it: a 3-tier synergy on its first step tied with maxed single-tier ones, which
+# dropped a bronze row into the middle of the gold block.
+# Active rows float above inactive: an inactive row ranks -1.0, the lowest value.
 # sort_custom is NOT stable, so creation order is the final key to keep rows with
-# equal tier+count from swapping (and flickering) each reflow.
+# equal rank+count from swapping (and flickering) each reflow.
 func _reflow() -> void:
 	var rows: Array = contentList.values()
 	rows.sort_custom(_compare_rows)
@@ -45,8 +50,8 @@ func _reflow() -> void:
 		rows[i].position.y = i * ROW_HEIGHT
 
 func _compare_rows(a: UISynergyContent, b: UISynergyContent) -> bool:
-	if a.getTier() != b.getTier():
-		return a.getTier() > b.getTier()
+	if not is_equal_approx(a.getTierRank(), b.getTierRank()):
+		return a.getTierRank() > b.getTierRank()
 	if a.getCount() != b.getCount():
 		return a.getCount() > b.getCount()
 	return a.getOrder() < b.getOrder()

--- a/scripts/ui/synergy/ui_synergy.gd
+++ b/scripts/ui/synergy/ui_synergy.gd
@@ -8,15 +8,15 @@ const ROW_HEIGHT := 100
 var contentList: Dictionary = {};   # synergy name -> UISynergyContent
 var _nextOrder := 0;                 # creation order, frozen per row (stable-sort tie-break)
 
-# A quest-type synergy (e.g. Tempus) pushes its cumulative progress here; it is
+# A mission-type synergy (e.g. Tempus) pushes its cumulative progress here; it is
 # stored on that synergy's row and shown at the bottom of the row's hover.
-func setQuestProgress(synergy_id: int, current: int) -> void:
+func setMissionProgress(synergy_id: int, current: int) -> void:
 	var data: SynergyData = ResourceManager.getSynergyData(synergy_id)
 	if data == null:
 		return
 	var content: UISynergyContent = contentList.get(data.display_name, null)
 	if content != null:
-		content.setQuestProgress(current)
+		content.setMissionProgress(current)
 
 # Create or update a synergy row from the single TowerTrait.synergy_updated signal:
 # count + tier drive the row (count, proc breakpoints, tier colour); synergy_id
@@ -35,7 +35,7 @@ func updateSynergy(synergyName: String, count: int, tier: int, synergy_id: int) 
 	_reflow()
 
 # Re-order rows on every update: active first, then unique, then tier RANK desc,
-# then count desc, then creation order.
+# then count desc, then Generation before Class, then creation order.
 # Rank - how far a synergy climbed toward its OWN top tier - is the same
 # number the row colour reads (SynergyData.tier_rank), so order and colour cannot
 # contradict each other. The raw tier index used to drive this and did contradict
@@ -63,4 +63,9 @@ func _compare_rows(a: UISynergyContent, b: UISynergyContent) -> bool:
 		return a.getTierRank() > b.getTierRank()
 	if a.getCount() != b.getCount():
 		return a.getCount() > b.getCount()
+	# Generation above Class on a genuine tie - the same Gen-first trait order the
+	# tower-select cards use. Without it the first placement decides, so a fresh
+	# board showed the new unit's two still-inactive traits in placement order.
+	if a.isGeneration() != b.isGeneration():
+		return a.isGeneration()
 	return a.getOrder() < b.getOrder()

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -173,6 +173,10 @@ static func build_hover_bbcode(data: SynergyData, fallback_name: String, tier: i
 
 	var lines: PackedStringArray = []
 	lines.append("[b]" + data.display_name + "[/b]")
+	# Category subtitle under the name, dimmed so it never competes with the name
+	# or the desc, then a blank line to set the desc apart as its own block.
+	lines.append("[i][color=" + DIM_COLOR + "]" + data.type_label() + "[/color][/i]")
+	lines.append("")
 
 	# Flavour preview the lowest tier's value when not yet proc'd (maxi(tier,0)).
 	var flavor := data.flavor(maxi(tier, 0), SCALING_COLOR)
@@ -203,8 +207,8 @@ static func build_hover_bbcode(data: SynergyData, fallback_name: String, tier: i
 enum TierRowState { LOCKED, PENDING, EARNED }
 
 # Truthful per-tier row state for the hover table.
-# Normal synergies keep today's single-active-row read (highest tier REPLACES).
-# Quest synergies (data.type == "quest") stack: unit gate uses the row's tier,
+# Standard synergies keep today's single-active-row read (highest tier REPLACES).
+# Mission synergies stack: unit gate uses the row's tier,
 # kill gate uses quest_progress vs mission_kills[i] - mirroring
 # SynergyEffectQuestTempus._check_rewards (same get_parameter clamp, so display
 # and effect cannot diverge). Assumes tier is monotonic within a run - holds
@@ -214,7 +218,7 @@ enum TierRowState { LOCKED, PENDING, EARNED }
 static func _tier_row_state(data: SynergyData, i: int, tier: int, quest_progress: int) -> TierRowState:
 	if i > tier:
 		return TierRowState.LOCKED
-	if data.type != "quest":
+	if data.type != SynergyData.TYPE_MISSION:
 		return TierRowState.EARNED if i == tier else TierRowState.LOCKED
 	var goal = data.get_parameter("mission_kills", i)
 	if goal != null and quest_progress >= int(goal):

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -61,6 +61,7 @@ func setup(p_name: String, current: int, tier: int, icon: Texture2D, data) -> vo
 # Sort keys read by UISynergy._reflow - kept on the row so its sort state has a
 # single source of truth (mirrors how _tier is already threaded via setup).
 func getTier() -> int: return _tier
+func getTierRank() -> float: return _rank_for(_tier)
 func getCount() -> int: return _count
 func getOrder() -> int: return _order
 func setOrder(value: int) -> void: _order = value
@@ -77,17 +78,24 @@ func setQuestProgress(current: int) -> void:
 # gold, whatever its tier count. Hero defines a single tier, so an absolute index
 # left it permanently bronze - the lowest rank while fully maxed.
 # 3 tiers -> bronze/silver/gold (unchanged); 2 -> bronze/gold; 1 -> gold.
+# The colour is only a 3-step quantization of the rank UISynergy sorts on, so
+# order and colour cannot contradict each other. Do not re-derive it here.
 func _tier_color(tier: int) -> String:
-	if tier < 0:
+	var rank := _rank_for(tier)
+	if rank < 0.0:
 		return INACTIVE_COLOR
 	var last := TIER_COLORS.size() - 1
-	var top_tier := 0
-	if _data != null:
-		top_tier = _data.tier_count() - 1
-	if top_tier <= 0:
-		return TIER_COLORS[last]
-	var idx := int(round(float(clampi(tier, 0, top_tier)) / float(top_tier) * float(last)))
-	return TIER_COLORS[clampi(idx, 0, last)]
+	return TIER_COLORS[clampi(int(round(rank * float(last))), 0, last)]
+
+# SynergyData.tier_rank for this row, tolerating a row whose data failed to
+# resolve: treat it as maxed, which is what the colour already did before rank
+# became shared - so a broken row still colours and sorts one consistent way.
+func _rank_for(tier: int) -> float:
+	if tier < 0:
+		return -1.0
+	if _data == null:
+		return 1.0
+	return _data.tier_rank(tier)
 
 # "3 4 5" with the active tier's threshold bracketed.
 func _breakpoints_text(tier: int) -> String:

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -12,7 +12,7 @@ const UNIQUE_COLOR := "#FF5A36"
 const SCALING_COLOR := "#5AC8FA"                          # the per-tier value that scales
 const DIM_COLOR := "#7A7A7A"                              # not-yet-reached tier rows in the hover
 const ACTIVE_HIGHLIGHT := "#FFD15A"                       # reward-running tier rows in the hover (gold)
-const QUEST_PENDING_HIGHLIGHT := "#8C7431"                # ACTIVE_HIGHLIGHT darkened ~45%: mission open, reward not yet earned
+const MISSION_PENDING_HIGHLIGHT := "#8C7431"              # ACTIVE_HIGHLIGHT darkened ~45%: mission open, reward not yet earned
 
 @onready var bg = $"."
 @onready var synergyName = $HBoxContainer/VBoxContainer/SynergyName
@@ -23,10 +23,10 @@ var _name: String = ""
 var _data: SynergyData = null
 var _tier: int = -1
 var _count: int = 0                   # live unit count (sort key; drops when units removed)
-var _quest_progress: int = -1         # quest cumulative progress (-1 = not a quest / unset)
+var _mission_progress: int = -1       # mission cumulative progress (-1 = not a mission / unset)
 var _order: int = -1                  # creation order, frozen by UISynergy (stable-sort tie-break)
 var _stylebox: StyleBoxFlat = null   # this row's own panel StyleBox (see setup)
-var _tooltip_label: RichTextLabel = null  # open hover's rich label, for live quest-progress refresh
+var _tooltip_label: RichTextLabel = null  # open hover's rich label, for live mission-progress refresh
 
 # tier: current active tier (-1 = not yet proc'd). data: SynergyData or null.
 func setup(p_name: String, current: int, tier: int, icon: Texture2D, data) -> void:
@@ -67,15 +67,16 @@ func setup(p_name: String, current: int, tier: int, icon: Texture2D, data) -> vo
 func getTier() -> int: return _tier
 func getTierRank() -> float: return _rank_for(_tier)
 func isUnique() -> bool: return _data != null and _data.is_unique()
+func isGeneration() -> bool: return _data != null and _data.is_generation()
 func getCount() -> int: return _count
 func getOrder() -> int: return _order
 func setOrder(value: int) -> void: _order = value
 
-# A quest synergy's cumulative progress; shown at the bottom of this row's hover.
+# A mission synergy's cumulative progress; shown at the bottom of this row's hover.
 # Refreshes the open tooltip live (TFT-style); Godot builds it once per hover, so
 # without this the number would freeze until the player re-hovers.
-func setQuestProgress(current: int) -> void:
-	_quest_progress = current
+func setMissionProgress(current: int) -> void:
+	_mission_progress = current
 	if _tooltip_label != null and is_instance_valid(_tooltip_label):
 		_tooltip_label.text = _build_hover_bbcode()
 
@@ -118,7 +119,7 @@ func _breakpoints_text(tier: int) -> String:
 # active tier marked + tier-coloured and the rest dimmed.
 func _make_custom_tooltip(_for_text: String) -> Object:
 	var panel := make_tooltip_card(_build_hover_bbcode(), 320.0, self)
-	# Keep a ref so live kills can refresh the open tooltip (see setQuestProgress).
+	# Keep a ref so live kills can refresh the open tooltip (see setMissionProgress).
 	_tooltip_label = panel.get_child(0) as RichTextLabel
 	return panel
 
@@ -162,12 +163,12 @@ static func make_tooltip_card(bbcode: String, width: float = 320.0, p_owner: Con
 	return panel
 
 func _build_hover_bbcode() -> String:
-	return build_hover_bbcode(_data, _name, _tier, _quest_progress)
+	return build_hover_bbcode(_data, _name, _tier, _mission_progress)
 
 # Shared with the tower-select card chips (synergy_chip_icon.gd) so both hovers
 # render identical text from one builder; hover colors stay single-source here.
-# tier -1 = definitional view (no active row); quest_progress -1 = no progress line.
-static func build_hover_bbcode(data: SynergyData, fallback_name: String, tier: int, quest_progress: int) -> String:
+# tier -1 = definitional view (no active row); mission_progress -1 = no progress line.
+static func build_hover_bbcode(data: SynergyData, fallback_name: String, tier: int, mission_progress: int) -> String:
 	if data == null:
 		return fallback_name
 
@@ -188,20 +189,20 @@ static func build_hover_bbcode(data: SynergyData, fallback_name: String, tier: i
 		lines.append("")
 		for i in data.tier_count():
 			var row := "(" + str(data.threshold_at(i)) + ")  " + data.tier_effect(i)
-			match _tier_row_state(data, i, tier, quest_progress):
+			match _tier_row_state(data, i, tier, mission_progress):
 				TierRowState.EARNED:
-					# Reward running (normal lane: the single active tier; quest
+					# Reward running (normal lane: the single active tier; mission
 					# lane: every earned mission, so 2+ gold arrow rows can show).
 					row = "[color=" + ACTIVE_HIGHLIGHT + "]> " + row + "[/color]"
 				TierRowState.PENDING:
-					row = "[color=" + QUEST_PENDING_HIGHLIGHT + "]" + row + "[/color]"   # mission open, unfinished
+					row = "[color=" + MISSION_PENDING_HIGHLIGHT + "]" + row + "[/color]"   # mission open, unfinished
 				TierRowState.LOCKED:
 					row = "[color=" + DIM_COLOR + "]" + row + "[/color]"
 			lines.append(row)
 
-	if quest_progress >= 0:
+	if mission_progress >= 0:
 		lines.append("")
-		lines.append("[b]Current Progress: " + str(quest_progress) + "[/b]")
+		lines.append("[b]Current Progress: " + str(mission_progress) + "[/b]")
 	return "\n".join(lines)
 
 enum TierRowState { LOCKED, PENDING, EARNED }
@@ -209,18 +210,18 @@ enum TierRowState { LOCKED, PENDING, EARNED }
 # Truthful per-tier row state for the hover table.
 # Standard synergies keep today's single-active-row read (highest tier REPLACES).
 # Mission synergies stack: unit gate uses the row's tier,
-# kill gate uses quest_progress vs mission_kills[i] - mirroring
-# SynergyEffectQuestTempus._check_rewards (same get_parameter clamp, so display
+# kill gate uses mission_progress vs mission_kills[i] - mirroring
+# SynergyEffectMissionTempus._check_rewards (same get_parameter clamp, so display
 # and effect cannot diverge). Assumes tier is monotonic within a run - holds
 # permanently: no tower-removal path exists by Director decision
 # (tower_synergy.md Notes). If a tower-destroying mechanic ever ships, the
 # effect's _rewarded[] is sticky while this recomputes live - re-derive then.
-static func _tier_row_state(data: SynergyData, i: int, tier: int, quest_progress: int) -> TierRowState:
+static func _tier_row_state(data: SynergyData, i: int, tier: int, mission_progress: int) -> TierRowState:
 	if i > tier:
 		return TierRowState.LOCKED
 	if data.type != SynergyData.TYPE_MISSION:
 		return TierRowState.EARNED if i == tier else TierRowState.LOCKED
 	var goal = data.get_parameter("mission_kills", i)
-	if goal != null and quest_progress >= int(goal):
+	if goal != null and mission_progress >= int(goal):
 		return TierRowState.EARNED
 	return TierRowState.PENDING   # incl. null goal: reward can never fire, matches effect

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -5,6 +5,10 @@ class_name UISynergyContent
 # player reads tier order at a glance; the scaling value gets its own accent.
 const INACTIVE_COLOR := "#4D4D4D"
 const TIER_COLORS := ["#CD7F32", "#C0C0C0", "#FFD15A"]   # bronze / silver / gold = tier 1 / 2 / 3
+# Unique synergies skip the tier ladder entirely - one holder in the whole game
+# means they are maxed the moment they activate, so a rank colour says nothing.
+# Vivid red-orange, deliberately far from the muted bronze above.
+const UNIQUE_COLOR := "#FF5A36"
 const SCALING_COLOR := "#5AC8FA"                          # the per-tier value that scales
 const DIM_COLOR := "#7A7A7A"                              # not-yet-reached tier rows in the hover
 const ACTIVE_HIGHLIGHT := "#FFD15A"                       # reward-running tier rows in the hover (gold)
@@ -62,6 +66,7 @@ func setup(p_name: String, current: int, tier: int, icon: Texture2D, data) -> vo
 # single source of truth (mirrors how _tier is already threaded via setup).
 func getTier() -> int: return _tier
 func getTierRank() -> float: return _rank_for(_tier)
+func isUnique() -> bool: return _data != null and _data.is_unique()
 func getCount() -> int: return _count
 func getOrder() -> int: return _order
 func setOrder(value: int) -> void: _order = value
@@ -84,6 +89,8 @@ func _tier_color(tier: int) -> String:
 	var rank := _rank_for(tier)
 	if rank < 0.0:
 		return INACTIVE_COLOR
+	if isUnique():
+		return UNIQUE_COLOR
 	var last := TIER_COLORS.size() - 1
 	return TIER_COLORS[clampi(int(round(rank * float(last))), 0, last)]
 

--- a/scripts/ui/tower_select/synergy_chip_icon.gd
+++ b/scripts/ui/tower_select/synergy_chip_icon.gd
@@ -3,7 +3,7 @@ extends TextureRect
 
 # Synergy-trait hover for tower-select cards: same text and opaque card as the
 # synergy panel hover via the shared helpers (ui_synergy_content.gd), rendered
-# definitionally (tier -1: no active-tier highlight or quest progress - live
+# definitionally (tier -1: no active-tier highlight or mission progress - live
 # state stays on the panel).
 
 var synergy_id: int = 0


### PR DESCRIPTION
**Summary:** The Synergy panel sorted rows by the raw tier index while colouring them by tier rank, so a bronze row could land inside the gold block. Both readings now share one measure. Adds a `unique` rarity axis (a trait only one tower in the game carries) that colours red-orange and floats to the top, and renames the `type` values to the words the hover prints.

**How it works:** `SynergyData.tier_rank(tier)` is the single progress measure - 0.0 at the lowest active tier, 1.0 when maxed against the tier count the synergy itself defines, -1.0 inactive. The row colour is only its 3-step quantization, so order and colour cannot drift apart again. Panel sort keys, in order: active before inactive, unique before common (active rows only), rank desc, unit count desc, Generation before Class, creation order.

`rarity` (`common` / `unique`) is a separate field from `type` rather than a third `type` value: `type` answers how the effect unlocks, `rarity` answers who may hold the trait, so a future unique synergy that unlocks through a mission stays authorable without migrating every synergy file. Load warns on an unknown `type` or `rarity`, and on a unique synergy whose threshold is not 1.

The hover gained a dimmed category subtitle under the trait name. `type` values became `standard` / `mission` (was `normal` / `quest`) so the authored key is the copy the player reads - no display mapping to fall out of sync - and the remaining `quest` naming (effect key, class, file, progress signal and methods, pending-highlight const) was renamed to match.

**Findings:**
- Marksman and Spell Caster tie on every sort key, so their relative order follows placement order. Intended: `Array.sort_custom` is not stable, and the frozen creation-order key is what stops equal rows from flickering each reflow.
- The `special` `type` value was reserved but never used by any file; `rarity` now owns that concept, so it was dropped rather than kept as dead schema.
- `Accepted debt` in `tower_synergy.md` still listed `quest` as unimplemented although Tempus shipped it; corrected in the same pass.
- An inactive unique row cannot occur in practice - a row is created only once a holder is placed, and a unique threshold is 1 - but the sort guards it anyway so a grey row never outranks a lit one.
- Godot-editor scan flagged a non-ASCII character in a comment in `synergy_effect_marksman.gd` (from #112). Left alone: `RULES.md` Section 8 scopes the ASCII rule to `.md` / `.py` / `.json` / configs, not `.gd`.

**Touched scenes:** none
