### PR TITLE
Remove claude-doc references from code comments

### DIFF
--- a/resources/database/effect/effects.yaml
+++ b/resources/database/effect/effects.yaml
@@ -4,8 +4,8 @@
 # icons by editing the icon path here (assets under resources/ui_asset/effects/).
 #
 # Fields per entry:
-#   name       display name (player-facing, English - see game_copy.md)
-#   desc       player-facing tooltip line (game_copy.md voice). Numbers are
+#   name       display name (player-facing, English)
+#   desc       player-facing tooltip line. Numbers are
 #              NEVER typed in: the {value} token resolves to the real applied
 #              magnitude (stacks included) at display time.
 #   icon       texture path relative to resources/

--- a/resources/database/enemy/forest01/boss/giant_boar.yaml
+++ b/resources/database/enemy/forest01/boss/giant_boar.yaml
@@ -3,9 +3,9 @@
 # waves this boss is eligible to spawn on; `scale` is the visual/hitbox size
 # multiplier applied at spawn. Skills are inline (3 max by design); balance
 # numbers live once in each skill's `parameters` - actions bind via *_param
-# keys and the desc renders the same values via {token} (enemy_skill.md).
+# keys and the desc renders the same values via {token}.
 # Area sizes ("5x5") stay literal in desc until the structural parameterize
-# task (post-demo). Design source: Director xlsx 2026-07-09 (boss.md Giant Boar).
+# task (post-demo). Design source: Director xlsx 2026-07-09.
 name: Giant Boar
 scale: 2
 wave:

--- a/resources/database/enemy/forest01/boss/king_salam.yaml
+++ b/resources/database/enemy/forest01/boss/king_salam.yaml
@@ -3,7 +3,7 @@
 # waves this boss is eligible to spawn on; `scale` is the visual/hitbox size
 # multiplier applied at spawn. Skills are inline (3 max by design); balance
 # numbers live once in each skill's `parameters` - actions bind via *_param
-# keys and the desc renders the same values via {token} (enemy_skill.md).
+# keys and the desc renders the same values via {token}.
 # Area sizes ("7x7") stay literal in desc until the structural parameterize
 # task (post-demo).
 name: King Salam

--- a/resources/database/enemy/forest01/elite/shielded_goblin.yaml
+++ b/resources/database/enemy/forest01/elite/shielded_goblin.yaml
@@ -1,6 +1,6 @@
 # Elite: Shielded Goblin (renamed from armored_goblin, 2026-07-07).
 # `type: passive` = the skill's actions apply once at spawn - the shield is
-# already up before the first hit (see enemy_skill.md).
+# already up before the first hit.
 stats:
   hp: 500
   def: 0

--- a/resources/database/staffs/a_chan.yaml
+++ b/resources/database/staffs/a_chan.yaml
@@ -14,7 +14,7 @@ end_sprite_scene: staffs/a_chan/sprite/staff_a_chan_sprite.tscn
 # Skill — "Hard Worker Ghost Release!!!" (Phase 2)
 # Active player-aimed AOE 4×4 cells; 1 charge per game.
 # Boss enemies → 25% Max HP True Damage; non-boss → 100% Max HP True Damage (= kill).
-# True damage bypasses armor + magic resist + ΣAmp + ΣRed (see damage_formula.md §4 TRUE).
+# True damage bypasses armor + magic resist + ΣAmp + ΣRed.
 skill:
   name: "Hard Worker Ghost Release!!!"
   desc: "A-Chan releases the spirits of hard workers, instantly killing all enemies in a 5x5 area. Boss enemies take 25% of their max HP as True Damage. Once per game."

--- a/resources/database/staffs/staffs.yaml
+++ b/resources/database/staffs/staffs.yaml
@@ -48,7 +48,7 @@
 # ------------------------------------------------------------
 # Skill schema  (reference for <staff_key>.yaml `skill:` block — Phase 2 onwards)
 # ------------------------------------------------------------
-# Reuses the Tower Skill resource + SkillAction primitives (see damage_formula.md §3,
+# Reuses the Tower Skill resource + SkillAction primitives (see
 # skill_utility.gd ParseAction for the full action-type catalog). Player-aimed AOE
 # skills set `context.extra.target_position` automatically via Staff.executeSkillAtPosition.
 #

--- a/resources/database/synergy/myth.yaml
+++ b/resources/database/synergy/myth.yaml
@@ -11,7 +11,7 @@ parameters:
   energy_return: [5, 7, 10]
 # Hover header (flavour). {energy_return} resolves to the current tier's value
 # and is auto-highlighted by the UI as the scaling number. Voice: units are
-# people - use they/them, never it/its (see game_copy.md voice rule).
+# people - use they/them, never it/its.
 desc: "Myth units possess the power of a primordial age, and whenever they cast a skill, all of them restore {energy_return} Energy."
 # Hover per-tier table line. One entry -> used for every tier (pure scaling).
 tier_effects:

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -34,7 +34,7 @@ stats:
     critMultiplier: 1.5
 
 # Active Skill - "Exocirst Field": a persistent purifying zone centered on
