### PR TITLE
Terminology redesign (Weapon/Magic/Basic Attack) + synergy hover highlight rework

### DIFF
--- a/resources/database/effect/effects.yaml
+++ b/resources/database/effect/effects.yaml
@@ -36,32 +36,32 @@
 # ---- Tower buffs ----
 
 attack_flat_up:
-  name: "Attack Up"
-  desc: "Attack increased by {value}."
+  name: "Weapon Attack Up"
+  desc: "Weapon Attack increased by {value}."
   icon: "ui_asset/effects/buff_generic.png"
   category: buff
   host: tower
   kind: attack_flat
 
 attack_mult_up:
-  name: "Attack Up"
-  desc: "Attack increased by {value}."
+  name: "Weapon Attack Up"
+  desc: "Weapon Attack increased by {value}."
   icon: "ui_asset/effects/buff_generic.png"
   category: buff
   host: tower
   kind: attack_mult
 
 magic_flat_up:
-  name: "Magic Up"
-  desc: "Magic power increased by {value}."
+  name: "Magic Attack Up"
+  desc: "Magic Attack increased by {value}."
   icon: "ui_asset/effects/buff_generic.png"
   category: buff
   host: tower
   kind: magic_flat
 
 magic_mult_up:
-  name: "Magic Up"
-  desc: "Magic power increased by {value}."
+  name: "Magic Attack Up"
+  desc: "Magic Attack increased by {value}."
   icon: "ui_asset/effects/buff_generic.png"
   category: buff
   host: tower
@@ -135,7 +135,7 @@ crit_damage_up:
 
 mana_regen_up:
   name: "Energy Regen Up"
-  desc: "Energy gained per attack increased by {value}."
+  desc: "Energy gained per basic attack increased by {value}."
   icon: "ui_asset/effects/buff_generic.png"
   category: buff
   host: tower
@@ -191,16 +191,16 @@ attack_speed_down:
   kind: attack_speed
 
 attack_mult_down:
-  name: "Damage Down"
-  desc: "Damage dealt is reduced by {value}."
+  name: "Weapon Attack Down"
+  desc: "Weapon Attack reduced by {value}."
   icon: "ui_asset/effects/debuff_generic.png"
   category: debuff
   host: tower
   kind: attack_mult
 
 magic_mult_down:
-  name: "Magic Down"
-  desc: "Magic power reduced by {value}."
+  name: "Magic Attack Down"
+  desc: "Magic Attack reduced by {value}."
   icon: "ui_asset/effects/debuff_generic.png"
   category: debuff
   host: tower

--- a/resources/database/enemy/forest01/boss/giant_boar.yaml
+++ b/resources/database/enemy/forest01/boss/giant_boar.yaml
@@ -92,9 +92,9 @@ skill:
       damage_down: 20
       debuff_duration: 8
     # damage_down uses the whole-percent scale (attack_mult/magic_mult kinds
-    # divide by 100 at consumption), so the desc token is {damage_down}% with a
-    # literal % sign - NOT {damage_down:percent}, which would render "2000%".
-    desc: "The Giant Boar stomps the ground, shaking a 5x5 area - units caught inside deal {damage_down}% less damage for {debuff_duration} seconds."
+    # divide by 100 at consumption), so the desc token is {damage_down:pct}
+    # (appends % as-is) - NOT {damage_down:percent}, which would render "2000%".
+    desc: "The Giant Boar stomps the ground, shaking a 5x5 area - units caught inside deal {damage_down:pct} less damage for {debuff_duration} seconds."
     action:
       - type: apply_effect
         data:
@@ -103,7 +103,7 @@ skill:
           range: 2
           value_param: damage_down
           duration_param: debuff_duration
-          title: "Bulldoze - Damage Down"
+          title: "Bulldoze - Weapon Attack Down"
       - type: apply_effect
         data:
           effect: magic_mult_down
@@ -112,4 +112,4 @@ skill:
           value_param: damage_down
           duration_param: debuff_duration
           show_area: false
-          title: "Bulldoze - Magic Down"
+          title: "Bulldoze - Magic Attack Down"

--- a/resources/database/synergy/hero.yaml
+++ b/resources/database/synergy/hero.yaml
@@ -10,9 +10,12 @@ effect: attack_per_active_trait
 # with the rest of the board instead of with the Hero count.
 thresholds: [1]
 parameters:
