### PR TITLE
Attack-range ring on the inspected tower

### DIFF
--- a/resources/database/towers/machina_x_flayon.yaml
+++ b/resources/database/towers/machina_x_flayon.yaml
@@ -66,7 +66,7 @@ skill:
 
 evolutionStat:
   damage: 400
-  attackRange: 4.0
+  attackRange: 2.0
   attackSpeed: 20
   mana: 100
   initialMana: 80

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -86,7 +86,7 @@ skills:
 
 evolutionStat:
   damage: 500
-  attackRange: 4.0
+  attackRange: 3.0
   attackSpeed: 60
   mana: 100
   initialMana: 60

--- a/scripts/enemy_detector.gd
+++ b/scripts/enemy_detector.gd
@@ -4,46 +4,87 @@ class_name EnemyDetector
 var radius: float = 3
 @export var collision: CollisionShape2D;
 
+# Attack-range ring, drawn for both the placement preview and an inspected tower
+# (ui.md). Publisher-CI blue family: bright cyan edge over a faint blue wash.
+# Static by design - the inspect outline already owns the pulsing beat, and a
+# second pulse on a shape this large reads as noise (Director 2026-07-20).
+const RING_FILL := Color(0.40, 0.85, 1.00, 0.12)
+const RING_STROKE := Color("#6cecfd", 0.95)
+# Blocked variant, placement only: the cell tint alone was easy to miss once the
+# ring drew in a friendly colour, so the ring itself answers "can I drop here"
+# (Director 2026-07-20).
+const RING_FILL_BLOCKED := Color(1.00, 0.35, 0.35, 0.12)
+const RING_STROKE_BLOCKED := Color(0.80, 0.16, 0.20, 0.95)
+# Cell-relative, not a pixel literal: world-space _draw() must survive camera
+# zoom and map-extent changes (ui.md world-drawing rule). CELL_SIZE comes from an
+# autoload, so this stays a fraction and is resolved at draw time, not a const.
+const RING_STROKE_CELL_FRAC := 0.046
+
 var target: Enemy = null
 var enemyInRange: Array[Enemy] = []
 var enableDrawRange: bool = false
+var rangeBlocked: bool = false
 
 signal onEnemyDetected(enemy: Enemy)
 signal onRemoveTarget()
 
 func setup(p_radius: float):
-	self.radius = p_radius + 0.5
-
 	# 🔥 Make shape unique so it won't affect other towers
 	if collision and collision.shape:
 		collision.shape = collision.shape.duplicate()
 
-	var circle = collision.shape as CircleShape2D
-	if circle:
-		circle.radius = self.radius * GridHelper.CELL_SIZE
+	syncRange(p_radius)
+
+	# Ring sits below every tower (z 0) and enemy (z 1) but above the TileMap
+	# (also -1, but earlier in tree order), so an inspected tower's ring never
+	# washes over its neighbours' art.
+	z_index = -1
 
 	connect("area_entered", Callable(self, "onCollisionHit"))
 	connect("area_exited", Callable(self, "onCollisionExit"))
 
+# The only place the detection radius is written. Call it whenever the tower's
+# range can have changed (level-up, evolve) - the value is a snapshot, not a
+# live read, so a missed call silently desyncs the real hitbox from the range
+# the stats panel displays (tower.md).
+func syncRange(p_range: float) -> void:
+	self.radius = p_range + 0.5
+
+	if collision != null:
+		var circle = collision.shape as CircleShape2D
+		if circle:
+			circle.radius = self.radius * GridHelper.CELL_SIZE
+
+	queue_redraw()
+
 func setEnabledDrawRange(value: bool):
+	if not value:
+		# Placement is the only writer of the blocked state, so clearing it on
+		# hide guarantees an inspected tower can never inherit a stale red ring.
+		rangeBlocked = false
 	enableDrawRange = value
+	queue_redraw()
+
+# Called every frame while a tower is being dragged, so it must stay a no-op
+# until the answer actually flips - otherwise the ring is back to redrawing
+# every frame.
+func setRangeBlocked(value: bool) -> void:
+	if rangeBlocked == value:
+		return
+	rangeBlocked = value
+	queue_redraw()
 
 func _draw():
 	if not enableDrawRange:
 		return
 
-	var circleColor = Color.SPRING_GREEN
-	circleColor.a = 0.25
+	var fill = RING_FILL_BLOCKED if rangeBlocked else RING_FILL
+	var stroke = RING_STROKE_BLOCKED if rangeBlocked else RING_STROKE
 
 	var draw_radius = radius * GridHelper.CELL_SIZE