-# Hakka. It is the first "field" execution pattern (tower_skill.md) - planted
+# Hakka. It is the first "field" execution pattern - planted
 # non-blocking (Hakka keeps auto-attacking) and ticks physical damage + slow to
 # enemies inside every tickInterval for skillDuration seconds. Zone VFX =
 # effect_script on the field action (ofuda orbit + spirit vortex, persistent

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -43,7 +43,7 @@ skills:
     names: ["Skill I", "Skill II", "Skill III"] # optional UI display names per tower level
     desc: "Just a skill with {damageBonus:percent} bonus" # tokenized display text: {param} / {param:percent} resolve from parameters; token-free text renders as-is
     icon: "" # optional — ว่างได้ ถ้ายังไม่มี icon
-    # tags = ป้ายสรุปสกิลแบบผู้เล่นอ่าน (controlled registry ดู tower_skill.md §Tags)
+    # tags = ป้ายสรุปสกิลแบบผู้เล่นอ่าน (controlled registry)
     tags:
       - damage
       - attack

--- a/resources/tower/hololive/en_branch/myth_gen/amelia/normal_effect/amelia_bullet.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/amelia/normal_effect/amelia_bullet.gdshader
@@ -3,7 +3,7 @@ render_mode blend_mix;
 // Watson Amelia — normal-attack bullet (Soft Glow). Clean round shape drawn entirely
 // in-shader (no sprite texture sampled, so no black rim). Warm-gold pistol round.
 // Static look — the bullet's animation is its transform, not the shader (no internal
-// TIME; matches shader.md). Do NOT use MODULATE: a custom-COLOR canvas_item fragment
+// TIME). Do NOT use MODULATE: a custom-COLOR canvas_item fragment
 // won't auto-apply it and an unknown built-in fails compile silently (square fallback).
 // First production bullet in the game to use a custom shader (others use sprite+tint).
 

--- a/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_skill_effect.gd
+++ b/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_skill_effect.gd
@@ -1,7 +1,7 @@
 extends Node2D
 # ════════════════════════════════════════════════════════════════
 # Calliope · "Ricky" (normal) VFX controller — self-centered 3x3 scythe sweep.
-# Self-centered / aura family (docs/shader.md): no lane helpers, one stationary
+# Self-centered / aura family: no lane helpers, one stationary
 # square ColorRect centred on the caster; the shader plays the whole sweep via
 # `progress`. Spawned by SkillActionPlayEffect (bare Node2D at tower.global_position);
 # no setup() needed — the effect is centred, nothing to orient (Amelia precedent).

--- a/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_skill_effect.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/caliolpe/skill_effect/calliope_skill_effect.gdshader
@@ -1,7 +1,7 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha;   // premultiplied: the dark void/purple body stays true over the
                                   // bright lit map while the white soul-core still adds
-                                  // (docs/shader.md Section 3, Kiara Hinotori lesson).
+                                  // (Kiara Hinotori lesson).
 
 // ════════════════════════════════════════════════════════════════
 // Calliope · "Ricky" (normal) — Reaper's dark-energy crescent (self-centered 3x3).

--- a/resources/tower/hololive/en_branch/myth_gen/inanis/normal_effect/ina_ink_stroke.gdshader
+++ b/resources/tower/hololive/en_branch/myth_gen/inanis/normal_effect/ina_ink_stroke.gdshader
@@ -15,7 +15,7 @@ render_mode blend_premul_alpha;
 // attack_config.vfx_shader warm (resource_manager.gd) covers the impact too.
 //
 // blend_premul_alpha, NOT blend_add: the palette is ink-dark and blend_add only adds
-// luminance, so the ink bands would vanish over a lit map (shader.md Section 3).
+// luminance, so the ink bands would vanish over a lit map.
 // Do NOT use MODULATE - a custom-COLOR canvas_item fragment does not apply it.
 //
 // NO internal TIME. `life` (seconds in flight) is pushed each frame by

--- a/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gd
+++ b/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gd
@@ -1,7 +1,7 @@
 extends Node2D
 # ================================================================
 # Banzoin Hakka · "Exocirst Field" (normal) VFX controller — the first
-# FIELD-family effect (persistent ground zone, docs/shader.md).
+# FIELD-family effect (persistent ground zone).
 #
 # Spawned ONCE at field plant by SkillActionField (bare Node2D at
 # tower.global_position, parent = tower.get_parent()), NOT per tick:

--- a/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gdshader
@@ -1,6 +1,6 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha;   // dark pool must survive the lit map
-                                  // (docs/shader.md Section 3, Hinotori lesson)
+                                  // (Hinotori lesson)
 
 // ================================================================
 // Banzoin Hakka · "Exocirst Field" (normal) — persistent purifying zone.
@@ -37,7 +37,7 @@ uniform vec4 soul_color  : source_color = vec4(0.55, 0.95, 0.92, 1.0); // firefl
 // zone in the SQUARE 3x3 hitbox left corner gaps where enemies took damage
 // while looking outside the circle - the ring now overshoots the box's flat
 // edges slightly to shrink the corner gap to an accepted level. Visual frame
-// may exceed the code-side AOE (shader.md house rule).
+// may exceed the code-side AOE (house rule).
 uniform float ring_radius : hint_range(0.2, 0.5) = 0.425;
 uniform float ellipse     : hint_range(1.0, 1.8)  = 1.22; // ground perspective
 uniform float orbit_speed : hint_range(0.0, 2.0)  = 0.55;

--- a/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gdshader
@@ -1,6 +1,6 @@
 shader_type canvas_item;
 render_mode blend_premul_alpha;   // dark body must survive the lit map