-  # Percent scale (5 = +5%), per active Trait on the field. Scalar, not an array:
-  # the value does not scale by tier, so it must not render as a tier-scaling number.
+  # Percent scale (5 = +5%), per active Trait on the field. Scalar = not a
+  # per-tier value (shape follows semantics; every resolved value highlights).
   atk_per_trait: 5
-desc: "Hero units carry a champion's resolve, growing stronger with every Trait awakened on the field - each active Trait grants them +{atk_per_trait}% Physical Attack."
+# Flavour only - the number lives in the tier line (value-in-table copy rule).
+# Lore-sourced: Altare's official bio says his earnest straightforwardness
+# "may well lead to him being called a 'hero' one day" (Director 2026-07-21).
+desc: "An earnest heart destined to be called Hero - he grows stronger with every Trait awakened on the field."
 tier_effects:
-  - "+{atk_per_trait}% Physical Attack per active Trait"
+  - "+{atk_per_trait:pct} Weapon Attack per active Trait"

--- a/resources/database/synergy/marksman.yaml
+++ b/resources/database/synergy/marksman.yaml
@@ -9,13 +9,12 @@ effect: damage_per_range
 thresholds: [2]
 parameters:
   # Percent granted per CELL of distance to the target, not a flat amplifier.
-  # Authored as a per-tier array even with one tier: only an array renders as a
-  # highlighted scaling value in the hover (SynergyData._render), and a second
-  # tier must not require rewriting the desc.
-  amp_per_cell: [5]
-# Literal % after the token: the :percent format multiplies by 100. Say "of
+  # Scalar = not a per-tier value (shape follows semantics; every resolved
+  # value highlights).
+  amp_per_cell: 5
+# :pct appends % to a percent-scale value as-is (:percent would x100). Say "of
 # distance to", never "between them and" - at one cell apart there are zero
 # tiles "between" but the bonus is already +5%.
-desc: "Marksman units steady their aim across the field, dealing {amp_per_cell}% more damage for every tile of distance to their target."
+desc: "Marksman units steady their aim across the field, dealing {amp_per_cell:pct} more damage for every tile of distance to their target."
 tier_effects:
-  - "+{amp_per_cell}% damage per tile of distance"
+  - "+{amp_per_cell:pct} damage per tile of distance"

--- a/resources/database/synergy/spellcaster.yaml
+++ b/resources/database/synergy/spellcaster.yaml
@@ -10,17 +10,15 @@ effect: magic_up_skill_crit
 # is already a real deck commitment, and the bonus does not scale past it.
 thresholds: [2]
 parameters:
-  # Percent scale (25 = +25%), matching MAGIC_MULT. Authored as a per-tier array
-  # even though there is one tier: only an array renders as a highlighted
-  # scaling value in the hover (SynergyData._render), and a second tier must not
-  # require rewriting the desc (Director 2026-07-19).
-  magic_bonus: [25]
-# Literal % after the token: the :percent format multiplies by 100 (SynergyData),
-# which would render 2500%. The crit half grants the ABILITY only - it adds no
-# critical chance, and copy must not imply one (Director 2026-07-19).
-desc: "Spell Caster units draw deeper from the arcane, gaining +{magic_bonus}% Magic Attack, and their skills can now land critical hits."
-# Per-tier table line: the scaling stat only, matching Myth. The crit ability is
+  # Percent scale (25 = +25%), matching MAGIC_MULT. Scalar = not a per-tier
+  # value (shape follows semantics; every resolved value highlights).
+  magic_bonus: 25
+# :pct appends % to a percent-scale value as-is (:percent would x100 -> 2500%).
+# The crit half grants the ABILITY only - it adds no critical chance, and copy
+# must not imply one (Director 2026-07-19).
+desc: "Spell Caster units draw deeper from the arcane, gaining +{magic_bonus:pct} Magic Attack, and their skills can now land critical hits."
+# Per-tier table line: the stat value only, matching Myth. The crit ability is
 # a one-off unlock, not a per-tier value, so it lives in desc and stays out of
 # this line (Director 2026-07-19).
 tier_effects:
-  - "+{magic_bonus}% Magic Attack"
+  - "+{magic_bonus:pct} Magic Attack"

