### PR TITLE
Skill crit structure (crit_rule) + SpellCaster redesign (Magic + Energy amp)

### DIFF
--- a/resources/database/effect/effects.yaml
+++ b/resources/database/effect/effects.yaml
@@ -93,13 +93,16 @@ crit_chance_up:
   kind: crit_chance
   duration: 4.0
 
-# SpellCaster synergy gate: unlocks the crit roll on the holder's SKILLS. It
-# grants no critical chance - a holder with 0 chance still never crits. mark =
-# pure flag, no stat aggregation; SkillActionAttack reads it live via
-# EffectContainer.stacks_of (NOT has_mark, which filters category == mark, and
-# NOT has_kind(MARK_ONLY), which `soul` would also satisfy).
-spellcaster_crit:
-  name: "Arcane Focus"
+# External skill-crit gate: unlocks the crit roll on the holder's SKILLS,
+# overriding an authored crit_rule: no_crit. It grants no critical chance - a
+# holder with 0 chance still never crits. Currently dormant: reserved for the
+# future Assassin synergy (was the SpellCaster gate until its 2026-07-22
+# redesign). mark = pure flag, no stat aggregation; the skill attack/projectile
+# actions read it live via EffectContainer.stacks_of (NOT has_mark, which
+# filters category == mark, and NOT has_kind(MARK_ONLY), which `soul` would
+# also satisfy).
+skill_crit_unlock:
+  name: "Skill Crit Unlock"
   desc: "Skills can land critical hits."
   icon: "ui_asset/effects/buff_generic.png"
   category: buff
@@ -140,6 +143,20 @@ mana_regen_up:
   category: buff
   host: tower
   kind: mana_regen
+
+# Percent multiplier on EVERY positive Energy intake (attack regen, synergy
+# grants, refunds) - applied once at SkillController.updateMana. Differs from
+# mana_regen_up, which adds flat Energy to the per-attack gain only.
+# First user: SpellCaster synergy (board lifetime, icon auto-hidden).
+energy_gain_up:
+  name: "Energy Gain Up"
+  desc: "Energy gained from every source increased by {value}."
+  icon: "ui_asset/effects/buff_generic.png"
+  category: buff
+  host: tower
+  kind: energy_gain
+  stack: refresh
+  duration: 0
 
 range_up:
   name: "Range Up"

--- a/resources/database/effect/effects.yaml
+++ b/resources/database/effect/effects.yaml
@@ -148,13 +148,13 @@ mana_regen_up:
 # grants, refunds) - applied once at SkillController.updateMana. Differs from
 # mana_regen_up, which adds flat Energy to the per-attack gain only.
 # First user: SpellCaster synergy (board lifetime, icon auto-hidden).
-energy_gain_up:
+energy_amp_up:
   name: "Energy Gain Up"
   desc: "Energy gained from every source increased by {value}."
   icon: "ui_asset/effects/buff_generic.png"
   category: buff
   host: tower
-  kind: energy_gain
+  kind: energy_amp
   stack: refresh
   duration: 0
 

--- a/resources/database/synergy/spellcaster.yaml
+++ b/resources/database/synergy/spellcaster.yaml
@@ -5,7 +5,7 @@ name: "Spell Caster"
 kind: class
 type: standard
 rarity: common
-effect: magic_up_skill_crit
+effect: magic_up_energy_gain
 # Single tier by design: 2 of the 3 demo Spell Casters (Gura / Ina'nis / Bettel)
 # is already a real deck commitment, and the bonus does not scale past it.
 thresholds: [2]
@@ -13,12 +13,13 @@ parameters:
   # Percent scale (25 = +25%), matching MAGIC_MULT. Scalar = not a per-tier
   # value (shape follows semantics; every resolved value highlights).
   magic_bonus: 25
+  # Percent scale (10 = +10%), matching ENERGY_GAIN: multiplies every Energy
+  # intake (attack regen, synergy grants, refunds) at the single choke point.
+  energy_gain: 10
 # :pct appends % to a percent-scale value as-is (:percent would x100 -> 2500%).
-# The crit half grants the ABILITY only - it adds no critical chance, and copy
-# must not imply one (Director 2026-07-19).
-desc: "Spell Caster units draw deeper from the arcane, gaining +{magic_bonus:pct} Magic Attack, and their skills can now land critical hits."
-# Per-tier table line: the stat value only, matching Myth. The crit ability is
-# a one-off unlock, not a per-tier value, so it lives in desc and stays out of
-# this line (Director 2026-07-19).
+# Redesign 2026-07-22: the old skill-crit gate moved off this synergy (mark
+# parked as skill_crit_unlock for a future Assassin synergy).
+desc: "Spell Caster units draw deeper from the arcane, gaining +{magic_bonus:pct} Magic Attack and +{energy_gain:pct} Energy from every source."
+# Per-tier table line: the stat values only, matching Myth.
 tier_effects:
-  - "+{magic_bonus:pct} Magic Attack"
+  - "+{magic_bonus:pct} Magic Attack, +{energy_gain:pct} Energy gain"

--- a/resources/database/synergy/spellcaster.yaml
+++ b/resources/database/synergy/spellcaster.yaml
@@ -5,7 +5,7 @@ name: "Spell Caster"
 kind: class
 type: standard
 rarity: common
-effect: magic_up_energy_gain
+effect: magic_up_energy_amp
 # Single tier by design: 2 of the 3 demo Spell Casters (Gura / Ina'nis / Bettel)
 # is already a real deck commitment, and the bonus does not scale past it.
 thresholds: [2]
@@ -13,13 +13,13 @@ parameters:
   # Percent scale (25 = +25%), matching MAGIC_MULT. Scalar = not a per-tier
   # value (shape follows semantics; every resolved value highlights).
   magic_bonus: 25
-  # Percent scale (10 = +10%), matching ENERGY_GAIN: multiplies every Energy
+  # Percent scale (10 = +10%), matching ENERGY_AMP: multiplies every Energy
   # intake (attack regen, synergy grants, refunds) at the single choke point.
-  energy_gain: 10
+  energy_amp: 10
 # :pct appends % to a percent-scale value as-is (:percent would x100 -> 2500%).
 # Redesign 2026-07-22: the old skill-crit gate moved off this synergy (mark
 # parked as skill_crit_unlock for a future Assassin synergy).