-                                  // (docs/shader.md Section 3, Hinotori lesson)
+                                  // (Hinotori lesson)
 
 // ================================================================
 // Banzoin Hakka · "Obey my omen, in hymns allure" (EVOLVE) —

--- a/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/normal_effect/shinri_arrow.gdshader
+++ b/resources/tower/holostars/en_branch/tempus_gen/josuiji_shinri/normal_effect/shinri_arrow.gdshader
@@ -8,7 +8,7 @@ render_mode blend_add;
 // STATIC by design (no internal TIME) - the motion is the projectile's transform. The bullet
 // .tscn quad is authored WIDE (154x64) so the long axis = local +X = travel/forward; the
 // Projectile node (projectile.gd) rotates to face its target. White/blue-white only =>
-// blend_add is safe (shader.md). Do NOT use MODULATE (custom-COLOR fragment won't apply it).
+// blend_add is safe. Do NOT use MODULATE (custom-COLOR fragment won't apply it).
 //
 // attack_controller._applyBulletVisual pushes core_color / mid_color / glow_softness from the
 // tower's attack_config (YAML). arm_hh / notch / tail_hh / intensity are NOT pushed, so their

--- a/resources/tower/shared/lane_fx.gdshaderinc
+++ b/resources/tower/shared/lane_fx.gdshaderinc
@@ -1,7 +1,6 @@
 // Shared lane-effect shader helpers (Holo.Ve) - functions only, NO uniforms (each shader
 // keeps its own uniforms + ranges). #include this into lane-static directional skill-VFX
 // shaders so the bug-prone frame/origin math lives in ONE corner-free place.
-// See docs/shader.md "Skill-VFX families + checklist" for when to use these.
 
 // Soft fade-in at the lane origin. Replaces a hard step(0.0, lane_x) scissor at the caster,
 // which clipped the head/tail into a hard edge. softness = fade band in lane-x units.

--- a/resources/ui_component/inspect_outline.gdshader
+++ b/resources/ui_component/inspect_outline.gdshader
@@ -1,6 +1,6 @@
 shader_type canvas_item;
 
-// Inspect-highlight outline (ui.md): silhouette border drawn on the sprite of
+// Inspect-highlight outline: silhouette border drawn on the sprite of
 // the tower/enemy currently selected into a stats panel. First character-sprite
 // shader in the project - assigned/removed at runtime by the two stats panels.
 //

--- a/scripts/combat/damage.gd
+++ b/scripts/combat/damage.gd
@@ -16,7 +16,7 @@ var isCritical: bool = false;
 # Master Formula and TRUE damage still bypasses it. Frozen on purpose: a
 # projectile carries this value through its whole flight, and every enemy a
 # piercing shot passes through takes the value derived from the ORIGINAL target
-# (Marksman synergy - tower_synergy.md).
+# (Marksman synergy).
 var sourceAmp: float = 0.0
 
 # True when a skill authored this damage. Kill attribution reads this instead of

--- a/scripts/combat/skill_vfx.gd
+++ b/scripts/combat/skill_vfx.gd
@@ -2,8 +2,7 @@ class_name SkillVfx
 
 # Shared helpers for lane-static skill-VFX controllers (composition, NOT a base class -
 # each controller keeps its own lifecycle/geometry/tweens). Pairs with the shader-side
-# helpers in resources/tower/shared/lane_fx.gdshaderinc. See docs/shader.md "Skill-VFX
-# families + checklist".
+# helpers in resources/tower/shared/lane_fx.gdshaderinc.
 
 # Resolve the RAW aim vector for a lane effect, caster-agnostic (no `as Tower`, so a future
 # non-Tower caster like a Staff works once SkillActionPlayEffect stops gating on Tower).

--- a/scripts/effect/effect_container.gd
+++ b/scripts/effect/effect_container.gd
@@ -128,7 +128,7 @@ func stacks_of(effect_id: String) -> int:
 			total += inst.stacks
 	return total
 
-# ---- Mark API (framework; no consumer tower yet - see buff_debuff.md) ----
+# ---- Mark API (framework; no consumer tower yet) ----
 
 func has_mark(effect_id: String) -> bool:
 	return mark_stacks(effect_id) > 0

--- a/scripts/effect/effect_def.gd
+++ b/scripts/effect/effect_def.gd
@@ -7,7 +7,7 @@ extends RefCounted
 
 var id: String = ""
 var display_name: String = ""
-# Player-facing tooltip line (game_copy.md voice). Numbers are NEVER typed
+# Player-facing tooltip line. Numbers are NEVER typed
 # in: the "{value}" token resolves to the instance's real applied magnitude
 # (stacks included) at display time - same single-source rule as the
 # tokenized skill desc.

--- a/scripts/effect/effect_instance.gd
+++ b/scripts/effect/effect_instance.gd
@@ -42,7 +42,7 @@ func set_applier(applier: Node) -> void:
 
 # Overhead status-icon title: the skill-authored title when set, else the
 # registry name. Single-source with the icon tooltip - the UI never hand-builds
-# a title (game_copy.md).
+# a title.
 func display_title() -> String:
 	return authored_title if authored_title != "" else def.display_name
 