--- a/resources/database/synergy/tempus.yaml
+++ b/resources/database/synergy/tempus.yaml
@@ -21,10 +21,12 @@ parameters:
   energy_percent: 0.1
   energy_interval: 5
 desc: "The Tempus guild fights as one - clear each Guild Mission and they grow stronger together."
-# One line per tier (qualitative). {mission_kills} is the per-tier scaling value
-# (highlighted); reward magnitudes read scalar params so the text cannot drift
-# from the applied effect. :percent renders a decimal-scale value as N%.
+# One line per tier (qualitative). All token values highlight; reward
+# magnitudes read scalar params so the text cannot drift from the applied
+# effect. :percent renders a decimal-scale value as N%; :pct appends % to a
+# percent-scale value as-is. T1 says "Attack" - the umbrella term (both the
+# Weapon and Magic halves), matching the applied attack_mult + magic_mult pair.
 tier_effects:
-  - "Guild Mission - defeat {mission_kills} enemies. Reward: Tempus units gain +{atk_bonus}% Physical and Magic Attack."
+  - "Guild Mission - defeat {mission_kills} enemies. Reward: Tempus units gain +{atk_bonus:pct} Attack."
   - "Guild Mission - defeat {mission_kills} enemies. Reward: Tempus units gain +{as_bonus:percent} Attack Speed."
   - "Guild Mission - defeat {mission_kills} enemies. Reward: all units regain {energy_percent:percent} max Energy every {energy_interval}s."

--- a/resources/database/towers/axel_syrios.yaml
+++ b/resources/database/towers/axel_syrios.yaml
@@ -36,7 +36,7 @@ stats:
 
 skill:
   name: "Skill"
-  desc: "Axel Syrios strikes the 3x1 line in front of him with a fierce blow, dealing physical damage to every enemy caught in it."
+  desc: "Axel Syrios strikes the 3x1 line in front of him with a fierce blow, dealing weapon damage to every enemy caught in it."
   target_summary:
     target_team: enemy
     target_type: enemy

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -43,11 +43,11 @@ skills:
   active:
     name: "Exocirst Field"
     names: ["Exocirst Field I", "Exocirst Field II", "Exocirst Field III"]
-    desc: "Banzoin Hakka conjures a purifying field in a 3x3 area around him for {skillDuration} seconds; enemies within take {skillDamage:percent} physical damage and are slowed by {slowEffect:percent} every second they remain inside."
+    desc: "Banzoin Hakka conjures a purifying field in a 3x3 area around him for {skillDuration} seconds; enemies within take {skillDamage:percent} weapon damage and are slowed by {slowEffect:percent} every second they remain inside."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - persistent
       - debuff
@@ -116,11 +116,11 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Obey my omen, in hymns allure"
-    desc: "Banzoin Hakka unleashes a greater purifying field across a 5x5 area for {skillDuration} seconds; enemies within take {skillDamage:percent} physical damage and are slowed by {slowEffect:percent} every second they remain, and when the field fades he recovers {energyRefund:percent} of his maximum Energy."
+    desc: "Banzoin Hakka unleashes a greater purifying field across a 5x5 area for {skillDuration} seconds; enemies within take {skillDamage:percent} weapon damage and are slowed by {slowEffect:percent} every second they remain, and when the field fades he recovers {energyRefund:percent} of his maximum Energy."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - persistent
       - debuff

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -41,12 +41,12 @@ skills:
   active:
     name: "Skill"
     names: ["Skill I", "Skill II", "Skill III"] # optional UI display names per tower level
-    desc: "Just a skill with {damageBonus:percent} bonus" # tokenized display text: {param} / {param:percent} resolve from parameters; token-free text renders as-is
+    desc: "Just a skill with {damageBonus:percent} bonus" # tokenized display text: {param} / {param:percent} (decimal x100) / {param:pct} (percent-scale as-is) resolve from parameters; token-free text renders as-is
     icon: "" # optional — ว่างได้ ถ้ายังไม่มี icon
     # tags = ป้ายสรุปสกิลแบบผู้เล่นอ่าน (controlled registry)
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - enemy
     # target_summary = สรุป target ระดับสกิลไว้โชว์ UI (บรรทัด AFFECTS ใน tooltip อ่าน team+shape)
@@ -102,7 +102,7 @@ skills:
           #
           # hit_distribution: [r1, r2, ...]  ← multi-hit, แบ่ง 100% ของ final damage
           #   ⚠️ caution: ผลรวม ratio ต้อง = 1.0 ไม่งั้น push_warning
