### PR TITLE
Ina normal attack: homing ink-stroke bullet with an on-hit impact beat

### DIFF
--- a/resources/combat/bullets/ina_normal_bullet.tscn
+++ b/resources/combat/bullets/ina_normal_bullet.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=7 format=3 uid="uid://cinainkbullet001"]
+
+[ext_resource type="Script" path="res://scripts/combat/projectile.gd" id="1_proj"]
+[ext_resource type="Shader" path="res://resources/tower/hololive/en_branch/myth_gen/inanis/normal_effect/ina_ink_stroke.gdshader" id="2_shdr"]
+
+[sub_resource type="Gradient" id="Gradient_w"]
+offsets = PackedFloat32Array(0, 1)
+colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradTex_w"]
+gradient = SubResource("Gradient_w")
+width = 154
+height = 64
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_b"]
+shader = ExtResource("2_shdr")
+
+[sub_resource type="CircleShape2D" id="Circle_b"]
+radius = 36.0
+
+[node name="InaNormalBullet" type="Area2D"]
+script = ExtResource("1_proj")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+material = SubResource("ShaderMaterial_b")
+texture = SubResource("GradTex_w")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("Circle_b")

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -8,6 +8,17 @@ attack_sound: "hit_ina"
 open_sound: "debut_ina"
 evolve_sound: "evo_ina"
 
+# Normal attack - "Wet Nib" ink stroke. Homing bullet, damage lands on hit.
+# The shader owns the palette; only geometry/pacing is authored here.
+attack:
+  mode: projectile
+  projectile: "res://resources/combat/bullets/ina_normal_bullet.tscn"
+  vfx_shader: "res://resources/tower/hololive/en_branch/myth_gen/inanis/normal_effect/ina_ink_stroke.gdshader"
+  speed: 6.0          # tiles/sec
+  size: 184           # stroke height px (scales sprite + hitbox); quad is 154x64
+  burst: 1            # one stroke - no cosmetic rounds
+  impact: true        # opt in to the on-hit beat (impact_size/impact_time keep their defaults)
+
 stats:
   - damage: 140
     attackRange: 3.0