--- a/scripts/effect/effect_types.gd
+++ b/scripts/effect/effect_types.gd
@@ -37,7 +37,7 @@ enum Kind {
 	HOT,
 	# Per-attack, per-target amplifier: aggregate() yields the percent granted per
 	# cell of distance; the attack site turns it into a real amp via
-	# TowerData.getDistanceAmp (Marksman synergy - tower_synergy.md).
+	# TowerData.getDistanceAmp (Marksman synergy).
 	DAMAGE_AMP_PER_CELL,
 }
 

--- a/scripts/enemy_detector.gd
+++ b/scripts/enemy_detector.gd
@@ -4,8 +4,8 @@ class_name EnemyDetector
 var radius: float = 3
 @export var collision: CollisionShape2D;
 
-# Attack-range ring, drawn for both the placement preview and an inspected tower
-# (ui.md). Publisher-CI blue family: bright cyan edge over a faint blue wash.
+# Attack-range ring, drawn for both the placement preview and an inspected tower.
+# Publisher-CI blue family: bright cyan edge over a faint blue wash.
 # Static by design - the inspect outline already owns the pulsing beat, and a
 # second pulse on a shape this large reads as noise (Director 2026-07-20).
 const RING_FILL := Color(0.40, 0.85, 1.00, 0.12)
@@ -16,7 +16,7 @@ const RING_STROKE := Color("#6cecfd", 0.95)
 const RING_FILL_BLOCKED := Color(1.00, 0.35, 0.35, 0.12)
 const RING_STROKE_BLOCKED := Color(0.80, 0.16, 0.20, 0.95)
 # Cell-relative, not a pixel literal: world-space _draw() must survive camera
-# zoom and map-extent changes (ui.md world-drawing rule). CELL_SIZE comes from an
+# zoom and map-extent changes. CELL_SIZE comes from an
 # autoload, so this stays a fraction and is resolved at draw time, not a const.
 const RING_STROKE_CELL_FRAC := 0.046
 
@@ -46,7 +46,7 @@ func setup(p_radius: float):
 # The only place the detection radius is written. Call it whenever the tower's
 # range can have changed (level-up, evolve) - the value is a snapshot, not a
 # live read, so a missed call silently desyncs the real hitbox from the range
-# the stats panel displays (tower.md).
+# the stats panel displays.
 func syncRange(p_range: float) -> void:
 	self.radius = p_range + 0.5
 

--- a/scripts/entity/enemy/enemy.gd
+++ b/scripts/entity/enemy/enemy.gd
@@ -31,7 +31,7 @@ var usingSkill: bool = false;
 # inCombatWindow seconds without damage puts the enemy back to sleep, looping.
 # A sleeping boss (out of coverage / towers busy elsewhere) is intended, not a
 # bug. Do NOT restore instant-cast-on-wake: with skills ready at spawn it
-# chain-casts the whole kit on first engagement (enemy_skill.md).
+# chain-casts the whole kit on first engagement.
 @export var inCombatWindow: float = 4.0
 @export var castWait: float = 4.0
 var inCombatRemaining: float = 0.0
@@ -147,8 +147,8 @@ func recvDamage(damage: Damage) -> int:
 
 	# Shield Block: one charge eats the WHOLE hit regardless of damage type
 	# (TRUE included). Unlike invincible the enemy STAYS targetable - that is
-	# the block vs untargetable line (enemy_skill.md). Charges live on
-	# stats.blockCount, outside the effect system (buff_debuff.md).
+	# the block vs untargetable line. Charges live on
+	# stats.blockCount, outside the effect system.
 	if stats.blockCount > 0:
 		stats.blockCount -= 1
 		Utility.show_float_text(global_position, get_parent(), "Block", Color(0.7, 0.85, 1.0))
@@ -161,7 +161,7 @@ func recvDamage(damage: Damage) -> int:
 	timer.timeout.connect(_on_damage_flash_timeout)
 
 	# TRUE damage bypasses armor/MR + ΣAmp + ΣRed — raw value applied straight to HP.
-	# First caller: Staff skill `damage_percent_maxhp` (see damage_formula.md §4).
+	# First caller: Staff skill `damage_percent_maxhp`.
 	var damageVal: int
 	if damage.type == Damage.DamageType.TRUE:
 		damageVal = damage.damage
@@ -195,7 +195,7 @@ func recvDamage(damage: Damage) -> int:
 	elif skillController != null:
 		# HP%-trigger check at the single HP-loss site; a killing blow never
 		# triggers (dead() wins). Only flags pending - the cast fires from the
-		# _process hook (enemy_skill.md Triggered).
+		# _process hook.
 		skillController.check_hp_triggers(float(currentHp) / float(stats.maxHp))
 
 	var dmgColor: Color
@@ -281,7 +281,7 @@ func isInCombat() -> bool:
 	return inCombatRemaining > 0.0
 
 # Pacing gate for EnemySkillController.useSkill: awake AND the castWait timer
-# has elapsed (enemy_skill.md cast rules).
+# has elapsed.
 func canCastNow() -> bool:
 	return isInCombat() and castWaitRemaining <= 0.0
 

--- a/scripts/entity/tower/tower.gd
+++ b/scripts/entity/tower/tower.gd
@@ -409,7 +409,7 @@ func showAttackRange(p_show: bool):
 # range must push the new value. Sourced from getAttackRange() (stat + RANGE
 # effects), not the raw stat, so the hitbox matches the stats-panel readout.
 # Known gap: nothing hooks effect apply/expire yet - dormant, no data uses