-          #   ⚠️ ใช้ได้กับ skill ของ tower เท่านั้น (normal attack ไม่มี multi-hit)
+          #   ⚠️ ใช้ได้กับ skill ของ tower เท่านั้น (basic attack ไม่มี multi-hit)
           #
           # ตัวอย่าง 4-hit skill ความเสียหาย 200% รวม:
           #   - type: attack
@@ -250,7 +250,7 @@ evolution_skills:
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - enemy
     target_summary:

--- a/resources/database/towers/gavis_bettel.yaml
+++ b/resources/database/towers/gavis_bettel.yaml
@@ -36,7 +36,7 @@ stats:
 
 skill:
   name: "Skill"
-  desc: "Gavis Bettel springs a phantom trick across the 3x1 line in front of him, dealing physical damage to every enemy caught in the act."
+  desc: "Gavis Bettel springs a phantom trick across the 3x1 line in front of him, dealing weapon damage to every enemy caught in the act."
   target_summary:
     target_team: enemy
     target_type: enemy

--- a/resources/database/towers/josuiji_shinri.yaml
+++ b/resources/database/towers/josuiji_shinri.yaml
@@ -50,11 +50,11 @@ skills:
   passive:
     name: "Bull Eyes"
     names: ["Bull Eyes I", "Bull Eyes II", "Bull Eyes III"]
-    desc: "Josuiji Shinri steadies his aim with every shot: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent}, then loses all Bull Eyes stacks."
+    desc: "Josuiji Shinri steadies his aim with every shot: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack:pct} critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent}, then loses all Bull Eyes stacks."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - crit_rate
       - projectile
       - aoe
@@ -96,11 +96,11 @@ evolutionStat:
 evolution_skills:
   passive:
     name: "Heartpierce Shot"
-    desc: "Josuiji Shinri's aim turns lethal: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack}% critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent} — and critical hits no longer consume his Bull Eyes stacks."
+    desc: "Josuiji Shinri's aim turns lethal: each non-critical hit adds a Bull Eyes stack, each granting +{critChancePerStack:pct} critical chance. On a critical hit, his shot becomes a piercing arrow that hits all enemies in a 1×4 tile line for critical damage +{bonusCritDamage:percent} — and critical hits no longer consume his Bull Eyes stacks."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - crit_rate
       - projectile
       - aoe

--- a/resources/database/towers/machina_x_flayon.yaml
+++ b/resources/database/towers/machina_x_flayon.yaml
@@ -36,7 +36,7 @@ stats:
 
 skill:
   name: "Skill"
-  desc: "Machina X Flayon drives a mecha strike through the 3x1 line in front of him, dealing physical damage to every enemy caught in it."
+  desc: "Machina X Flayon drives a mecha strike through the 3x1 line in front of him, dealing weapon damage to every enemy caught in it."
   target_summary:
     target_team: enemy
     target_type: enemy

--- a/resources/database/towers/mori_calliope.yaml
+++ b/resources/database/towers/mori_calliope.yaml
@@ -40,11 +40,11 @@ skills:
   active:
     name: "Ricky"
     names: ["Ricky I", "Ricky II", "Ricky III"]
-    desc: "Calliope sweeps her scythe Ricky through the 3x3 area around her, dealing {skillDamage:percent} physical damage plus {soulBonus:percent} more per Soul she holds. Each enemy killed by this skill grants her 1 Soul, kept for the whole run."
+    desc: "Calliope sweeps her scythe Ricky through the 3x3 area around her, dealing {skillDamage:percent} weapon damage plus {soulBonus:percent} more per Soul she holds. Each enemy killed by this skill grants her 1 Soul, kept for the whole run."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - stack
     target_summary:
@@ -127,11 +127,11 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Excuse My Rudeness, But Could You Please RIP?"
-    desc: "Calliope reaps the 3x3 area around her for {skillDamage:percent} physical damage plus {soulBonus:percent} per Soul. {aftershockDelay}s later the same ground erupts for {aftershockDamage:percent} physical damage plus {aftershockSoulBonus:percent} per Soul she holds at that moment. Each enemy killed grants her 1 Soul."
+    desc: "Calliope reaps the 3x3 area around her for {skillDamage:percent} weapon damage plus {soulBonus:percent} per Soul. {aftershockDelay}s later the same ground erupts for {aftershockDamage:percent} weapon damage plus {aftershockSoulBonus:percent} per Soul she holds at that moment. Each enemy killed grants her 1 Soul."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - stack
     target_summary:

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -39,11 +39,11 @@ skills:
   active:
     name: "Gun and Blade"
     names: ["Gun and Blade I", "Gun and Blade II", "Gun and Blade III"]
