### PR TITLE
Hakka: switch to physical damage on attack and skill

### DIFF
--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -1,7 +1,7 @@
 maxLevel: 3
 towerClass: warrior
 generation: tempus
-attackType: magic
+attackType: physic
 evolutionCost: 1
 
 attack_sound: "hit_hakka"
@@ -35,7 +35,7 @@ stats:
 
 # Active Skill - "Exocirst Field": a persistent purifying zone centered on
 # Hakka. It is the first "field" execution pattern (tower_skill.md) - planted
-# non-blocking (Hakka keeps auto-attacking) and ticks magic damage + slow to
+# non-blocking (Hakka keeps auto-attacking) and ticks physical damage + slow to
 # enemies inside every tickInterval for skillDuration seconds. Zone VFX =
 # effect_script on the field action (ofuda orbit + spirit vortex, persistent
 # for the whole duration); the red debug rects are authored off (show_area).
@@ -43,11 +43,11 @@ skills:
   active:
     name: "Exocirst Field"
     names: ["Exocirst Field I", "Exocirst Field II", "Exocirst Field III"]
-    desc: "Banzoin Hakka conjures a purifying field in a 3x3 area around him for {skillDuration} seconds; enemies within take {skillDamage:percent} magic damage and are slowed by {slowEffect:percent} every second they remain inside."
+    desc: "Banzoin Hakka conjures a purifying field in a 3x3 area around him for {skillDuration} seconds; enemies within take {skillDamage:percent} physical damage and are slowed by {slowEffect:percent} every second they remain inside."
     icon: ""
     tags:
       - damage
-      - magic
+      - attack
       - aoe
       - persistent
       - debuff
@@ -89,7 +89,7 @@ skills:
           duration_param_name: "skillDuration"
           tick_interval_param_name: "tickInterval"
           damage_multiplier_param_name: "skillDamage"
-          damage_type: magic
+          damage_type: physic
           can_crit: false
           show_area: false            # per-tick red debug box off (VFX replaces it)
           effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gd"
@@ -116,11 +116,11 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Obey my omen, in hymns allure"
-    desc: "Banzoin Hakka unleashes a greater purifying field across a 5x5 area for {skillDuration} seconds; enemies within take {skillDamage:percent} magic damage and are slowed by {slowEffect:percent} every second they remain, and when the field fades he recovers {energyRefund:percent} of his maximum Energy."
+    desc: "Banzoin Hakka unleashes a greater purifying field across a 5x5 area for {skillDuration} seconds; enemies within take {skillDamage:percent} physical damage and are slowed by {slowEffect:percent} every second they remain, and when the field fades he recovers {energyRefund:percent} of his maximum Energy."
     icon: ""
     tags:
       - damage
-      - magic
+      - attack
       - aoe
       - persistent
       - debuff
@@ -160,7 +160,7 @@ evolution_skills:
           duration_param_name: "skillDuration"
           tick_interval_param_name: "tickInterval"
           damage_multiplier_param_name: "skillDamage"
-          damage_type: magic
+          damage_type: physic
           can_crit: false
           energy_refund_percent_param_name: "energyRefund"
           show_area: false            # per-tick red debug box off (VFX replaces it)


### PR DESCRIPTION
**Summary:** Banzoin Hakka now deals PHYSIC damage instead of MAGIC, on both his normal attack and Exocirst Field (both tiers). Data-only change to `resources/database/towers/banzoin_hakka.yaml` - no GDScript touched.

**How it works:** `attackType: magic -> physic`, plus the `damage_type` override on each of the two `field` actions (normal 3x3, evolve 5x5). The `field` action has no damage-type handling of its own - `skill_utility.gd:292` re-feeds the whole `data:` block through the `attack` parser, so `damage_type` there IS `SkillActionAttack`'s key and had to be flipped separately from `attackType`. Player-facing copy follows: both `desc` strings say "physical damage", and the damage-type tag moves `magic -> attack` per the `tower_skill.md` rule (`attack` pairs with `attackType: physic`, never combined with `magic`; same shape as Kiara and Altare).

Everything downstream reads the type at runtime and needed no edit: the stats panel type label, the floating damage-number colour, and the armor-vs-MR mitigation branch all switch on their own.

**Findings:**
- Base damage does not move. `tower_data.gd:64-76` `getTotalAttack()` reads the single `TowerStat.damage` for both types; the `match attackType` only selects which buff bucket it aggregates. There is no separate magic base stat and no `getTotalMagic()`.
- Live gameplay effect today is near-zero, and that was worth measuring before shipping. Across the full forest01 roster (11 enemies) only two have asymmetric defence: `armored_boar` (def 2 / mDef 0) and `flying_flower` (def 0 / mDef 2), so Hakka moves -2% and +2% against those; every other enemy including both bosses is symmetric at 0/0 or 5/5. Director informed and accepted - the change is for system/theme correctness (he is `towerClass: warrior`), not a power tune. If a power change is wanted it has to come from `damage:`.
- New axis exposure, both currently inert but directional: Altare's `armor_mult_down` shred (`regis_altare.yaml:96,180`) now amplifies Hakka, and the `armor_mult_up` auras on `armored_boar.yaml:23` / `flying_flower.yaml:23` now reach him. No `marmor_mult_up` producer exists in any enemy data, so the MR axis he leaves is entirely unused.
- Synergy exposure unchanged. Tempus (`synergy_effect_mission_tempus.gd:91`) grants `attack_mult_up` AND `magic_mult_up` at the same value, so his +20% is identical. SpellCaster and Hero gate on class/trait membership, not damage type, and `warrior` is not in `synergy_list.yaml` at all - Tempus is his only synergy either way. Giant Boar's Bulldoze debuff is likewise symmetric across both buckets.
- Visuals and audio deliberately unchanged (Director). Consequence worth recording: Hakka is now the only tower whose VFX hue and damage-number colour disagree - purple-pink field, white/red numbers - because `enemy.gd:201-210` colours by damage type. Intended, not a bug.
- Pre-existing issues noticed and NOT touched here: `sound_database.gd:52-63` maps all 12 `hit_*` SFX keys to the same metal-sword file, so Hakka's own recorded mp3s are unreferenced; and `banzoin_hakka.tscn:4-5` still loads Altare's sprites as placeholder art. Both unrelated to damage type, both flagged to Director.

**Implementation Notes:** The `damage_type` keys were kept explicit on both `field` blocks rather than deleted to inherit from `attackType` - matches the authored house style and keeps the type readable at the action. Worth knowing for review: the enum spelling is `physic`, and `Utility.parse_string_to_enum` falls back to index 0 (= `PHYSIC`) with only a `push_error` on an unrecognized string, so a typo like `physical` would have produced the correct result silently here. Verified against the live damage-number colour in-engine rather than trusted.

Tested in Godot by the Director: attack and field both read physical (white/red numbers), copy and tag line correct on both tiers, evolve field and its Energy refund intact, Tempus synergy bonus unchanged, and damage against a plain goblin byte-identical to before.