-# Kind.RANGE today (tower.md).
+# Kind.RANGE today.
 func _syncDetectorRange():
 	if enemyDetector != null:
 		enemyDetector.syncRange(data.getAttackRange());

--- a/scripts/resource_manager/resource_manager.gd
+++ b/scripts/resource_manager/resource_manager.gd
@@ -189,7 +189,7 @@ static func warmSkillEffectShaders(host: Node) -> void:
 		if data.attack_config != null and data.attack_config.vfx_shader != "":
 			shaderPaths[data.attack_config.vfx_shader] = true
 
-	# Inspect-highlight outline (tower/enemy click-select, ui.md): assigned to a
+	# Inspect-highlight outline (tower/enemy click-select): assigned to a
 	# character sprite on first selection, so warm it here with the rest.
 	shaderPaths["res://resources/ui_component/inspect_outline.gdshader"] = true
 

--- a/scripts/skill/enemy_skill_controller.gd
+++ b/scripts/skill/enemy_skill_controller.gd
@@ -67,7 +67,7 @@ func onSuccess(skill: Skill):
 # after the HP write; check_hp_triggers only flags PENDING - the cast fires
 # from useTriggeredSkill() in the Enemy._process hook once the busy flag frees,
 # bypassing the castWait pacing gate (the condition is its own telegraph; the
-# gate paces gate-driven Actives, not condition reactions - enemy_skill.md).
+# gate paces gate-driven Actives, not condition reactions).
 var pendingTriggered: Array[Skill] = []
 
 func check_hp_triggers(hp_ratio: float):

--- a/scripts/skill/skillActions/skill_action_aftershock.gd
+++ b/scripts/skill/skillActions/skill_action_aftershock.gd
@@ -1,7 +1,7 @@
 class_name SkillActionAftershock
 extends SkillAction
 
-# "aftershock" execution pattern (tower_skill.md): the cast plants a delayed
+# "aftershock" execution pattern: the cast plants a delayed
 # re-hit of the SAME area and returns immediately - the tower resumes normal
 # behavior while the bomb waits. Everything resolves at EXPLOSION time: fresh
 # target query at the snapshotted cast-time center, live Total Attack, live

--- a/scripts/skill/skillActions/skill_action_attack.gd
+++ b/scripts/skill/skillActions/skill_action_attack.gd
@@ -81,7 +81,7 @@ func execute(context: SkillContext):
 	# Cache crit context (avoid recomputing per-target)
 	var stat = tower.data.getStat()
 	# The authored canCrit gate can be opened from outside by the SpellCaster
-	# synergy marker (tower_synergy.md). It unlocks the roll only - the synergy
+	# synergy marker. It unlocks the roll only - the synergy
 	# grants no crit chance, so a 0-chance holder still never crits.
 	var critAllowed: bool = canCrit or tower.data.effects.stacks_of("spellcaster_crit") > 0
 	var critChance: float = tower.data.getCritChance() if critAllowed else 0.0

--- a/scripts/skill/skillActions/skill_action_channel.gd
+++ b/scripts/skill/skillActions/skill_action_channel.gd
@@ -1,7 +1,7 @@
 class_name SkillActionChannel
 extends SkillAction
 
-# "channel" execution pattern (tower_skill.md): the cast locks the aimed zone
+# "channel" execution pattern: the cast locks the aimed zone
 # and holds the tower busy for `cast_time` seconds while re-striking that zone
 # every `tick_interval`. BLOCKING - execute() awaits until the channel ends, so
 # the controller keeps usingSkill true and Energy drains only at onSuccess

--- a/scripts/skill/skillActions/skill_action_dash.gd
+++ b/scripts/skill/skillActions/skill_action_dash.gd
@@ -9,7 +9,7 @@ extends SkillAction
 # normally: Enemy._process runs its endpoint check outside the movement gate,
 # and the path curve does not loop, so overshoot clamps (design: a dash into
 # the base IS a leak). A stunned caster still completes the slide - cast rule
-# "a started skill always completes" (enemy_skill.md).
+# "a started skill always completes".
 
 @export var cells: float = 1.0
 @export var duration: float = 0.3

--- a/scripts/skill/skillActions/skill_action_field.gd
+++ b/scripts/skill/skillActions/skill_action_field.gd
@@ -1,7 +1,7 @@
 class_name SkillActionField
 extends SkillActionChannel
 
-# "field" execution pattern (tower_skill.md): a NON-BLOCKING, self-centered,
+# "field" execution pattern: a NON-BLOCKING, self-centered,
 # persistent damaging + debuffing zone. Unlike "channel" (which BLOCKS the
 # caster for the whole duration), the field is planted and execute() returns
 # immediately - the tower resumes auto-attack while the zone ticks on its own,

--- a/scripts/skill/skillActions/skill_create_circle_projectile.gd
+++ b/scripts/skill/skillActions/skill_create_circle_projectile.gd
@@ -17,6 +17,6 @@ func setupProjectile(projectile: Projectile, i: int, context: SkillContext):
 	var damage := Damage.new(tower, int(multi * tower.data.getDamage(null, null).damage), damageType)
 	damage.isSkillDamage = true
 	# No sourceAmp: getDamage(null, null) has no target to measure against, so