-    desc: "Altare strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} physical damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a gun volley down a 1x3 lane deals {beat2Damage:percent} physical damage with a guaranteed critical."
+    desc: "Altare strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} weapon damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a gun volley down a 1x3 lane deals {beat2Damage:percent} weapon damage with a guaranteed critical."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - combo
       - debuff
@@ -129,11 +129,11 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Heroic Requiem"
-    desc: "Altare's finisher strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} physical damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a long gun volley down a 1x6 lane deals {beat2Damage:percent} physical damage with a guaranteed critical."
+    desc: "Altare's finisher strikes twice with his Gun Blade. A forward slash across a 3x1 tile area deals {beat1Damage:percent} weapon damage and reduces armor by {armorShred:percent} for {shredDuration}s, then a long gun volley down a 1x6 lane deals {beat2Damage:percent} weapon damage with a guaranteed critical."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - combo
       - debuff

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -37,11 +37,11 @@ skills:
   active:
     name: "Flame Slash"
     names: ["Flame Slash I", "Flame Slash II", "Flame Slash III"]
-    desc: "Kiara swings her immortal phoenix flame sword forward through a 3×1 tile area, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
+    desc: "Kiara swings her immortal phoenix flame sword forward through a 3×1 tile area, dealing {damageMultiplier:percent} weapon damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} Attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - dot
     target_summary:
@@ -113,11 +113,11 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Hinotori"
-    desc: "Kiara empowers her sword with sacred phoenix fire and unleashes a devastating slash forward through a 3×5 tile corridor, dealing {damageMultiplier:percent} physical damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
+    desc: "Kiara empowers her sword with sacred phoenix fire and unleashes a devastating slash forward through a 3×5 tile corridor, dealing {damageMultiplier:percent} weapon damage. All enemies hit are scorched by Phoenix Flame, taking ({phoenixAtk:percent} Attack + {phoenixHp:percent} max HP) magic damage every 1 second for {phoenixDuration} seconds."
     icon: ""
     tags:
       - damage
-      - attack
+      - weapon
       - aoe
       - dot
       - projectile

--- a/resources/database/towers/watson_amelia.yaml
+++ b/resources/database/towers/watson_amelia.yaml
@@ -102,7 +102,7 @@ evolutionStat:
 evolution_skills:
   active:
     name: "Elementary my dear"
-    desc: "Watson Amelia invokes the Clock of Time, increasing attack speed by {attackSpeedBuff:percent} for herself and nearby towers within 1 tile, and granting herself {critChanceBuff}% critical chance for 4 seconds."
+    desc: "Watson Amelia invokes the Clock of Time, increasing attack speed by {attackSpeedBuff:percent} for herself and nearby units within 1 tile, and granting herself {critChanceBuff:pct} critical chance for 4 seconds."
     icon: ""
     tags:
       - buff

--- a/resources/ui_component/tower_stats_panel.tscn
+++ b/resources/ui_component/tower_stats_panel.tscn
@@ -183,7 +183,7 @@ label_settings = SubResource("LabelSettings_dim")
 
 [node name="TypeValue" type="Label" parent="StatsGrid"]
 layout_mode = 2
-text = "Physical"
+text = "Weapon"
 label_settings = SubResource("LabelSettings_body")
 
 [node name="RangeName" type="Label" parent="StatsGrid"]

--- a/scripts/skill/skill.gd
+++ b/scripts/skill/skill.gd
@@ -39,8 +39,11 @@ func get_display_name(level: int) -> String:
 	return name
 
 # highlight_color (BBCode hex, e.g. "#5AC8FA"): wraps values coming from a