--- a/resources/tower/hololive/en_branch/myth_gen/inanis/normal_effect/ina_ink_stroke.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/inanis/normal_effect/ina_ink_stroke.gdshader
@@ -1,0 +1,143 @@
+shader_type canvas_item;
+render_mode blend_premul_alpha;
+
+// Ninomae Ina'nis - normal-attack bullet, "Wet Nib" ink stroke. Second production
+// bullet family after Amelia's Soft Glow and Shinri's arrow, and the first to draw
+// its own IMPACT beat as well as the projectile.
+//
+// Ina the illustrator: the bullet is a WET BRUSH STROKE flying point-first, thinning
+// as the ink runs out, with a lit violet core line down its middle and two lagging
+// afterimages selling the speed. The hit is an ink splat whose droplets arc down
+// under gravity - ink flung at a page.
+//
+// TWO BEATS, ONE SHADER via `phase` (0 = bullet, 1 = impact) - the Calliope evo
+// pattern. Uniform branching does not create a second pipeline, so the single
+// attack_config.vfx_shader warm (resource_manager.gd) covers the impact too.
+//
+// blend_premul_alpha, NOT blend_add: the palette is ink-dark and blend_add only adds
+// luminance, so the ink bands would vanish over a lit map (shader.md Section 3).
+// Do NOT use MODULATE - a custom-COLOR canvas_item fragment does not apply it.
+//
+// NO internal TIME. `life` (seconds in flight) is pushed each frame by
+// AttackController._onBulletMove via ProjectileCallback.onMove, so the dry-out rides
+// the same _process delta as the projectile: pause-frozen and x2-correct for free.
+// `progress` (impact 0->1) is tweened by AttackController._spawnImpact.
+//
+// Director calls, 2026-07-20: cut the cream rim, the gold tip flick, and the impact
+// rune ring. The read is ink and violet only - the silhouette carries the shot.
+
+uniform float phase : hint_range(0.0, 1.0) = 0.0;      // 0 = bullet, 1 = impact
+uniform float progress : hint_range(0.0, 1.0) = 0.0;   // impact beat 0->1
+uniform float life = 0.0;                              // seconds in flight
+
+uniform vec4 ink_color  : source_color = vec4(0.05, 0.03, 0.10, 1.0);  // wet ink core
+uniform vec4 body_color : source_color = vec4(0.42, 0.22, 0.72, 1.0);  // Ina violet
+uniform vec4 nib_color  : source_color = vec4(0.80, 0.62, 1.00, 1.0);  // lit core line
+uniform vec4 rim_color  : source_color = vec4(0.93, 0.90, 0.82, 1.0);  // parchment cream (droplets)
+
+uniform float stroke_hh : hint_range(0.10, 0.48) = 0.34;  // stroke half-height at its fattest
+uniform float taper     : hint_range(0.0, 1.0)   = 0.65;  // 0 = even width, 1 = whip-thin tail
+uniform float bristle   : hint_range(0.0, 1.0)   = 0.55;  // dry split-bristle gaps in the tail
+uniform float dry_rate  : hint_range(0.0, 1.0)   = 0.45;  // how fast the ink thins in flight
+uniform float nib_core  : hint_range(0.0, 1.0)   = 0.85;  // lit core-line strength
+uniform float alpha_mul : hint_range(0.0, 1.0)   = 1.0;
+
+const float AA = 0.012;
+const float TIPX = 0.46;
+const float BACKX = -0.48;
+
+// Half-height of the brush at lane position x. Leaf-tapered both ends: the two edges
+// converge to a rounded apex, never a stuck-on cap (vfx-craft.md "Tapered tip").
+float brush_hh(float x, float hh_scale) {
+	float t = clamp((TIPX - x) / (TIPX - BACKX), 0.0, 1.0);   // 0 at tip, 1 at tail end
+	float front = smoothstep(0.0, 0.13, t);
+	float fall = mix(1.0 - t, (1.0 - t) * (1.0 - t), taper);
+	float press = 1.0 - dry_rate * clamp(life * 1.6, 0.0, 1.0) * 0.4;   // ink runs out
+	return stroke_hh * hh_scale * front * fall * press;
+}
+
+// One stroke's coverage. xshift slides it BACK along the lane for the afterimages -
+// it must stay negative: a positive shift pushes the ghost tip past the quad edge,
+// where the scissor turns it into a flat lit cap on the head.
+float stroke_body(vec2 q, float hh_scale, float xshift) {
+	vec2 s = q - vec2(xshift, 0.0);
+	float ay = abs(s.y);
+	float hh = brush_hh(s.x, hh_scale);
+	float body = 1.0 - smoothstep(hh - AA, hh + AA, ay);
+
+	// Dry split bristles: thin gaps that only appear in the back half.
+	float t = clamp((TIPX - s.x) / (TIPX - BACKX), 0.0, 1.0);
+	float dry_zone = smoothstep(0.32, 0.95, t);
+	float gaps = smoothstep(0.55, 0.96, abs(sin(s.y * 46.0)));
+	body *= 1.0 - dry_zone * gaps * bristle;
+	return clamp(body, 0.0, 1.0);
+}
+
+void draw_stroke(vec2 q, out vec3 col, out float a) {
+	float t = clamp((TIPX - q.x) / (TIPX - BACKX), 0.0, 1.0);
+	col = mix(ink_color.rgb, body_color.rgb, smoothstep(0.0, 0.55, t));
+
+	float body = stroke_body(q, 1.0, 0.0);
+
+	// Lit core line: keeps a dark stroke off a dark map without adding a bright rim.
+	float hh = max(brush_hh(q.x, 1.0), 1e-3);
+	float core = (1.0 - smoothstep(hh * 0.20, hh * 0.50, abs(q.y))) * body;
+	col = mix(col, nib_color.rgb, core * nib_core);
+
+	// Two lagging afterimages: reads as speed even at a slow travel rate.
+	float g1 = stroke_body(q, 0.82, -0.10) * 0.30;
+	float g2 = stroke_body(q, 0.64, -0.20) * 0.14;
+	float ghosts = max(g1, g2);
+	col = mix(col, ink_color.rgb, clamp(ghosts - body, 0.0, 1.0) * 0.8);
+
+	a = clamp(max(body, ghosts), 0.0, 1.0);
+}
+
+// Impact. Drawn on a SQUARE quad: length()/atan() on UV-0.5 are only isotropic there.
+// Spawned unrotated, so the droplet gravity below actually reads as "down".
+void draw_impact(vec2 q, out vec3 col, out float a) {
+	float p = clamp(progress, 0.0, 1.0);
+	float r = length(q) * 2.0;
+	float ang = atan(q.y, q.x);
+
+	// Splat: an irregular blob that snaps open, then holds.
+	float grow = smoothstep(0.0, 0.30, p);
+	float wob = 0.07 * sin(ang * 7.0) + 0.045 * sin(ang * 11.0 + 1.7);
+	float rad = (0.16 + 0.20 * grow) + wob * grow;
+	float blob = 1.0 - smoothstep(rad - 0.035, rad + 0.035, r);
+
+	// Droplets: flung outward, falling in an arc, still drifting through the fade
+	// (no stop-then-vanish).
+	float drops = 0.0;
+	for (int i = 0; i < 7; i++) {
+		float fi = float(i);
+		float a0 = fi * 0.897 + 0.4;
+		float dist = 0.22 + 0.46 * smoothstep(0.0, 0.75, p) * (0.7 + 0.3 * sin(fi * 2.3));
+		vec2 c = vec2(cos(a0), sin(a0)) * dist * 0.5;
+		c.y += 0.30 * p * p;   // gravity
+		float sz = (0.030 + 0.016 * sin(fi * 1.7)) * (1.0 - 0.35 * p);
+		drops = max(drops, 1.0 - smoothstep(sz, sz + 0.012, length(q - c)));
+	}
+
+	col = mix(body_color.rgb, ink_color.rgb, smoothstep(0.0, 0.5, r));
+	col = mix(col, rim_color.rgb, drops * 0.35);
+	col = mix(col, nib_color.rgb, blob * (1.0 - smoothstep(0.0, 0.25, p)) * 0.5);
+
+	a = clamp(max(blob, drops), 0.0, 1.0);
+	a *= 1.0 - smoothstep(0.5, 1.0, p);
+}
+
+void fragment() {
+	vec2 q = UV - 0.5;
+	vec3 col = vec3(0.0);
+	float a = 0.0;
+
+	if (phase < 0.5) {
+		draw_stroke(q, col, a);
+	} else {
+		draw_impact(q, col, a);
+	}
+
+	a *= alpha_mul;
+	COLOR = vec4(col * a, a);   // premultiplied
+}