-	draw_circle(position, draw_radius, circleColor)
-
-	if target != null:
-		var targetLocalPos = to_local(target.global_position)
-		draw_line(position, targetLocalPos, Color.RED, 2.0)
-
-func _process(_delta):
-	queue_redraw();
+	draw_circle(position, draw_radius, fill)
+	draw_arc(position, draw_radius, 0.0, TAU, 64, stroke,
+			GridHelper.CELL_SIZE * RING_STROKE_CELL_FRAC, true)
 
 func onCollisionHit(area: Area2D):
 	if area.is_in_group("enemy"):

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -76,7 +76,7 @@ func _ready():
 		attackController.setup(self, Callable(stat, "getAttackDelay"));
 
 	if(enemyDetector != null):
-		enemyDetector.setup(stat.attackRange);
+		enemyDetector.setup(data.getAttackRange());
 		Utility.ConnectSignal(enemyDetector, "onRemoveTarget", Callable(self, "clearEnemy"))
 		if inPlaceMode:
 			showAttackRange(true);
@@ -187,6 +187,8 @@ func exitPlaceMode():
 
 func upgrade():
 	var success = data.levelUp()
+	if success:
+		_syncDetectorRange()
 	setTowerStar(data.level);
 	return success
 
@@ -194,6 +196,7 @@ func evolve():
 	var success = data.evolve()
 	if success:
 		_play_evolve_sound()
+		_syncDetectorRange()
 		setTowerStar(4)
 		if data.evolutionSkill != null:
 			if skillController != null:
@@ -294,6 +297,8 @@ func updateTowerState():
 	var cellPos = GridHelper.WorldToCell(position);
 	var valid = Map.isCellAvailable(cellPos);
 	updateSpriteColor(valid);
+	if enemyDetector != null:
+		enemyDetector.setRangeBlocked(!valid);
 	isOnValidCell = valid;
 
 func updateSpriteColor(available: bool):
@@ -399,6 +404,15 @@ func resetForWave():
 func showAttackRange(p_show: bool):
 	if enemyDetector != null:
 		enemyDetector.setEnabledDrawRange(p_show);
+
+# The detector caches its radius, so every path that can change the tower's
+# range must push the new value. Sourced from getAttackRange() (stat + RANGE
+# effects), not the raw stat, so the hitbox matches the stats-panel readout.
+# Known gap: nothing hooks effect apply/expire yet - dormant, no data uses
+# Kind.RANGE today (tower.md).
+func _syncDetectorRange():
+	if enemyDetector != null:
+		enemyDetector.syncRange(data.getAttackRange());
 
 func setTowerStar(tier: int):
 	if(towerStar != null):

--- a/scripts/scene/game_scene.gd
+++ b/scripts/scene/game_scene.gd
@@ -268,6 +268,11 @@ func _on_staff_died():
 	# Mark game over BEFORE any UI work so popup factories early-return if they fire
 	# concurrently from a wave-end timer or deferred callback.
 	state = "game_over"
+	# Drop the inspected tower/enemy. The end screen is a centred panel, not a
+	# full-screen cover, so an outline or range ring left behind it stays visible
+	# - and _unhandled_input early-returns on game_over, so the player could
+	# never clear it.
+	_clear_inspection()
 	# Dismiss any tower-select / deck popup currently open so it can't sit on top of
 	# the end screen or accept clicks after the game is over.
 	if _active_popup != null and is_instance_valid(_active_popup):

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -34,9 +34,12 @@ var _tower: Tower = null
 # Rebuild key for the skill-icon row ("level_isEvolved"): icons/tooltips only
 # change on level-up or evolve, so the per-frame poll skips the rebuild.
 var _skills_key: String = ""
-# Inspect-highlight outline on the selected tower's sprite (ui.md). One material
-# is enough: only one unit is ever selected (panels mutually clear).
+# Inspect visuals on the selected tower (ui.md): the sprite outline plus the
+# attack-range ring. One material is enough - only one unit is ever selected
+# (panels mutually clear). Both visuals share one apply/remove pair so a future
+# teardown path cannot clear one and leak the other.
 var _outline_mat: ShaderMaterial
+var _hl_tower: Tower = null
 var _hl_sprite: AnimatedSprite2D = null
 
 func _ready():
@@ -51,7 +54,7 @@ func show_tower(tower: Tower) -> void:
 	# Container lives on TowerData, which evolve() mutates in place and which
 	# outlives the node - bind once per selection is safe.
 	_effect_row.setup(tower.data.effects if tower.data != null else null)
-	_apply_highlight(tower.spr)
+	_apply_highlight(tower)
 	_refresh()
 
 func clear() -> void:
@@ -64,8 +67,15 @@ func clear() -> void:
 # grow contraction). Feeding it live from the sprite - instead of hardcoding any
 # frame/sheet size - keeps the highlight correct through future asset resizes
 # or repacks (Director requirement 2026-07-17).