-# per-level (array) parameter so the player sees which number scales -
-# mirrors SynergyData._render. "" returns plain text.
+# per-level (array) parameter so the player sees which number scales. Token
+# grammar mirrors SynergyData._render, but the highlight rule deliberately
+# differs: synergy hovers highlight every value, skill descs carry too many
+# numbers for that and keep the scaling-only rule (Director 2026-07-21).
+# "" returns plain text.
 func get_display_desc(level: int, highlight_color: String = "") -> String:
 	if desc == "":
 		return ""
@@ -87,6 +90,8 @@ func _format_display_parameter(value, format: String) -> String:
 	match format:
 		"percent":
 			return _format_display_number(float(value) * 100.0) + "%"
+		"pct":
+			return _format_display_number(value) + "%"
 		"":
 			return _format_display_number(value)
 		_:

--- a/scripts/synergy/synergy_data.gd
+++ b/scripts/synergy/synergy_data.gd
@@ -18,6 +18,12 @@ const RARITY_COMMON := "common"
 const RARITY_UNIQUE := "unique"
 const RARITIES := [RARITY_COMMON, RARITY_UNIQUE]
 
+# Legal desc token formats ("" = plain number). `percent` renders a
+# decimal-scale value as N% (x100: 0.5 -> "50%"); `pct` appends % to a
+# percent-scale value as-is (25 -> "25%"). Shared with the loader's
+# token validation.
+const FORMATS := ["", "percent", "pct"]
+
 var id: String = ""                # file/data key, e.g. "myth"
 var synergy_id: int = 0            # TowerTrait enum int (resolved at load)
 var display_name: String = ""
@@ -92,9 +98,9 @@ func get_parameter(param_name: String, tier: int):
 		return value[index]
 	return value
 
-# Flavour line resolved for a tier. highlight_color (BBCode hex) wraps values
-# that come from a per-tier (array) parameter, so the player sees which number
-# scales; "" returns plain text.
+# Flavour line resolved for a tier. highlight_color (BBCode hex) wraps EVERY
+# resolved value - cyan means "the number that matters", independent of whether
+# it scales by tier (Director 2026-07-21); "" returns plain text.
 func flavor(tier: int, highlight_color: String = "") -> String:
 	return _render(desc, tier, highlight_color)
 
@@ -120,10 +126,17 @@ func _render(template: String, tier: int, highlight_color: String) -> String:
 		var m := matches[i]
 		var pname := m.get_string(1)
 		var fmt := m.get_string(2)
-		var is_scaling: bool = parameters.has(pname) and parameters[pname] is Array
-		var text := _format_value(get_parameter(pname, tier), fmt)
-		if highlight_color != "" and is_scaling:
-			text = "[color=" + highlight_color + "]" + text + "[/color]"
+		var value = get_parameter(pname, tier)
+		var text: String
+		if value == null:
+			# Missing parameter: keep the raw {token} visible instead of an empty
+			# hole so the breakage shows in-game (mirrors Skill.get_display_desc);
+			# get_parameter already warned.
+			text = m.get_string()
+		else:
+			text = _format_value(value, fmt)
+			if highlight_color != "":
+				text = "[color=" + highlight_color + "]" + text + "[/color]"
 		result = result.substr(0, m.get_start()) + text + result.substr(m.get_end())
 	return result
 
@@ -134,6 +147,8 @@ func _format_value(value, fmt: String) -> String:
 	match fmt:
 		"percent":
 			return _format_number(float(value) * 100.0) + "%"
+		"pct":
+			return _format_number(value) + "%"
 		"":
 			return _format_number(value)
 		_:

--- a/scripts/synergy/synergy_data_loader.gd
+++ b/scripts/synergy/synergy_data_loader.gd
@@ -69,11 +69,33 @@ static func _build(raw: Dictionary, path: String) -> SynergyData:
 	if params is Dictionary:
 		d.parameters = params
 
+	# A bad token only shows its breakage when the row is hovered in-game, so
+	# validate desc/tier_effects tokens at load instead.
+	_validate_desc_tokens(d)
+
 	d.synergy_id = _resolve_synergy_id(d.kind, d.id)
 	if d.synergy_id == 0:
 		push_error("SynergyDataLoader: cannot resolve id for '" + d.id + "' (kind=" + d.kind + ") in " + path)
 		return null
 	return d