-desc: "Spell Caster units draw deeper from the arcane, gaining +{magic_bonus:pct} Magic Attack and +{energy_gain:pct} Energy from every source."
+desc: "Spell Caster units draw deeper from the arcane, gaining +{magic_bonus:pct} Magic Attack and +{energy_amp:pct} Energy from every source."
 # Per-tier table line: the stat values only, matching Myth.
 tier_effects:
-  - "+{magic_bonus:pct} Magic Attack, +{energy_gain:pct} Energy gain"
+  - "+{magic_bonus:pct} Magic Attack, +{energy_amp:pct} Energy gain"

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -90,7 +90,7 @@ skills:
           tick_interval_param_name: "tickInterval"
           damage_multiplier_param_name: "skillDamage"
           damage_type: physic
-          crit_rule: no_crit
+          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
           show_area: false            # per-tick red debug box off (VFX replaces it)
           effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gd"
           effects:
@@ -161,7 +161,7 @@ evolution_skills:
           tick_interval_param_name: "tickInterval"
           damage_multiplier_param_name: "skillDamage"
           damage_type: physic
-          crit_rule: no_crit
+          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
           energy_refund_percent_param_name: "energyRefund"
           show_area: false            # per-tick red debug box off (VFX replaces it)
           effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gd"

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -90,7 +90,7 @@ skills:
           tick_interval_param_name: "tickInterval"
           damage_multiplier_param_name: "skillDamage"
           damage_type: physic
-          can_crit: false
+          crit_rule: no_crit
           show_area: false            # per-tick red debug box off (VFX replaces it)
           effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gd"
           effects:
@@ -161,7 +161,7 @@ evolution_skills:
           tick_interval_param_name: "tickInterval"
           damage_multiplier_param_name: "skillDamage"
           damage_type: physic
-          can_crit: false
+          crit_rule: no_crit
           energy_refund_percent_param_name: "energyRefund"
           show_area: false            # per-tick red debug box off (VFX replaces it)
           effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gd"

--- a/resources/database/towers/banzoin_hakka.yaml
+++ b/resources/database/towers/banzoin_hakka.yaml
@@ -90,7 +90,7 @@ skills:
           tick_interval_param_name: "tickInterval"
           damage_multiplier_param_name: "skillDamage"
           damage_type: physic
-          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
+          crit_rule: no_crit   # how this skill crits: no_crit / use_crit_chance / guaranteed_crit
           show_area: false            # per-tick red debug box off (VFX replaces it)
           effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_effect.gd"
           effects:
@@ -161,7 +161,7 @@ evolution_skills:
           tick_interval_param_name: "tickInterval"
           damage_multiplier_param_name: "skillDamage"
           damage_type: physic
-          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
+          crit_rule: no_crit   # how this skill crits: no_crit / use_crit_chance / guaranteed_crit
           energy_refund_percent_param_name: "energyRefund"
           show_area: false            # per-tick red debug box off (VFX replaces it)
           effect_script: "res://resources/tower/holostars/en_branch/tempus_gen/hakka/skill_effect/hakka_field_evo_effect.gd"

--- a/resources/database/towers/default_tower.yaml
+++ b/resources/database/towers/default_tower.yaml
@@ -96,9 +96,10 @@ skills:
           #
           # damage_type ถ้าไม่ใส่ → ใช้ tower.attackType (default ตาม design 1 tower 1 type)
           #
-          # can_crit:
-          #   - true (default) → skill roll crit ตามเลขของ tower
-          #   - false           → skill ไม่ crit (เช่น skill Kiara ตามดีไซน์)
+          # crit_rule: (skill ไม่ crit เว้นแต่สั่งเปิด — default = no_crit)
+          #   - no_crit (default, ไม่ต้องเขียน) → skill ไม่ crit
+          #   - use_crit_chance → skill roll crit ตามเลขของ tower
+          #   - guaranteed_crit → crit ทุก hit ไม่สน crit chance (เช่น ปืน Altare beat 2)
           #
           # hit_distribution: [r1, r2, ...]  ← multi-hit, แบ่ง 100% ของ final damage
           #   ⚠️ caution: ผลรวม ratio ต้อง = 1.0 ไม่งั้น push_warning
@@ -110,11 +111,11 @@ skills:
           #       damage_multiplier: 2.0
           #       hit_distribution: [0.2, 0.2, 0.1, 0.5]   # รวม = 1.0 ✓
           #
-          # ตัวอย่าง skill non-crit ที่ scale ตาม level:
+          # ตัวอย่าง skill ที่ crit ได้และ scale ตาม level:
           #   - type: attack
           #     data:
           #       damage_multiplier: [1.4, 1.5, 1.7]
-          #       can_crit: false
+          #       crit_rule: use_crit_chance
           #
           # stack_bonus_effect + stack_bonus_per_stack_param_name:
           #   สกิลสเกลตาม stack (เช่น Soul ของ Calliope) — ตัวคูณเพิ่มขึ้น
@@ -201,7 +202,7 @@ skills:
       #       animation: "skill"                          # คลิปร่าย เล่นค้างตลอด channel
       #       damage_multiplier_param_name: "tickDamage"
       #       damage_type: magic
-      #       can_crit: false
+      #       crit_rule: no_crit
       #       effects:
       #         - effect: "stun"
       #           duration_param: "tickStun"
@@ -224,7 +225,7 @@ skills:
       #       tick_interval_param_name: "tickInterval"  # หรือ tick_interval: 1.0 ตรง ๆ
       #       damage_multiplier_param_name: "skillDamage"
       #       damage_type: magic
-      #       can_crit: false
+      #       crit_rule: no_crit
       #       energy_refund_percent_param_name: "energyRefund"   # optional (ใช้ตอน evolve)
       #       effects:
       #         - effect: "move_speed_down"

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -83,7 +83,7 @@ skills:
           count: 4
           damage_multiplier_param_name: "damageMultiplier"
           damage_type: "magic"
