### PR TITLE
Wave counter shows the next wave; popup stops eating tooltips

### DIFF
--- a/scripts/map/enemy_wave/wave_controller.gd
+++ b/scripts/map/enemy_wave/wave_controller.gd
@@ -114,7 +114,7 @@ func startNextWave():
 		_startCountdown()
 		setupSpawnTask()
 
-	updateUI();
+	updateUI(currWave);
 
 func endWave():
 	if endWaveCalled:
@@ -129,6 +129,14 @@ func endWave():
 		if(ui):
 			get_tree().current_scene.add_child(ui);
 	else:
+		# The Managing Phase (tower/deck select) reads as "preparing wave N+1", so the
+		# counter switches the moment the field clears - before the popup beat.
+		# DISPLAY ONLY: currWave must NOT be incremented early. Five consumers read it as
+		# "the wave just finished / currently running": the deck-unlock milestone match
+		# (game_scene.on_wave_ended), the end-of-run check above, startNextWave's own
+		# bound check + increment (double-increment overruns waveDatas), the boss lookup,
+		# and the spawn-generation guards.
+		updateUI(currWave + 1);
 		data.onWaveEnd.call();
 
 func setupSpawnTask():
@@ -328,9 +336,11 @@ func summon(enemyId: String, count: int, interval: float, pathProgress: float):
 			if not is_instance_valid(self) or currWave != gen:
 				return
 
-func updateUI():
+# Display-only. The number shown is passed in because the Managing Phase shows the
+# NEXT wave while currWave still holds the finished one - see endWave().
+func updateUI(displayWave: int):
 	if waveCounterText != null:
-		waveCounterText.text = "wave " + str(currWave)
+		waveCounterText.text = "wave " + str(displayWave)
 
 func _startCountdown():
 	_wave_elapsed = 0.0

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -362,6 +362,7 @@ func show_deck_popup():
 	var popup: UITowerSelect = PopupPanelScene.instantiate() as UITowerSelect
 	_popup_open = true
 	_active_popup = popup
+	_clear_inspection()
 	get_tree().root.add_child(popup)
 
 	var cards: Array = []
@@ -405,6 +406,7 @@ func show_popup_panel():
 	var popup: UITowerSelect = PopupPanelScene.instantiate() as UITowerSelect;
 	_popup_open = true
 	_active_popup = popup
+	_clear_inspection()
 	# Ensure it's added to the UI layer, not just as a child of the 2D scene
 	get_tree().root.add_child(popup)
 
@@ -428,6 +430,17 @@ func _on_popup_closed():
 # do not open a second one"). The hide-popup button (coding log) flips only this half.
 func _popup_is_blocking() -> bool:
 	return _popup_open
+
+# Inspection and the card-pick modal are mutually exclusive (Director 2026-07-20): the popup
+# draws above the field, so a stats panel - with its inspect outline, and the planned tower
+# range ring - would sit half-covered under it. Clearing on open keeps the choosing moment
+# clean; re-selecting is already refused while _popup_is_blocking(). When the hide-popup
+# button lands, consider hiding + restoring the selection instead of dropping it.
+func _clear_inspection() -> void:
+	if _tower_stats_panel != null:
+		_tower_stats_panel.clear()
+	if _enemy_stats_panel != null:
+		_enemy_stats_panel.clear()
 
 func _on_tower_select_skipped():
 	push_warning("Tower select skipped - no valid towers available")

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -80,7 +80,7 @@ func _unhandled_input(event):
 	# clicks handled, and (unlike Area2D input_event, which missed clicks while a
 	# tower was mid-cast) this path has no physics dependency at all.
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		if state == "tower_placement" or state == "staff_skill_casting" or _popup_open or state == "game_over":
+		if state == "tower_placement" or state == "staff_skill_casting" or _popup_is_blocking() or state == "game_over":
 			return
 		if _tower_stats_panel == null:
 			return
@@ -283,8 +283,9 @@ func _on_staff_skill_button_pressed():
 	if staff == null:
 		return
 	# Guard against re-entry across the wave-end popup beat (PR #51): never enter aiming
-	# once a popup is open or the run is over.
-	if _popup_open or state == "game_over":
+	# once a popup is open or the run is over. The button stays hoverable so the player
+	# can still READ the skill tooltip while choosing a tower - only the press is refused.
+	if _popup_is_blocking() or state == "game_over":
 		return
 	if state == "staff_skill_casting":
 		_cancel_staff_skill_cast()
@@ -422,6 +423,11 @@ func show_popup_panel():
 func _on_popup_closed():
 	_popup_open = false
 	_active_popup = null
+
+# "A popup is covering the field", split from _popup_open's other meaning ("a popup exists,
+# do not open a second one"). The hide-popup button (coding log) flips only this half.
+func _popup_is_blocking() -> bool:
+	return _popup_open
 
 func _on_tower_select_skipped():
 	push_warning("Tower select skipped - no valid towers available")

--- a/scripts/ui/tower_select/UI_tower_select.gd
+++ b/scripts/ui/tower_select/UI_tower_select.gd
@@ -19,6 +19,14 @@ var _title_label: Label = null
 
 
 func _ready() -> void:
+	# PopupPanel is a full-rect Control that draws nothing - its only effect was eating
+	# mouse input across the whole screen, which made every tooltip UNDER the popup
+	# unreachable (synergy rows, Staff skill button, stats-panel icons): Godot's built-in
+	# tooltips only fire on the topmost mouse hit. Modality does not depend on it -
+	# GameScene._popup_is_blocking() already gates field clicks and the Staff skill press.
+	# IGNORE lets hover through; the Panel card below still STOPs clicks on its own rect.
+	# Set here rather than in tower_select.tscn for the same reason as _title_label above.
+	$CanvasLayer/PopupPanel.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	setupRefreshText(refreshLeft, maxRefresh);
 
 func setup(evoToken: int = 0, p_maxRefresh: int = 0, title: String = ""):


### PR DESCRIPTION
**Summary:** Two wave-end quality-of-life fixes reported by the Director, plus the follow-up his review of them produced. The top-left wave counter now shows the wave the player is about to face instead of the one they just cleared, and the tower/deck-select popup no longer kills every tooltip underneath it.

**How it works:**

*Wave counter.* `WaveController.updateUI()` now takes the number to display instead of reading `currWave`. `endWave()` calls `updateUI(currWave + 1)` on the non-final branch, so the counter flips the moment the field clears - before the popup beat - and `startNextWave()` re-displays the same number with no visible jump. `currWave` itself is untouched.

*Popup hover.* The popup's `CanvasLayer/PopupPanel` is a full-rect `Control` that draws nothing; it existed only to eat mouse input across the whole screen. Godot's built-in tooltips fire only on the topmost mouse hit, so everything under it went hover-dead. It is now `MOUSE_FILTER_IGNORE`, set in `UITowerSelect._ready()`. The centred `Panel` card still STOPs clicks on its own rect.

*Modality.* Nothing was loosened. `GameScene` already refused field clicks (`_unhandled_input`) and the Staff skill press while a popup was open; those two guards now read a named `_popup_is_blocking()`, which splits "a popup is covering the field" from `_popup_open`'s other meaning, "a popup exists, do not open a second one". Same value today - the split is the seam the queued hide-popup button needs.

*Inspection.* Opening either popup clears both stats panels, dropping the inspect outline with them.

**Findings:**

- The full-rect blocker was a redundant second layer of modality - the real enforcement has always been the `_popup_open` guards in `GameScene`. Its only live effect was killing hover. Verdict (Engineer, confirmed by a `/scrutinize` pass before coding): make it hit-transparent rather than restructuring CanvasLayers or reparenting the HUD, which was the first design and would have churned node paths in `tower_factory.gd` and `game_scene.gd` for no gain.
- That fix initially lived in `tower_select.tscn`. The scrutinize pass found the same file already builds its title header programmatically to avoid scene edits (`UI_tower_select.gd:15-18`), so the property moved into `_ready()`. Verdict: no `.tscn` change in this PR at all.
- Making the blocker transparent also made the stats panels' effect and skill icons hoverable under the popup. Shipped as a bonus, then rejected by the Director on review: a panel left open sits half-covered by a centred modal, and the queued "show tower range on inspect" task would be hidden the same way. Verdict (Director): clear the selection when a popup opens. The range ring will clear for free since it hangs off the same selection.
- `currWave` must not be incremented early to "simplify" the counter. Four consumers read it as the wave just finished: the deck-unlock milestone match, the end-of-run check, `startNextWave`'s own bound check plus increment, and the boss lookup. Recorded as an invariant in `game_stage.md` and at the call site.
- Audited every Control under the blocker before loosening it. All inert (`IGNORE` since PR #85, or `visible = false`) except the Staff skill button, whose press was already guarded. The two stats-panel roots are `STOP` but have no input handler anywhere in `scripts/`. No action needed - recorded so the next agent does not re-derive it.
- If the staff dies to the last enemy reaching the endpoint, the counter flips for roughly one frame before the End Demo screen covers it. Verdict: cosmetic, accepted, not guarded.

**Implementation Notes:**

`updateUI` changed signature; it had exactly one caller and no scene-side connection, both verified before the change.

Worth a close look: the `_popup_is_blocking()` swap at `_unhandled_input` replaces **only** the `_popup_open` term. The `state == "game_over"` term must stay - `_on_deck_selected` / `_on_deck_skipped` briefly set `_popup_open = false` while a popup is still in the tree, and on the game-over path that term is what still blocks.

`_popup_is_blocking()` is an identity wrapper today, which the project's Simplicity First rule would normally reject. It is here because the Director asked for the groundwork for the hide-popup button; two call sites, two comment lines. A follow-up idea is recorded at `_clear_inspection()`: once that button exists, hiding and restoring the selection may beat dropping it, so pressing hide returns the player to their last inspected tower with its range.

Godot test passed 2026-07-20 across both popup paths (tower select and the wave-5 deck popup), boss waves, the final wave, and a fresh run.