+
+# Load-time token check for desc + tier_effects: warn on a token naming no
+# parameter (renders as the raw token) and on an unknown format suffix (a
+# ":pcnt" typo would otherwise only warn at render). Scalar refs are legal -
+# shape follows semantics, highlight no longer depends on it.
+static func _validate_desc_tokens(d: SynergyData) -> void:
+	var regex := RegEx.new()
+	regex.compile("\\{([^}:]+)(?::([^}]+))?\\}")
+	var texts: Array = [d.desc]
+	texts.append_array(d.tier_effects)
+	for text in texts:
+		for m in regex.search_all(str(text)):
+			var pname := m.get_string(1)
+			var fmt := m.get_string(2)
+			if not d.parameters.has(pname):
+				push_warning("Synergy '" + d.id + "': desc token {" + pname + "} names no parameter - the raw token will show in the hover.")
+			if not SynergyData.FORMATS.has(fmt):
+				push_warning("Synergy '" + d.id + "': token {" + pname + ":" + fmt + "} uses unknown format '" + fmt + "' - expected one of " + str(SynergyData.FORMATS) + ".")
 
 # Maps the YAML id string to the TowerTrait enum int via the display-name tables.
 static func _resolve_synergy_id(kind: String, id: String) -> int:

--- a/scripts/ui/tower_stats_panel.gd
+++ b/scripts/ui/tower_stats_panel.gd
@@ -146,7 +146,7 @@ func _refresh() -> void:
 
 	# Stats: live getters, so buffs/debuffs show (player-facing terms). 3x2 grid: attack block left, crit block + range right.
 	_set_text(_atk_value, str(data.getTotalAttack()))
-	_set_text(_type_value, "Magic" if data.attackType == Damage.DamageType.MAGIC else "Physical")
+	_set_text(_type_value, "Magic" if data.attackType == Damage.DamageType.MAGIC else "Weapon")
 	_set_text(_as_value, _format_number(data.getAttackSpeed()))
 	_set_text(_range_value, _format_number(data.getAttackRange()))
 	_set_text(_crit_value, _format_number(data.getCritChance()) + "%")


### PR DESCRIPTION
**Summary:** Team-feedback terminology redesign - player-facing damage vocabulary is now Attack (total power), Weapon Attack (physical, replaces "Physical"), Magic Attack, and Basic Attack (normal attack) - swept across skill tags, stats panel, effect names, and every skill/synergy desc. Synergy hover highlight reworked: every resolved value highlights (cyan = "the number that matters"), % signs always inside the highlight, plus Hero gets a shorter lore-based desc.

**How it works:**
- `SynergyData._render` now highlights every resolved token (highlight no longer tied to the param being an array); a missing param keeps the raw `{token}` visible instead of an invisible hole.
- New `:pct` desc format in both renderers (`SynergyData` / `Skill`): appends % to a percent-scale value as-is (25 -> "25%"); existing `:percent` (x100 for decimal-scale) unchanged. Skill hover keeps its scaling-only highlight rule by design.
- `SynergyDataLoader` validates desc/tier_effects tokens at load: warns on tokens naming no parameter and on unknown format suffixes.
- Synergy YAML shape now follows semantics: per-tier arrays only for values that truly scale by tier; single-tier values are scalars (SpellCaster/Marksman flattened - safe, all effects read through `get_parameter`).
- Skill tag `attack` renamed `weapon` across all tower YAML (tags render raw).

**Findings:**
- The buff pair `attack_flat_up`/`attack_mult_up` ("Attack Up") buffs the weapon half only, so its display name is now "Weapon Attack Up"; same logic renamed "Damage Down" (attack_mult_down) to "Weapon Attack Down" and the Giant Boar Bulldoze titles - Engineer call, registry ids untouched.
- Amelia's evolved-skill desc said "nearby towers"; corrected to "units" per the copy rule while editing that line for the `:pct` migration.
- Scalar literal-% descs (Shinri, Giant Boar) migrated to `:pct` for one corpus-wide convention; rendered output is identical.
- Tempus tier-1 reward line now reads "+20% Attack" - the umbrella term exactly matches the applied attack_mult + magic_mult pair.

**Implementation Notes:** Hero desc is lore-sourced (official bio: his earnest straightforwardness "may well lead to him being called a 'hero' one day"); the mechanic number lives only in the tier line, per the value-in-table copy rule. Reviewer focus: `synergy_data.gd` `_render` (highlight + missing-token path) and the loader validation.

**Touched scenes:** `resources/ui_component/tower_stats_panel.tscn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