-          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
+          crit_rule: no_crit   # how this skill crits: no_crit / use_crit_chance / guaranteed_crit
           # Scale multipliers on the projectile root (visual + collision).
           # 1.0 keeps the .tscn default size; raise both to widen each wave's hitbox.
           projectile_size_w: 1
@@ -146,7 +146,7 @@ evolution_skills:
           count: 8
           damage_multiplier_param_name: "damageMultiplier"
           damage_type: "magic"
-          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
+          crit_rule: no_crit   # how this skill crits: no_crit / use_crit_chance / guaranteed_crit
           projectile_size_w: 1
           projectile_size_h: 1
           effects:

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -83,6 +83,7 @@ skills:
           count: 4
           damage_multiplier_param_name: "damageMultiplier"
           damage_type: "magic"
+          crit_rule: no_crit   # Gura design: skill cannot crit (both tiers)
           # Scale multipliers on the projectile root (visual + collision).
           # 1.0 keeps the .tscn default size; raise both to widen each wave's hitbox.
           projectile_size_w: 1
@@ -145,6 +146,7 @@ evolution_skills:
           count: 8
           damage_multiplier_param_name: "damageMultiplier"
           damage_type: "magic"
+          crit_rule: no_crit   # Gura design: skill cannot crit (both tiers)
           projectile_size_w: 1
           projectile_size_h: 1
           effects:

--- a/resources/database/towers/gawr_gura.yaml
+++ b/resources/database/towers/gawr_gura.yaml
@@ -83,7 +83,7 @@ skills:
           count: 4
           damage_multiplier_param_name: "damageMultiplier"
           damage_type: "magic"
-          crit_rule: no_crit   # Gura design: skill cannot crit (both tiers)
+          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
           # Scale multipliers on the projectile root (visual + collision).
           # 1.0 keeps the .tscn default size; raise both to widen each wave's hitbox.
           projectile_size_w: 1
@@ -146,7 +146,7 @@ evolution_skills:
           count: 8
           damage_multiplier_param_name: "damageMultiplier"
           damage_type: "magic"
-          crit_rule: no_crit   # Gura design: skill cannot crit (both tiers)
+          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
           projectile_size_w: 1
           projectile_size_h: 1
           effects:

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -107,11 +107,12 @@ evolutionStat:
 # Evolved Active Skill - the game's first "channel" pattern skill: Ina'nis
 # locks the 3x3 zone in front of her and strikes it 12 times over 3 seconds
 # (every 0.25s), stunning enemies caught inside on every strike. She is busy
-# for the whole channel (no auto-attack). The ticks do not crit on their own
-# (can_crit: false below); the evolved BASE stat keeps critChance 50 for her
-# normal attacks (stat-consistency verdict, Director 2026-07-14). Superseded in
-# part 2026-07-19: the SpellCaster synergy opens this gate for its holders, so
-# the ticks DO crit while that trait is active - intended, do not re-block it.
+# for the whole channel (no auto-attack). The ticks do not crit
+# (crit_rule: no_crit below); the evolved BASE stat keeps critChance 50 for her
+# normal attacks (stat-consistency verdict, Director 2026-07-14). The dormant
+# skill_crit_unlock mark can reopen this gate from outside (reserved for a
+# future synergy, e.g. Assassin) - the 2026-07-22 SpellCaster redesign removed
+# the only live applier.
 evolution_skills:
   active:
     name: "Book of Ancient Ones"
@@ -154,7 +155,7 @@ evolution_skills:
           animation: "skill"
           damage_multiplier_param_name: "tickDamage"
           damage_type: magic
-          can_crit: false            # ticks do not crit on their own; the SpellCaster synergy overrides this gate for holders
+          crit_rule: no_crit         # ticks do not crit; only the dormant skill_crit_unlock mark can reopen this
           effects:
             - effect: "stun"
               duration_param: "tickStun"

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -155,7 +155,7 @@ evolution_skills:
           animation: "skill"
           damage_multiplier_param_name: "tickDamage"
           damage_type: magic
-          crit_rule: no_crit         # ticks do not crit; only the dormant skill_crit_unlock mark can reopen this
+          crit_rule: no_crit         # no_crit / use_crit_chance / guaranteed_crit
           effects:
             - effect: "stun"
               duration_param: "tickStun"

--- a/resources/database/towers/ninomae_ina_nis.yaml
+++ b/resources/database/towers/ninomae_ina_nis.yaml
@@ -155,7 +155,7 @@ evolution_skills:
           animation: "skill"
           damage_multiplier_param_name: "tickDamage"
           damage_type: magic
-          crit_rule: no_crit         # no_crit / use_crit_chance / guaranteed_crit
+          crit_rule: no_crit         # how this skill crits: no_crit / use_crit_chance / guaranteed_crit
           effects:
             - effect: "stun"
               duration_param: "tickStun"

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -110,7 +110,7 @@ skills:
         data:
           damage_multiplier_param_name: "beat2Damage"
           damage_type: physic
-          force_crit: true                       # guaranteed critical
+          crit_rule: guaranteed_crit             # every hit crits
       - type: play_animation
         data:
           animation: "idle"
@@ -194,7 +194,7 @@ evolution_skills:
         data:
           damage_multiplier_param_name: "beat2Damage"
           damage_type: physic
-          force_crit: true
+          crit_rule: guaranteed_crit             # every hit crits
       - type: play_animation
         data:
           animation: "idle"

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -110,7 +110,7 @@ skills:
         data:
           damage_multiplier_param_name: "beat2Damage"
           damage_type: physic
-          crit_rule: guaranteed_crit             # every hit crits
+          crit_rule: guaranteed_crit   # no_crit / use_crit_chance / guaranteed_crit
       - type: play_animation
         data:
           animation: "idle"
@@ -194,7 +194,7 @@ evolution_skills:
         data:
           damage_multiplier_param_name: "beat2Damage"
           damage_type: physic
-          crit_rule: guaranteed_crit             # every hit crits
+          crit_rule: guaranteed_crit   # no_crit / use_crit_chance / guaranteed_crit
       - type: play_animation
         data:
           animation: "idle"

--- a/resources/database/towers/regis_altare.yaml
+++ b/resources/database/towers/regis_altare.yaml
@@ -110,7 +110,7 @@ skills:
         data:
           damage_multiplier_param_name: "beat2Damage"
           damage_type: physic