-	# skill projectiles carry no distance bonus (gap noted in tower_synergy.md).
+	# skill projectiles carry no distance bonus (known gap).
 	projectile.setup_circle(tower, damage, circle_radius, angular_speed, initial_angle + (angle_offset * i), lifetime, ProjectileCallback.new(Callable(self, "onHit"), Callable(), Callable()))
 	super.setupProjectile(projectile, i, context)

--- a/scripts/skill/skillActions/skill_create_directional_projectile.gd
+++ b/scripts/skill/skillActions/skill_create_directional_projectile.gd
@@ -22,7 +22,7 @@ func setupProjectile(projectile: Projectile, i: int, context: SkillContext):
 	var damage: Damage = Damage.new(tower, int(multi * tower.data.getDamage(null, null).damage), damageType)
 	damage.isSkillDamage = true
 	# No sourceAmp: getDamage(null, null) has no target to measure against, so
-	# skill projectiles carry no distance bonus (gap noted in tower_synergy.md).
+	# skill projectiles carry no distance bonus (known gap).
 
 	# Direction = from tower toward primary target. Prefer the first target
 	# picked by find_multi_enemy (closest-to-path-end after sorting). Fall

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -16,7 +16,7 @@ static func ParseSkill(skillDataList: Array) -> Array[Skill]:
 		# author per-beat play_animation cast_time instead (idle-hold key removed).
 		var castTime = float(skill.get("cast_time", 0.0));
 		# Single source for balance numbers: actions bind via *_param keys and
-		# the desc renders the same values via {token} (enemy_skill.md Copy).
+		# the desc renders the same values via {token}.
 		var parameters: Dictionary = skill.get("parameters", {});
 		var actions: Array[SkillAction] = [];
 		var actionList = skill.get("action", []);
@@ -63,7 +63,7 @@ static func ParseSkill(skillDataList: Array) -> Array[Skill]:
 # warns and falls back to the literal/default - loud but not fatal (the desc
 # side shows the raw {token} for the same breakage). Convention note: these new
 # keys use the short `*_param` suffix (matching apply_effect's runtime keys);
-# the older `*_param_name` sites stay as-is (enemy_skill.md).
+# the older `*_param_name` sites stay as-is.
 static func _resolve_param(skillData: Dictionary, parameters: Dictionary, param_key: String, fallback: float) -> float:
 	var pname := str(skillData.get(param_key, ""));
 	if pname == "":
@@ -193,7 +193,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 				skill.statusEffects = EffectUtility.parse_effect_list(attackEffectList, parameters, "action_" + str(skill.get_instance_id()));
 		"aftershock":
 			# Delayed non-blocking re-hit of a snapshotted area ("aftershock"
-			# pattern - tower_skill.md). The inner find/attack are built from
+			# pattern). The inner find/attack are built from
 			# this same data block via this parser, so damage_multiplier_param_name,
 			# damage_type, can_crit, and stack_bonus_* all work in the explosion.
 			skill = SkillActionAftershock.new();
@@ -215,7 +215,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			if skillData.has("effect_script"):
 				skill.effect_action = ParseAction({"type": "play_effect", "data": {"effect_script": skillData["effect_script"]}}, parameters) as SkillActionPlayEffect;
 		"channel":
-			# Blocking zone-locked multi-tick ("channel" pattern - tower_skill.md).
+			# Blocking zone-locked multi-tick ("channel" pattern).
 			# The inner find/attack are built from this same data block via this
 			# parser, so damage_multiplier_param_name, damage_type, can_crit, and
 			# effects all work per tick.
@@ -254,8 +254,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			if skillData.has("effect_script"):
 				skill.effect_action = ParseAction({"type": "play_effect", "data": {"effect_script": skillData["effect_script"]}}, parameters) as SkillActionPlayEffect;
 		"field":
-			# Non-blocking persistent damage+debuff zone ("field" pattern -
-			# tower_skill.md). Reuses channel's inner find/attack build and its
+			# Non-blocking persistent damage+debuff zone ("field" pattern). Reuses channel's inner find/attack build and its
 			# ChannelTicker; castTime holds the field LIFETIME (not a cast hold).
 			# First user: Banzoin Hakka "Exocirst Field".
 			skill = SkillActionField.new();

--- a/scripts/synergy/synergy_data_loader.gd
+++ b/scripts/synergy/synergy_data_loader.gd
@@ -35,7 +35,7 @@ static func _build(raw: Dictionary, path: String) -> SynergyData:
 	d.rarity = str(raw.get("rarity", SynergyData.RARITY_COMMON))
 	d.effect = str(raw.get("effect", ""))
 	# YamlParser does not process escapes; translate \n loader-side, only for the
-	# text fields that want it (data_pipeline.md Problem #1).
+	# text fields that want it.
 	# Single tokenized desc key; a stale desc_template key warns and wins.
 	d.desc = str(raw.get("desc", "")).replace("\\n", "\n")
 	if raw.has("desc_template"):

--- a/scripts/synergy/synergy_effect.gd
+++ b/scripts/synergy/synergy_effect.gd
@@ -18,7 +18,7 @@ func activate() -> void:
 	pass
 
 # Active tier increased to new_tier (0-based). Tier never decreases mid-run
-# (no synergy deactivation by design - see tower_synergy.md).
+# (no synergy deactivation by design).
 func on_tier_changed(_new_tier: int) -> void:
 	pass
 