--- a/scripts/entity/attack_controller.gd
+++ b/scripts/entity/attack_controller.gd
@@ -4,6 +4,12 @@ class_name AttackController
 @onready var attackDelayTimer = $AttackDelayTimer
 @export var projectile: PackedScene #for test projectile
 
+## Bullet lifetime in seconds. Also the clock the bullet shader's `life` uniform is
+## derived from (BULLET_LIFETIME - proj.lifetime), so it must stay the value passed to
+## setupTarget below.
+const BULLET_LIFETIME := 5.0
+const IMPACT_QUAD_PX := 64.0   # carrier quad for the impact beat; scaled to cfg.get_impact_size()
+
 var getAttackCooldown: Callable;
 
 var tower: Tower;
@@ -95,15 +101,24 @@ func _spawnBullet(target: Enemy, cfg: TowerAttackConfig, dmg: Damage, saved_gen:
 	var aim_dir := (target.global_position - tower.global_position).normalized()
 	proj.global_position = Utility.muzzle_origin(tower.global_position, aim_dir)
 	proj.speed = cfg.speed * GridHelper.CELL_SIZE
-	_applyBulletVisual(proj, cfg)
+	var mat := _applyBulletVisual(proj, cfg)
+
+	# onMove ticks the bullet shader's `life` every frame (Projectile calls it before
+	# processLifetime, so frame one reads 0.0). Rides the same _process delta as the
+	# bullet, so it is pause-frozen and x2-correct for free. A bullet shader without a
+	# `life` uniform just ignores the push.
+	var move_cb := Callable()
+	if mat != null:
+		move_cb = Callable(self, "_onBulletMove").bind(mat)
 
 	var cb: ProjectileCallback
 	if carries_damage:
-		# bound saved_gen arrives as the 3rd arg of _onProjectileHit(proj, target, gen)
-		cb = ProjectileCallback.new(Callable(self, "_onProjectileHit").bind(saved_gen), Callable(), Callable())
+		# Projectile emits onHit.call(self, target) and bind() appends, so the bound args
+		# land as _onProjectileHit(proj, target, saved_gen, cfg) - order matters.
+		cb = ProjectileCallback.new(Callable(self, "_onProjectileHit").bind(saved_gen, cfg), Callable(), move_cb)
 	else:
-		cb = ProjectileCallback.new()   # empty -> no damage; fizzles on hit / target death
-	proj.setupTarget(tower, target, dmg, 5.0, cb)
+		cb = ProjectileCallback.new(Callable(), Callable(), move_cb)   # no damage; visual only
+	proj.setupTarget(tower, target, dmg, BULLET_LIFETIME, cb)
 
 func _spawnBurstRemainder(target: Enemy, cfg: TowerAttackConfig, saved_gen: int) -> void:
 	for i in range(1, cfg.burst):
@@ -114,18 +129,73 @@ func _spawnBurstRemainder(target: Enemy, cfg: TowerAttackConfig, saved_gen: int)
 			return
 		_spawnBullet(target, cfg, null, saved_gen, false)
 
-func _onProjectileHit(proj: Projectile, target, saved_gen: int) -> void:
+func _onProjectileHit(proj: Projectile, target, saved_gen: int, cfg: TowerAttackConfig) -> void:
 	if not is_instance_valid(tower) or tower.skill_lock_generation != saved_gen:
 		return   # stale: a wave reset happened since fire — don't hit a recycled enemy
 	if target is Enemy and is_instance_valid(target):
+		# Impact BEFORE the damage: a killing blow can run endWave -> resetForWave
+		# synchronously inside recvDamage (see Tower.attackEnemy), and this beat belongs
+		# to the moment of contact. Centred on the ENEMY, not on the bullet: the bullet
+		# stops a collision-radius short of it.
+		_spawnImpact(cfg, (target as Enemy).global_position)
 		(target as Enemy).recvDamage(proj.damage)
 		executeModifier()
+
+# Pushes seconds-in-flight to the bullet shader (see BULLET_LIFETIME).
+func _onBulletMove(proj: Projectile, mat: ShaderMaterial) -> void:
+	if not is_instance_valid(proj) or mat == null:
+		return
+	mat.set_shader_parameter("life", BULLET_LIFETIME - proj.lifetime)
+
+# On-hit beat for bullets whose shader draws a phase-1 impact (opt-in via `impact: true`).
+# Square quad and rotation 0 on purpose: the impact fragment is radial, and its droplet
+# gravity only reads as "down" while the quad is unrotated.
+func _spawnImpact(cfg: TowerAttackConfig, at: Vector2) -> void:
+	if cfg == null or not cfg.has_impact or cfg.vfx_shader == "":
+		return
+	if not is_instance_valid(tower):
+		return
+	var shader = load(cfg.vfx_shader)
+	if shader == null:
+		return
+
+	var spr := Sprite2D.new()
+	spr.texture = _whiteQuad()
+	var mat := ShaderMaterial.new()
+	mat.shader = shader
+	mat.set_shader_parameter("phase", 1.0)
+	mat.set_shader_parameter("progress", 0.0)
+	spr.material = mat
+	spr.scale = Vector2.ONE * (cfg.get_impact_size() / IMPACT_QUAD_PX)
+	tower.get_tree().root.add_child(spr)
+	spr.global_position = at
+
+	# Tween lives on the sprite: it freezes with the tree on pause and dies with the node.
+	var t := spr.create_tween()
+	t.tween_method(
+		func(p: float): mat.set_shader_parameter("progress", p),
+		0.0, 1.0, cfg.impact_time
+	)
+	t.tween_callback(spr.queue_free)
+
+# Plain white carrier quad - the impact shader draws everything from UV, sampling nothing.
+func _whiteQuad() -> GradientTexture2D:
+	var grad := Gradient.new()
+	grad.offsets = PackedFloat32Array([0.0, 1.0])
+	grad.colors = PackedColorArray([Color.WHITE, Color.WHITE])
+	var tex := GradientTexture2D.new()
+	tex.gradient = grad
+	tex.width = int(IMPACT_QUAD_PX)
+	tex.height = int(IMPACT_QUAD_PX)
+	return tex
 
 # Scales sprite + collision to cfg.size and pushes ONLY the shader-uniform overrides the
 # YAML actually set (cfg.visual_overrides); anything omitted keeps the shader's own default.
 # Duplicates the shared ShaderMaterial / CircleShape2D so per-bullet (and per-tower) tuning
-# never mutates the scene's shared resources.
-func _applyBulletVisual(proj: Projectile, cfg: TowerAttackConfig) -> void:
+# never mutates the scene's shared resources. Returns the per-bullet ShaderMaterial (null if
+# the bullet has none) so the caller can drive per-frame uniforms on it.
+func _applyBulletVisual(proj: Projectile, cfg: TowerAttackConfig) -> ShaderMaterial:
+	var bullet_mat: ShaderMaterial = null
 	for child in proj.get_children():
 		if child is Sprite2D:
 			var spr := child as Sprite2D
@@ -134,6 +204,7 @@ func _applyBulletVisual(proj: Projectile, cfg: TowerAttackConfig) -> void:
 			if spr.material is ShaderMaterial:
 				var mat := (spr.material as ShaderMaterial).duplicate() as ShaderMaterial
 				spr.material = mat
+				bullet_mat = mat
 				for uniform_name in cfg.visual_overrides:
 					mat.set_shader_parameter(uniform_name, cfg.visual_overrides[uniform_name])
 		elif child is CollisionShape2D:
@@ -142,3 +213,4 @@ func _applyBulletVisual(proj: Projectile, cfg: TowerAttackConfig) -> void:
 				var shape := (cs.shape as CircleShape2D).duplicate() as CircleShape2D
 				shape.radius = cfg.size * 0.5
 				cs.shape = shape
+	return bullet_mat

--- a/scripts/entity/tower/tower_attack_config.gd
+++ b/scripts/entity/tower/tower_attack_config.gd
@@ -20,12 +20,22 @@ const MODE_PROJECTILE := "projectile"
 # Colour uniforms the `attack:` block may override (parsed from "#rrggbb" or [r,g,b(,a)]).
 const COLOR_KEYS = ["core_color", "mid_color", "edge_color"]
 
+# Unauthored impact diameter = bullet size * this.
+const IMPACT_SIZE_FACTOR := 1.8
+
 var mode: String = MODE_HITSCAN
 var projectile_scene: PackedScene = null
 var vfx_shader: String = ""          # shader path, for ResourceManager warm (avoids first-fire hitch)
 var speed: float = 9.0               # tiles/sec (converted to px at spawn via GridHelper.CELL_SIZE)
 var size: float = 84.0               # bullet height/diameter px (drives sprite scale AND collision radius)
 var burst: int = 3                   # rounds fired per attack (visual; damage still lands once)
+
+# On-hit impact beat (opt-in). The bullet SHADER draws it from a `phase` uniform, so a
+# tower opting in needs a shader with a phase-1 branch; towers that omit `impact` behave
+# exactly as before. Defaults reproduce the approved Ina values without authoring them.
+var has_impact: bool = false
+var impact_size: float = -1.0        # px; < 0 => size * IMPACT_SIZE_FACTOR
+var impact_time: float = 0.35        # seconds the impact beat runs
 
 # Shader-uniform overrides explicitly set in YAML (uniform name -> value). ONLY these are
 # pushed onto the bullet material; any uniform not here keeps the shader's own default.
@@ -34,6 +44,12 @@ var visual_overrides: Dictionary = {}
 func is_projectile() -> bool:
 	return mode == MODE_PROJECTILE
 
+# Resolved impact diameter in px (falls back off the bullet size when unauthored).
+func get_impact_size() -> float:
+	if impact_size > 0.0:
+		return impact_size
+	return size * IMPACT_SIZE_FACTOR
+
 static func from_dict(d: Dictionary) -> TowerAttackConfig:
 	var cfg := TowerAttackConfig.new()
 	cfg.mode = str(d.get("mode", MODE_HITSCAN))
@@ -41,6 +57,11 @@ static func from_dict(d: Dictionary) -> TowerAttackConfig:
 	cfg.speed = float(d.get("speed", cfg.speed))
 	cfg.size = float(d.get("size", cfg.size))
 	cfg.burst = max(1, int(d.get("burst", cfg.burst)))   # never 0 bullets
+
+	# Impact beat: opt-in, and its two knobs stay unauthored unless a tower needs them.
+	cfg.has_impact = bool(d.get("impact", false))
+	cfg.impact_size = float(d.get("impact_size", cfg.impact_size))
+	cfg.impact_time = max(0.01, float(d.get("impact_time", cfg.impact_time)))
 
 	# Store ONLY the visual uniforms the YAML actually sets (presence = `d.has(key)`), so
 	# the shader's own defaults stand for anything omitted - a bullet never inherits


### PR DESCRIPTION
**Summary:** Ninomae Ina'nis switches her normal attack from hitscan to a homing projectile drawn by a custom shader ("Wet Nib" ink stroke), and the bullet family gains its first on-hit impact beat.

**How it works:** `ninomae_ina_nis.yaml` gains an `attack:` block (`mode: projectile`, `speed`, `size`, `burst: 1`, `impact: true`), so `TowerAttackConfig` routes her through the existing `AttackController.attackProjectile` path - no change to `tower.gd`, which already branches on `is_projectile()`. One shader draws both beats off a `phase` uniform (0 = flight, 1 = impact), the Calliope evo pattern: uniform branching is not a second pipeline, so the existing `attack_config.vfx_shader` warm covers the hit too. Per-frame flight state reaches the shader as `life` through the previously unused `ProjectileCallback.onMove` slot, so the stroke's dry-out rides the projectile's own `_process` delta - pause-frozen and x2-correct without a separate clock. `_spawnImpact` is opt-in per tower, so Amelia and Shinri are behaviourally untouched.

**Findings:**
- A `/scrutinize` pass before coding caught that the approved shader's `life` dry-out had no production driver - `_applyBulletVisual` only pushes `visual_overrides`. Without the `onMove` hook the bullet would have shipped frozen at its fattest frame. Fixed before implementation.
- The same pass caught the impact spawning at `proj.global_position`: the bullet detonates on Area2D contact with a 92px collision radius, so the splat would have landed short of the enemy. Now spawned on the target.
- `_spawnImpact` runs BEFORE `recvDamage` - a killing blow can run `endWave -> resetForWave` synchronously inside that call, and the beat belongs to the moment of contact.
- The impact sprite deliberately does NOT join the `projectile` group: it carries no `Damage` and no target reference and self-frees in 0.35s, so the wave-reset sweep has nothing to protect against. A wave-end inside that window leaves it mid-fade - accepted.
- Impact config keys were trimmed from three to one during review; `impact_size` / `impact_time` exist as optional overrides but default to the approved values (`size * 1.8`, `0.35s`).
- Direction chosen by the Director from an in-engine 3-variant preview, then a second round of 3 branches off the winner. The cream rim, gold tip flick, and impact rune ring were cut on his call. The preview harness was deleted at handoff per the template lifecycle rule.

**Touched scenes:** none (the new bullet `.tscn` is a new file).