-          crit_rule: guaranteed_crit   # no_crit / use_crit_chance / guaranteed_crit
+          crit_rule: guaranteed_crit   # how this skill crits: no_crit / use_crit_chance / guaranteed_crit
       - type: play_animation
         data:
           animation: "idle"
@@ -194,7 +194,7 @@ evolution_skills:
         data:
           damage_multiplier_param_name: "beat2Damage"
           damage_type: physic
-          crit_rule: guaranteed_crit   # no_crit / use_crit_chance / guaranteed_crit
+          crit_rule: guaranteed_crit   # how this skill crits: no_crit / use_crit_chance / guaranteed_crit
       - type: play_animation
         data:
           animation: "idle"

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -89,7 +89,7 @@ skills:
         data:
           # Skill multiplier reads parameters.damageMultiplier (single source w/ desc).
           damage_multiplier_param_name: "damageMultiplier"
-          crit_rule: no_crit   # Kiara design: skill cannot crit
+          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
           effects:
             - effect: "phoenix_flame"
               duration_param: "phoenixDuration"   # binds to parameters (single source)
@@ -176,7 +176,7 @@ evolution_skills:
           max_range: 5.0       # Max travel distance in tiles — projectile despawns past this
           damage_multiplier: 3.0   # Fallback; runtime reads parameters.damageMultiplier (default param name)
           damage_type: "physic"
-          crit_rule: no_crit   # Kiara design: skill cannot crit (live gate now that projectiles roll crit)
+          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
           effects:
             - effect: "phoenix_flame"
               duration_param: "phoenixDuration"   # binds to parameters (single source)

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -89,7 +89,7 @@ skills:
         data:
           # Skill multiplier reads parameters.damageMultiplier (single source w/ desc).
           damage_multiplier_param_name: "damageMultiplier"
-          can_crit: false   # Kiara design: skill cannot crit
+          crit_rule: no_crit   # Kiara design: skill cannot crit
           effects:
             - effect: "phoenix_flame"
               duration_param: "phoenixDuration"   # binds to parameters (single source)
@@ -176,7 +176,7 @@ evolution_skills:
           max_range: 5.0       # Max travel distance in tiles — projectile despawns past this
           damage_multiplier: 3.0   # Fallback; runtime reads parameters.damageMultiplier (default param name)
           damage_type: "physic"
-          can_crit: false
+          crit_rule: no_crit   # Kiara design: skill cannot crit (live gate now that projectiles roll crit)
           effects:
             - effect: "phoenix_flame"
               duration_param: "phoenixDuration"   # binds to parameters (single source)

--- a/resources/database/towers/takanashi_kiara.yaml
+++ b/resources/database/towers/takanashi_kiara.yaml
@@ -89,7 +89,7 @@ skills:
         data:
           # Skill multiplier reads parameters.damageMultiplier (single source w/ desc).
           damage_multiplier_param_name: "damageMultiplier"
-          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
+          crit_rule: no_crit   # how this skill crits: no_crit / use_crit_chance / guaranteed_crit
           effects:
             - effect: "phoenix_flame"
               duration_param: "phoenixDuration"   # binds to parameters (single source)
@@ -176,7 +176,7 @@ evolution_skills:
           max_range: 5.0       # Max travel distance in tiles — projectile despawns past this
           damage_multiplier: 3.0   # Fallback; runtime reads parameters.damageMultiplier (default param name)
           damage_type: "physic"
-          crit_rule: no_crit   # no_crit / use_crit_chance / guaranteed_crit
+          crit_rule: no_crit   # how this skill crits: no_crit / use_crit_chance / guaranteed_crit
           effects:
             - effect: "phoenix_flame"
               duration_param: "phoenixDuration"   # binds to parameters (single source)

--- a/scripts/effect/effect_types.gd
+++ b/scripts/effect/effect_types.gd
@@ -11,6 +11,7 @@ class_name EffectTypes
 #   CRIT_CHANCE                         percent points
 #   DAMAGE_AMPLIFIER / DAMAGE_REDUCTION decimal
 #   DAMAGE_AMP_PER_CELL                 percent per cell of attacker-to-target distance