--- a/scripts/synergy/synergy_effect_marksman.gd
+++ b/scripts/synergy/synergy_effect_marksman.gd
@@ -10,10 +10,10 @@ extends SynergyEffect
 # (percent per cell); TowerData.getDistanceAmp turns that rate into a real
 # amplifier at each attack, and Enemy.recvDamage sums it into ΣAmp. That keeps
 # the bonus in the amplifier position of the Master Formula, so TRUE damage
-# still bypasses it (damage_formula.md).
+# still bypasses it.
 #
 # Distance is measured at fire time and rounded to the nearest whole cell
-# (Director 2026-07-20) - detail and rationale in tower_synergy.md Notes.
+# (Director 2026-07-20).
 
 const _SOURCE := "synergy_marksman"
 

--- a/scripts/synergy/synergy_effect_mission_tempus.gd
+++ b/scripts/synergy/synergy_effect_mission_tempus.gd
@@ -7,7 +7,7 @@ extends SynergyEffect
 # SUM rather than replace). Kill count starts when Tempus first activates (2 units)
 # and lives here in the effect; SynergyController is run-level, so it persists
 # across waves (never reset per wave). Rewards are BOARD-lifetime (survive wave
-# reset by construction - see buff_debuff.md).
+# reset by construction).
 #
 #   Tier 0 (2 units, 100 kills): Tempus units +atk_bonus% Physical & Magic Attack
 #   Tier 1 (4 units, 200 kills): Tempus units +as_bonus Attack Speed

--- a/scripts/ui/enemy_stats_panel.gd
+++ b/scripts/ui/enemy_stats_panel.gd
@@ -4,7 +4,7 @@ extends Control
 # Placeholder enemy stats panel (bottom-left HUD; artist design pass pending).
 # Sibling of TowerStatsPanel - both share the bottom-left slot, one selection
 # at a time (Director 2026-07-17). Skeleton cloned from tower_stats_panel.gd,
-# the shared layout convention (ui.md).
+# the shared layout convention.
 
 @onready var _portrait: TextureRect = $Portrait
 @onready var _name_label: Label = $NameLabel
@@ -14,7 +14,7 @@ extends Control
 @onready var _mr_value: Label = $StatsGrid/MrValue
 @onready var _hp_bar: ProgressBar = $HpRow/HpBar
 @onready var _hp_text: Label = $HpRow/HpBar/HpText
-# Right-edge column: hover popups open toward the open playfield (ui.md rule).
+# Right-edge column: hover popups open toward the open playfield.
 @onready var _skill_column: VBoxContainer = $SkillColumn
 # Buff/debuff strip floating above the panel's top border (rich hover).
 @onready var _effect_row: EffectIconRow = $EffectRow