-func _apply_highlight(spr: AnimatedSprite2D) -> void:
+func _apply_highlight(tower: Tower) -> void:
 	_remove_highlight()
+	if tower == null:
+		return
+	_hl_tower = tower
+	# The ring is the tower's own placement-preview draw, reused as-is: same
+	# radius source as the real detection shape, so it cannot lie about reach.
+	tower.showAttackRange(true)
+	var spr := tower.spr
 	if spr == null:
 		return
 	_hl_sprite = spr
@@ -78,6 +88,9 @@ func _apply_highlight(spr: AnimatedSprite2D) -> void:
 	spr.animation_changed.connect(_update_highlight_region)
 
 func _remove_highlight() -> void:
+	if _hl_tower != null and is_instance_valid(_hl_tower):
+		_hl_tower.showAttackRange(false)
+	_hl_tower = null
 	if _hl_sprite != null and is_instance_valid(_hl_sprite):
 		_hl_sprite.material = null
 		if _hl_sprite.frame_changed.is_connected(_update_highlight_region):


### PR DESCRIPTION
> **Stacked on #116** - base is `feat/wave-counter-and-popup-hover`, not `main`. The game-over fix calls `_clear_inspection()`, which only exists in #116. Merge #116 first; GitHub will retarget this to `main` automatically.

**Summary:** Attack range was visible only while dragging a tower onto the board. Clicking a placed tower now draws the same ring alongside the stats panel, restyled to the publisher CI for both triggers.

**How it works:** No new node. The placement preview is `EnemyDetector._draw()`, already a child of every tower and already sized off the same value that feeds the real `CircleShape2D`, so the ring cannot lie about reach. `TowerStatsPanel` toggles it through the existing `_apply_highlight` / `_remove_highlight` pair rather than a second stored reference, so every deselect path that already cleared the outline clears the ring too. Extension point: `EnemyDetector.syncRange()` is now the single writer of the detection radius.

Visual: bright cyan edge over a faint blue wash, static - the inspect outline owns the pulsing beat, and a second pulse on a shape this large reads as noise. Blue now means "range" everywhere, leaving green/red to mean only "buildable". During placement the ring additionally flips to a red pair on an invalid cell, since the cell tint alone was easy to miss once the ring read as friendly. `z_index = -1` keeps it under neighbouring tower art. All four colours and the stroke width are consts at the top of `enemy_detector.gd`.

**Findings:**

- **Detector radius was write-once (pre-existing).** Set at `_ready` and never again, so level-up, evolve, and `Kind.RANGE` effects moved the stats-panel number without moving the hitbox. Consolidated into `EnemyDetector.syncRange()`, called from `_ready` / `upgrade()` / `evolve()` and sourced from `getAttackRange()` so the effect term is included. Remaining seam, deliberately not built: nothing hooks effect apply/expire - dormant, no data uses `Kind.RANGE` today.
- **Ina and Flayon authored an evolve range of 4.0** against base 3.0 / 2.0. Per Director, no tower is designed to change range on evolve, so both are corrected to match base. Net gameplay effect **zero**: real detection already used the base value, only the displayed number was wrong. The other ten towers hold range constant across all levels and evolve.
- **Game over never cleared the inspection (pre-existing, dates to #103).** The end screen is a centred panel, not a full-screen cover, and `_unhandled_input` early-returns on `game_over` - so an outline (and now a ring) stayed visible behind it with no way to dismiss it. One line in `_on_staff_died()`.
- **Deleted the red target-tracking line** in `_draw()`: a placement-era debug aid that never fired while dragging (no target yet) but would fire constantly on a tower inspected mid-combat.
- **Dropped the per-frame `queue_redraw()`** running on every tower for the life of the run. With the debug line gone nothing in the draw is time-dependent, so it redraws only when its three inputs change; the blocked-state setter no-ops until the answer actually flips. Verified in-engine that the placement ring still tracks the dragged tower.
- `ninomae_ina_nis.yaml` also changes in #115, on unrelated lines (attack VFX block vs `evolutionStat`). Cherry-pick auto-merged clean; no action needed.

**Implementation Notes:** Look closely at the shared `_apply_highlight` / `_remove_highlight` pair in `tower_stats_panel.gd` - it now owns two visuals, which was the deliberate choice over a parallel `_ring_tower` reference that a future teardown path could forget. `enemy_stats_panel.gd` keeps its own private copy of the pair and is unaffected. Also worth a look: `setEnabledDrawRange(false)` clears the blocked state, which is what guarantees an inspected tower can never inherit a stale red ring from placement.

Ring radius is `(attackRange + 0.5) * CELL_SIZE`, so a tower whose panel reads "Range 3" gets a 3.5-cell ring. That half-cell is pre-existing authoring language (range 1.0 reaches all eight neighbouring cell centres) and matches the real `CircleShape2D`; left unchanged.