+#   ENERGY_GAIN                         percent (10 = +10% Energy from every gain)
 #   *_FLAT / RANGE / MANA_REGEN / MOVE_SPEED_FLAT  flat additive
 enum Kind {
 	ATTACK_SPEED,
@@ -39,6 +40,10 @@ enum Kind {
 	# cell of distance; the attack site turns it into a real amp via
 	# TowerData.getDistanceAmp (Marksman synergy).
 	DAMAGE_AMP_PER_CELL,
+	# Multiplies every positive Energy intake at SkillController.updateMana
+	# (attack regen, synergy grants, refunds); wave-start refill is a direct
+	# reset, not a gain, and is deliberately outside (SpellCaster synergy).
+	ENERGY_GAIN,
 }
 
 enum Category { BUFF, DEBUFF, MARK }
@@ -78,6 +83,7 @@ const KIND_FROM_STRING := {
 	"invincible": Kind.INVINCIBLE,
 	"hot": Kind.HOT,
 	"damage_amp_per_cell": Kind.DAMAGE_AMP_PER_CELL,
+	"energy_gain": Kind.ENERGY_GAIN,
 }
 
 const CATEGORY_FROM_STRING := {
@@ -100,7 +106,7 @@ static func is_stat_kind(kind: int) -> bool:
 	# The `< STUN` range test only works for kinds declared before the behavior
 	# block; kinds appended after HOT must be listed explicitly (the enum is
 	# append-only, so the block cannot be re-sorted).
-	return kind < Kind.STUN or kind == Kind.DAMAGE_AMP_PER_CELL
+	return kind < Kind.STUN or kind == Kind.DAMAGE_AMP_PER_CELL or kind == Kind.ENERGY_GAIN
 
 # Decimal-scale kinds display as percent (0.5 -> "50%"); percent-scale kinds
 # append % directly; flats show the plain number. Used by the {value} desc
@@ -110,7 +116,7 @@ const _DECIMAL_PERCENT_KINDS := [
 	Kind.MARMOR_MULT, Kind.DAMAGE_AMPLIFIER, Kind.DAMAGE_REDUCTION,
 	Kind.CRIT_DAMAGE_BONUS,
 ]
-const _PERCENT_POINT_KINDS := [Kind.ATTACK_MULT, Kind.MAGIC_MULT, Kind.CRIT_CHANCE]
+const _PERCENT_POINT_KINDS := [Kind.ATTACK_MULT, Kind.MAGIC_MULT, Kind.CRIT_CHANCE, Kind.ENERGY_GAIN]
 
 static func format_value(kind: int, value: float) -> String:
 	var v: float = absf(value)

--- a/scripts/effect/effect_types.gd
+++ b/scripts/effect/effect_types.gd
@@ -11,7 +11,7 @@ class_name EffectTypes
 #   CRIT_CHANCE                         percent points
 #   DAMAGE_AMPLIFIER / DAMAGE_REDUCTION decimal
 #   DAMAGE_AMP_PER_CELL                 percent per cell of attacker-to-target distance
-#   ENERGY_GAIN                         percent (10 = +10% Energy from every gain)
+#   ENERGY_AMP                          percent (10 = +10% Energy from every gain)
 #   *_FLAT / RANGE / MANA_REGEN / MOVE_SPEED_FLAT  flat additive
 enum Kind {
 	ATTACK_SPEED,
@@ -43,7 +43,7 @@ enum Kind {
 	# Multiplies every positive Energy intake at SkillController.updateMana
 	# (attack regen, synergy grants, refunds); wave-start refill is a direct
 	# reset, not a gain, and is deliberately outside (SpellCaster synergy).
-	ENERGY_GAIN,
+	ENERGY_AMP,
 }
 
 enum Category { BUFF, DEBUFF, MARK }
@@ -83,7 +83,7 @@ const KIND_FROM_STRING := {
 	"invincible": Kind.INVINCIBLE,
 	"hot": Kind.HOT,
 	"damage_amp_per_cell": Kind.DAMAGE_AMP_PER_CELL,
-	"energy_gain": Kind.ENERGY_GAIN,
+	"energy_amp": Kind.ENERGY_AMP,
 }
 
 const CATEGORY_FROM_STRING := {
@@ -106,7 +106,7 @@ static func is_stat_kind(kind: int) -> bool:
 	# The `< STUN` range test only works for kinds declared before the behavior
 	# block; kinds appended after HOT must be listed explicitly (the enum is
 	# append-only, so the block cannot be re-sorted).
-	return kind < Kind.STUN or kind == Kind.DAMAGE_AMP_PER_CELL or kind == Kind.ENERGY_GAIN
+	return kind < Kind.STUN or kind == Kind.DAMAGE_AMP_PER_CELL or kind == Kind.ENERGY_AMP
 
 # Decimal-scale kinds display as percent (0.5 -> "50%"); percent-scale kinds
 # append % directly; flats show the plain number. Used by the {value} desc
@@ -116,7 +116,7 @@ const _DECIMAL_PERCENT_KINDS := [
 	Kind.MARMOR_MULT, Kind.DAMAGE_AMPLIFIER, Kind.DAMAGE_REDUCTION,
 	Kind.CRIT_DAMAGE_BONUS,
 ]
-const _PERCENT_POINT_KINDS := [Kind.ATTACK_MULT, Kind.MAGIC_MULT, Kind.CRIT_CHANCE, Kind.ENERGY_GAIN]
+const _PERCENT_POINT_KINDS := [Kind.ATTACK_MULT, Kind.MAGIC_MULT, Kind.CRIT_CHANCE, Kind.ENERGY_AMP]
 
 static func format_value(kind: int, value: float) -> String:
 	var v: float = absf(value)

--- a/scripts/skill/skillActions/skill_action_attack.gd
+++ b/scripts/skill/skillActions/skill_action_attack.gd
@@ -16,12 +16,13 @@ class_name SkillActionAttack
 # Sum should = 1.0 (warns if not). Each ratio applies to baseDamage before pipeline.
 @export var hitDistribution: Array[float] = []
 
-# Crit toggle — false disables crit roll for this skill (e.g. Kiara fire blade)
-@export var canCrit: bool = true
-
-# Guaranteed crit — true forces every hit to crit regardless of crit chance
-# (e.g. Regis Altare beat-2 gun shot). Still applies the normal crit multiplier.
-@export var forcedCrit: bool = false
+# Crit rule (YAML `crit_rule`) — skills never crit unless authored:
+#   NO_CRIT          default; the skill cannot crit
+#   USE_CRIT_CHANCE  rolls the tower's own crit chance per hit
+#   GUARANTEED_CRIT  every hit crits (normal crit multiplier), ignoring chance
+#                    (e.g. Regis Altare beat-2 gun shot)
+enum CritRule { NO_CRIT, USE_CRIT_CHANCE, GUARANTEED_CRIT }
+@export var critRule: CritRule = CritRule.NO_CRIT
 
 # Damage type — defaults to tower.data.attackType (set damageTypeOverride=true to use this)
 @export var damageType: Damage.DamageType = Damage.DamageType.PHYSIC
@@ -80,10 +81,11 @@ func execute(context: SkillContext):
 
 	# Cache crit context (avoid recomputing per-target)
 	var stat = tower.data.getStat()
-	# The authored canCrit gate can be opened from outside by the SpellCaster
-	# synergy marker. It unlocks the roll only - the synergy
-	# grants no crit chance, so a 0-chance holder still never crits.
-	var critAllowed: bool = canCrit or tower.data.effects.stacks_of("spellcaster_crit") > 0
+	# The skill_crit_unlock mark opens the roll from outside, overriding an
+	# authored no_crit (dormant - reserved for a future synergy, e.g. Assassin).
+	# It unlocks the roll only: no crit chance is granted, so a 0-chance holder
+	# still never crits.
+	var critAllowed: bool = critRule == CritRule.USE_CRIT_CHANCE or tower.data.effects.stacks_of("skill_crit_unlock") > 0
 	var critChance: float = tower.data.getCritChance() if critAllowed else 0.0
 	var sigmaCD: float = stat.critMultiplier + tower.data.effects.aggregate(EffectTypes.Kind.CRIT_DAMAGE_BONUS)
 
@@ -94,8 +96,8 @@ func execute(context: SkillContext):
 			if not is_instance_valid(target) or not target.has_method("recvDamage"):
 				continue
 			# randi_range(1, 100) → 100 values for exact critChance/100 probability (§6.2 #1 fix)
-			# forcedCrit overrides the roll (guaranteed crit, e.g. Altare beat 2).
-			var isCrit: bool = forcedCrit or (critAllowed and critChance > 0 and randi_range(1, 100) <= critChance)
+			# GUARANTEED_CRIT skips the roll (e.g. Altare beat 2).
+			var isCrit: bool = critRule == CritRule.GUARANTEED_CRIT or (critAllowed and critChance > 0 and randi_range(1, 100) <= critChance)
 			var hitDamage: float = hitBase
 			if isCrit:
 				# §5: Critical Damage = 1 + (1 × (ΣCD − 1)) = ΣCD

--- a/scripts/skill/skillActions/skill_action_field.gd
+++ b/scripts/skill/skillActions/skill_action_field.gd
@@ -18,7 +18,7 @@ extends SkillActionChannel
 # YAML: width, height, duration/duration_param_name (-> castTime),
 #   tick_interval/tick_interval_param_name, energy_refund_percent/
 #   energy_refund_percent_param_name, plus the full "attack" key set
-#   (damage_multiplier_param_name, damage_type, can_crit, effects) reused each
+#   (damage_multiplier_param_name, damage_type, crit_rule, effects) reused each
 #   tick. Reference: resources/database/towers/banzoin_hakka.yaml.
 
 @export var energyRefundPercent: float = 0.0

--- a/scripts/skill/skillActions/skill_action_projectile.gd
+++ b/scripts/skill/skillActions/skill_action_projectile.gd
@@ -6,6 +6,10 @@ extends SkillAction
 @export var damageMultiplier: float = 1;
 @export var damageMultiplierParamName: String = "";
 @export var damageType: Damage.DamageType = Damage.DamageType.PHYSIC
+# Crit rule (YAML `crit_rule`, same values as the attack action). Parse-time
+# constant, safe on the shared action instance; per-cast state must live on
+# the Projectile instead (one action spawns every cast's projectiles).
+@export var critRule: SkillActionAttack.CritRule = SkillActionAttack.CritRule.NO_CRIT
 @export var projectileTemplate: PackedScene;
 @export var statusEffects: Array[EffectSpec] = [];
 
@@ -50,13 +54,39 @@ func addStatusEffects(projectile: Projectile):
 func onHit(projectile: Projectile, target: Enemy):
 	if target is Enemy:
 		var enemy: Enemy = target as Enemy
-		enemy.recvDamage(projectile.damage)
+		enemy.recvDamage(_build_hit_damage(projectile))
 
 		if not is_instance_valid(enemy):
 			return
 
 	if projectile.lifetime < 0:
 		projectile.queue_free()
+
+# Per-hit crit roll: each enemy contact rolls independently, matching the
+# attack action's per-hit rolls (a circle projectile's re-hits included).
+# projectile.damage stays the non-crit base snapshot from spawn - it is the
+# delivered value on a non-crit hit and the fallback when the shooter has
+# been freed mid-flight.
+func _build_hit_damage(projectile: Projectile) -> Damage:
+	var base: Damage = projectile.damage
+	var shooter: Tower = projectile.shooter
+	if not is_instance_valid(shooter):
+		return base
+	# The skill_crit_unlock mark opens the roll from outside, overriding an
+	# authored no_crit - same gate as the attack action, read live per hit.
+	var critAllowed: bool = critRule == SkillActionAttack.CritRule.USE_CRIT_CHANCE \
+			or shooter.data.effects.stacks_of("skill_crit_unlock") > 0
+	var isCrit: bool = critRule == SkillActionAttack.CritRule.GUARANTEED_CRIT
+	if not isCrit and critAllowed:
+		var critChance: float = shooter.data.getCritChance()
+		isCrit = critChance > 0 and randi_range(1, 100) <= critChance
+	if not isCrit:
+		return base
+	var sigmaCD: float = shooter.data.getStat().critMultiplier \
+			+ shooter.data.effects.aggregate(EffectTypes.Kind.CRIT_DAMAGE_BONUS)
+	var dmg := Damage.new(shooter, int(base.damage * sigmaCD), base.type, true)
+	dmg.isSkillDamage = true
+	return dmg
 
 func getDamageMultiplier(context: SkillContext):
 	var tower: Tower = context.user as Tower

--- a/scripts/skill/skill_controller.gd
+++ b/scripts/skill/skill_controller.gd
@@ -10,6 +10,14 @@ func _init(p_user: Node, p_maxMana: float, initialMana: float, skill: Skill):
 	currentMana = initialMana;
 
 func updateMana(amount: float):
+	# Single intake choke: every positive Energy gain (attack regen, synergy
+	# grants, refunds) is multiplied by the holder's ENERGY_GAIN aggregate here.
+	# Drains are negative and must never be amplified. Wave-start refill and the
+	# constructor write currentMana directly - a reset, not a gain.
+	if amount > 0 and user is Tower:
+		amount *= 1.0 + (user as Tower).data.effects.aggregate(EffectTypes.Kind.ENERGY_GAIN) / 100.0
+	# The clamp must land EXACTLY on maxMana: the skill-ready check compares
+	# floats with == (tower.gd), and gains can be non-integral (x1.1).
 	currentMana = clamp(currentMana + amount, 0, maxMana)
 	on_mana_updated.emit(currentMana);
 

--- a/scripts/skill/skill_controller.gd
+++ b/scripts/skill/skill_controller.gd
@@ -11,11 +11,11 @@ func _init(p_user: Node, p_maxMana: float, initialMana: float, skill: Skill):
 
 func updateMana(amount: float):
 	# Single intake choke: every positive Energy gain (attack regen, synergy
-	# grants, refunds) is multiplied by the holder's ENERGY_GAIN aggregate here.
+	# grants, refunds) is multiplied by the holder's ENERGY_AMP aggregate here.
 	# Drains are negative and must never be amplified. Wave-start refill and the
 	# constructor write currentMana directly - a reset, not a gain.
 	if amount > 0 and user is Tower:
-		amount *= 1.0 + (user as Tower).data.effects.aggregate(EffectTypes.Kind.ENERGY_GAIN) / 100.0
+		amount *= 1.0 + (user as Tower).data.effects.aggregate(EffectTypes.Kind.ENERGY_AMP) / 100.0
 	# The clamp must land EXACTLY on maxMana: the skill-ready check compares
 	# floats with == (tower.gd), and gains can be non-integral (x1.1).
 	currentMana = clamp(currentMana + amount, 0, maxMana)

--- a/scripts/skill/skill_utility.gd
+++ b/scripts/skill/skill_utility.gd
@@ -73,6 +73,32 @@ static func _resolve_param(skillData: Dictionary, parameters: Dictionary, param_
 	push_warning("Skill action: ", param_key, " '", pname, "' not in skill parameters - using fallback ", fallback);
 	return fallback;
 
+# Crit authoring (`crit_rule`): no_crit (default) / use_crit_chance /
+# guaranteed_crit. Skills never crit unless authored. Legacy `can_crit` /
+# `force_crit` booleans still map (with a deprecation warning) so an
+# unmigrated file keeps its authored behavior; an ABSENT legacy key falls to
+# the new no-crit default on purpose - that flip is the design rule.
+static func _parse_crit_rule(skillData: Dictionary) -> SkillActionAttack.CritRule:
+	if skillData.has("crit_rule"):
+		var rule := str(skillData["crit_rule"]);
+		match rule:
+			"no_crit":
+				return SkillActionAttack.CritRule.NO_CRIT;
+			"use_crit_chance":
+				return SkillActionAttack.CritRule.USE_CRIT_CHANCE;
+			"guaranteed_crit":
+				return SkillActionAttack.CritRule.GUARANTEED_CRIT;
+			_:
+				push_warning("crit_rule '", rule, "' unknown - use no_crit / use_crit_chance / guaranteed_crit; falling back to no_crit.");
+				return SkillActionAttack.CritRule.NO_CRIT;
+	if skillData.has("force_crit") or skillData.has("can_crit"):
+		push_warning("'can_crit'/'force_crit' are deprecated - author crit_rule: no_crit / use_crit_chance / guaranteed_crit (legacy value mapped).");
+		if bool(skillData.get("force_crit", false)):
+			return SkillActionAttack.CritRule.GUARANTEED_CRIT;
+		if bool(skillData.get("can_crit", false)):
+			return SkillActionAttack.CritRule.USE_CRIT_CHANCE;
+	return SkillActionAttack.CritRule.NO_CRIT;
+
 static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillAction:
 	var skillType = data.get("type", "");
 	var skill: SkillAction;
@@ -173,8 +199,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 				for v in hd:
 					hdArr.append(float(v))
 				skill.hitDistribution = hdArr
-			skill.canCrit = skillData.get("can_crit", true)
-			skill.forcedCrit = skillData.get("force_crit", false)
+			skill.critRule = _parse_crit_rule(skillData)
 			# Stack-scaling bonus (e.g. Calliope Souls): + stacks x per-stack
 			# value on the multiplier, count read live at execute time.
 			skill.stackBonusEffectId = str(skillData.get("stack_bonus_effect", ""))
@@ -195,7 +220,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			# Delayed non-blocking re-hit of a snapshotted area ("aftershock"
 			# pattern). The inner find/attack are built from
 			# this same data block via this parser, so damage_multiplier_param_name,
-			# damage_type, can_crit, and stack_bonus_* all work in the explosion.
+			# damage_type, crit_rule, and stack_bonus_* all work in the explosion.
 			skill = SkillActionAftershock.new();
 			var skillData = data.get("data", {});
 			skill.width = int(skillData.get("width", 3));
@@ -217,7 +242,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 		"channel":
 			# Blocking zone-locked multi-tick ("channel" pattern).
 			# The inner find/attack are built from this same data block via this
-			# parser, so damage_multiplier_param_name, damage_type, can_crit, and
+			# parser, so damage_multiplier_param_name, damage_type, crit_rule, and
 			# effects all work per tick.
 			skill = SkillActionChannel.new();
 			var skillData = data.get("data", {});
@@ -338,6 +363,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill.damageMultiplierParamName = skillData.get("damage_multiplier_param_name", "damageMultiplier");
 			skill.projectile_size_w = skillData.get("projectile_size_w", 1.0);
 			skill.projectile_size_h = skillData.get("projectile_size_h", 1.0);
+			skill.critRule = _parse_crit_rule(skillData);
 			var circleEffectList = skillData.get("effects", []);
 			if(circleEffectList.size() > 0):
 				skill.statusEffects = EffectUtility.parse_effect_list(circleEffectList, parameters, "action_" + str(skill.get_instance_id()));
@@ -351,6 +377,7 @@ static func ParseAction(data: Dictionary, parameters: Dictionary = {}) -> SkillA
 			skill.max_range = float(skillData.get("max_range", -1.0));
 			skill.count = skillData.get("count", 1);
 			skill.lifetime = float(skillData.get("lifetime", 1.5));
+			skill.critRule = _parse_crit_rule(skillData);
 			skill.damageMultiplier = float(skillData.get("damage_multiplier", 1.0));
 			skill.damageType = Utility.parse_string_to_enum(Damage.DamageType, skillData.get("damage_type", "physic"));
 			skill.damageMultiplierParamName = skillData.get("damage_multiplier_param_name", "damageMultiplier");

--- a/scripts/synergy/synergy_effect.gd
+++ b/scripts/synergy/synergy_effect.gd
@@ -49,7 +49,7 @@ static func create(effect_key: String) -> SynergyEffect:
 			return SynergyEffectMissionTempus.new()
 		"attack_per_active_trait":
 			return SynergyEffectAttackPerTrait.new()
-		"magic_up_skill_crit":
+		"magic_up_energy_gain":
 			return SynergyEffectSpellcaster.new()
 		"damage_per_range":
 			return SynergyEffectMarksman.new()

--- a/scripts/synergy/synergy_effect.gd
+++ b/scripts/synergy/synergy_effect.gd
@@ -49,7 +49,7 @@ static func create(effect_key: String) -> SynergyEffect:
 			return SynergyEffectMissionTempus.new()
 		"attack_per_active_trait":
 			return SynergyEffectAttackPerTrait.new()
-		"magic_up_energy_gain":
+		"magic_up_energy_amp":
 			return SynergyEffectSpellcaster.new()
 		"damage_per_range":
 			return SynergyEffectMarksman.new()

--- a/scripts/synergy/synergy_effect_spellcaster.gd
+++ b/scripts/synergy/synergy_effect_spellcaster.gd
@@ -1,11 +1,11 @@
 class_name SynergyEffectSpellcaster
 extends SynergyEffect
 
-# SpellCaster - the first synergy that grants an ABILITY, not only a number:
-# holders get +magic_bonus% Magic Attack AND their skills are allowed to roll
-# critical hits. It deliberately grants NO critical chance (Director 2026-07-19),
-# so a holder sitting at 0 chance still never crits; the gate only stops being
-# the limiting factor. Do not "fix" this by adding crit_chance_up.
+# SpellCaster (redesigned 2026-07-22): holders get +magic_bonus% Magic Attack
+# AND +energy_gain% Energy from every intake (the ENERGY_GAIN multiplier at
+# SkillController.updateMana). The old skill-crit gate moved off this synergy -
+# its mark lives on as the dormant `skill_crit_unlock`, reserved for a future
+# synergy (e.g. Assassin).
 #
 # Two effects share one source_id: EffectInstance.key() is source_id + "/" + id,
 # so the keys stay distinct. Both are REFRESH, so the per-placement re-apply
@@ -23,13 +23,14 @@ func on_tower_added(_tower) -> void:
 
 func _apply_all() -> void:
 	var bonus = data.get_parameter("magic_bonus", 0)
-	if bonus == null:
+	var energy_gain = data.get_parameter("energy_gain", 0)
+	if bonus == null or energy_gain == null:
 		return
 	for tower in controller.towers_with(data.synergy_id):
 		if not is_instance_valid(tower):
 			continue
 		_apply(tower, "magic_mult_up", float(bonus))
-		_apply(tower, "spellcaster_crit", 1.0)
+		_apply(tower, "energy_gain_up", float(energy_gain))
 
 # Lifetime and duration are set explicitly: a registry def is WAVE with a
 # non-zero duration by default, both wrong for a permanent synergy buff (same

--- a/scripts/synergy/synergy_effect_spellcaster.gd
+++ b/scripts/synergy/synergy_effect_spellcaster.gd
@@ -2,7 +2,7 @@ class_name SynergyEffectSpellcaster
 extends SynergyEffect
 
 # SpellCaster (redesigned 2026-07-22): holders get +magic_bonus% Magic Attack
-# AND +energy_gain% Energy from every intake (the ENERGY_GAIN multiplier at
+# AND +energy_amp% Energy from every intake (the ENERGY_AMP multiplier at
 # SkillController.updateMana). The old skill-crit gate moved off this synergy -
 # its mark lives on as the dormant `skill_crit_unlock`, reserved for a future
 # synergy (e.g. Assassin).
@@ -23,14 +23,14 @@ func on_tower_added(_tower) -> void:
 
 func _apply_all() -> void:
 	var bonus = data.get_parameter("magic_bonus", 0)
-	var energy_gain = data.get_parameter("energy_gain", 0)
-	if bonus == null or energy_gain == null:
+	var energy_amp = data.get_parameter("energy_amp", 0)
+	if bonus == null or energy_amp == null:
 		return
 	for tower in controller.towers_with(data.synergy_id):
 		if not is_instance_valid(tower):
 			continue
 		_apply(tower, "magic_mult_up", float(bonus))
-		_apply(tower, "energy_gain_up", float(energy_gain))
+		_apply(tower, "energy_amp_up", float(energy_amp))
 
 # Lifetime and duration are set explicitly: a registry def is WAVE with a
 # non-zero duration by default, both wrong for a permanent synergy buff (same


### PR DESCRIPTION
**Summary:** Skill crit structure: a single authored `crit_rule` key (`no_crit` default / `use_crit_chance` / `guaranteed_crit`) replaces `can_crit`/`force_crit` - skills never crit unless authored. Skill projectiles (Gura circle, Kiara evolved directional) now roll crit per hit at impact. SpellCaster synergy redesigned: +25% Magic Attack + 10% Energy from every source (new ENERGY_AMP effect kind); its old crit gate is parked as the dormant `skill_crit_unlock` mark for a future Assassin synergy.

**How it works:** One parse helper maps `crit_rule` (legacy keys still map, with a deprecation warning) and feeds the attack action plus both projectile create actions; channel/aftershock/field inherit through their inner attack. Projectiles keep a non-crit base `Damage` snapshot and build a fresh per-hit `Damage` at impact from the shooter's live crit stats (freed-shooter falls back to the base). Energy: every positive intake flows through `SkillController.updateMana`, which multiplies by the holder's ENERGY_AMP aggregate (percent); drains are negative and wave-start refill is a direct reset, both untouched. Extension points: any synergy/item can apply `energy_amp_up` or the `skill_crit_unlock` mark with no code change.

**Findings:** Kiara evolved `can_crit: false` was a silent no-op (the projectile parse ignored it) and becomes a live gate under per-hit rolls - kept no-crit per Director. `SkillActionAttackWithParameter` rolls crit outside `crit_rule` but is unreachable (its parser arm is `pass`) - left as-is, flag only. Ina'nis evolved channel loses the demo's only visible skill crit (the SpellCaster gate applier is gone) - intended per the redesign. This branch overlapped PR #119 on 6 files, so it was pushed after that merge per Director.

**Implementation Notes:** All 9 authored YAML sites migrated and carry the enum-comment convention (`# how this skill crits: <options>`). Every default-critter (Altare beat 1, Calliope attack + aftershock, Ina normal, Axel/Bettel/Flayon) stops critting under the new default - a deliberate balance change, Director-tested. Reviewer focus: the `amount > 0` guard in `updateMana` (drains must never be amplified) and the per-hit `Damage` build in `skill_action_projectile.gd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