@@ -28,7 +28,7 @@ const TIER_NAMES := {
 const OUTLINE_SHADER := preload("res://resources/ui_component/inspect_outline.gdshader")
 
 var _enemy: Enemy = null
-# Inspect-highlight outline on the selected enemy's sprite (ui.md). Enemies are
+# Inspect-highlight outline on the selected enemy's sprite. Enemies are
 # single full textures, so no frame-region feed is needed (unlike the tower
 # panel): the shader reads texture dimensions itself and region stays the
 # default whole-texture rect.

--- a/scripts/ui/staff_widget.gd
+++ b/scripts/ui/staff_widget.gd
@@ -16,7 +16,7 @@ signal skill_pressed  # forwarded by GameScene → Staff.requestCastSkill (Phase
 @onready var _skill_border: TextureRect = $SkillBorder
 
 # Hover effect — subtle scale tween on the skill area when mouse enters / leaves the button.
-# Reusable pattern for future skill widgets across the project (see ui.md §8 Artist-friendly principles).
+# Reusable pattern for future skill widgets across the project.
 const HOVER_SCALE := Vector2(1.05, 1.05)
 const HOVER_TWEEN_DURATION := 0.12
 var _hover_tween: Tween = null

--- a/scripts/ui/synergy/ui_synergy_content.gd
+++ b/scripts/ui/synergy/ui_synergy_content.gd
@@ -213,8 +213,8 @@ enum TierRowState { LOCKED, PENDING, EARNED }
 # kill gate uses mission_progress vs mission_kills[i] - mirroring
 # SynergyEffectMissionTempus._check_rewards (same get_parameter clamp, so display
 # and effect cannot diverge). Assumes tier is monotonic within a run - holds
-# permanently: no tower-removal path exists by Director decision
-# (tower_synergy.md Notes). If a tower-destroying mechanic ever ships, the
+# permanently: no tower-removal path exists by Director decision.
+# If a tower-destroying mechanic ever ships, the
 # effect's _rewarded[] is sticky while this recomputes live - re-derive then.
 static func _tier_row_state(data: SynergyData, i: int, tier: int, mission_progress: int) -> TierRowState:
 	if i > tier:

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -4,7 +4,7 @@ extends Control
 # Placeholder tower stats panel (bottom-left HUD). Artist design pass pending.
 # The skeleton (portrait / name+level header / trait row / stat grid / energy
 # bar / right-edge skill icon column) is the shared layout convention for the
-# future enemy stats panel (ui.md).
+# future enemy stats panel.
 
 @onready var _portrait: TextureRect = $Portrait
 @onready var _name_label: Label = $NameLabel
@@ -34,7 +34,7 @@ var _tower: Tower = null
 # Rebuild key for the skill-icon row ("level_isEvolved"): icons/tooltips only
 # change on level-up or evolve, so the per-frame poll skips the rebuild.
 var _skills_key: String = ""
-# Inspect visuals on the selected tower (ui.md): the sprite outline plus the
+# Inspect visuals on the selected tower: the sprite outline plus the
 # attack-range ring. One material is enough - only one unit is ever selected
 # (panels mutually clear). Both visuals share one apply/remove pair so a future
 # teardown path cannot clear one and leak the other.
@@ -144,8 +144,7 @@ func _refresh() -> void:
 	_class_icon.texture = _trait_sprite(class_display)
 	_gen_icon.texture = _trait_sprite(gen_display)
 
-	# Stats: live getters, so buffs/debuffs show (player-facing terms per
-	# game_copy.md). 3x2 grid: attack block left, crit block + range right.
+	# Stats: live getters, so buffs/debuffs show (player-facing terms). 3x2 grid: attack block left, crit block + range right.
 	_set_text(_atk_value, str(data.getTotalAttack()))
 	_set_text(_type_value, "Magic" if data.attackType == Damage.DamageType.MAGIC else "Physical")
 	_set_text(_as_value, _format_number(data.getAttackSpeed()))
@@ -192,7 +191,7 @@ func _make_skill_icon(skill: Skill, kind: String, level: int) -> TowerSkillIcon:
 
 	# No tower skill icon art exists yet; the shared synergy default placeholder
 	# stands in (a dedicated skills/default asset needs a Godot-generated .import,
-	# so reuse beats hand-adding a binary - see tower_skill.md icon note).
+	# so reuse beats hand-adding a binary).
 	var texture: Texture2D = null
 	if skill.icon != "":
 		texture = ResourceManager.loadImage("skill_icon", skill.icon, skill.icon)

--- a/test/vfx_template/lane_effect_template.gd
+++ b/test/vfx_template/lane_effect_template.gd
@@ -19,7 +19,7 @@ extends Node2D
 #              (Hinotori - the project quality bar)
 #   this shape kiara_skill_effect.gd + .gdshader (Flame Slash)
 #
-# OTHER FAMILIES (docs/shader.md "Skill-VFX families"):
+# OTHER FAMILIES:
 #   centered/aura  - drop setup()'s aim/rotation and the lane include;
 #                    keep the rect + tweens. See amelia_skill_effect.gd.
 #   lingering tail - a second, longer clock ("life_t") owns queue_free.

--- a/test/vfx_template/lane_effect_template.gdshader
+++ b/test/vfx_template/lane_effect_template.gdshader
@@ -2,7 +2,7 @@ shader_type canvas_item;
 // blend_add suits bright/warm palettes. If the palette has DARK bands
 // (violet/crimson/deep magenta), switch to blend_premul_alpha - blend_add
 // only ADDS luminance, so dark bands vanish over the lit map (Kiara
-// Hinotori lesson, docs/shader.md Section 3). Verify over the real map.
+// Hinotori lesson). Verify over the real map.
 render_mode blend_add;
 
 #include "res://resources/tower/shared/lane_fx.gdshaderinc"
@@ -13,7 +13,7 @@ render_mode blend_add;
 // white-hot core, and spark scatter. Replace the LAYER blocks with the
 // real effect; keep the frame/envelope structure.
 //
-// Rules baked in (docs/shader.md Section 2 + lane checklist):
+// Rules baked in:
 //   - progress / scale_p uniforms drive ALL motion - never TIME
 //   - lane_coord / lane_origin_gate / lane_frame_mask come from the
 //     shared include - never hand-roll frame/origin math, never step()
@@ -22,7 +22,7 @@ render_mode blend_add;
 //   - bounded tail: clean cut behind the head, no long faded drag
 // ================================================================
 
-// REQUIRED on every skill effect (docs/shader.md Section 2):
+// REQUIRED on every skill effect:
 uniform float progress : hint_range(0.0, 1.0) = 0.0;   // whole sequence (controller tween)
 uniform float scale_p  : hint_range(0.01, 1.2) = 1.0;  // elastic pop-in
 uniform float aspect   : hint_range(1.0, 6.0)  = 2.8;  // rect width/height (controller passes)

--- a/test/vfx_template/vfx_preview_harness.gd
+++ b/test/vfx_template/vfx_preview_harness.gd
@@ -13,7 +13,7 @@ extends Node2D
 #
 # This dark background hides blend_add washout: verify additive or
 # dark-band effects over the real lit map before calling a look final
-# (docs/shader.md Section 3, Kiara Hinotori lesson).
+# (Kiara Hinotori lesson).
 # ================================================================
 
 const EFFECT_SCRIPT := "res://test/vfx_template/lane_effect_template.gd"


### PR DESCRIPTION
﻿**Summary:** Remove every claude-doc name reference from game-repo comments (~70 sites, 49 files). Comment/annotation text only - zero behavior change (verified: every changed diff line is a comment line).

**How it works:** Doc-file names are cut while the explanation text stays, e.g. `(see enemy_skill.md)` dropped, `(docs/shader.md Section 3, Hinotori lesson)` -> `(Hinotori lesson)`. Rationale (Director 2026-07-21): the referenced docs live in a private notes repo the team does not have, so the names only confuse reviewers.

**Findings:** none.

Comment-only, no Godot test needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
