### PR TITLE
Fix bullet preview harness UID (adopt Godot-minted) + harness save normalization

### DIFF
--- a/test/vfx_template/bullet_preview_harness.tscn
+++ b/test/vfx_template/bullet_preview_harness.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://cbul1etprevhw"]
+[gd_scene load_steps=2 format=3 uid="uid://35rsy34ftpcq"]
 
 [ext_resource type="Script" path="res://test/vfx_template/bullet_preview_harness.gd" id="1_harness"]
 
@@ -17,5 +17,5 @@ offset_top = 16.0
 offset_right = 1896.0
 offset_bottom = 120.0
 theme_override_font_sizes/font_size = 26
-autowrap_mode = 3
 text = "loading..."
+autowrap_mode = 3

--- a/test/vfx_template/vfx_preview_harness.tscn
+++ b/test/vfx_template/vfx_preview_harness.tscn
@@ -17,5 +17,5 @@ offset_top = 16.0
 offset_right = 1896.0
 offset_bottom = 120.0
 theme_override_font_sizes/font_size = 26
-autowrap_mode = 3
 text = "loading..."
+autowrap_mode = 3


### PR DESCRIPTION
**Problem:** `bullet_preview_harness.tscn` (PR #121) shipped with a hand-written scene UID; Godot rejects it and mints a real one on first editor open, leaving both harness scenes locally modified on every fresh checkout (fake-UID pattern from PR #65/#69).
**Impact:** Dev-only noise - recurring dirty files and a possible `invalid UID` warning; no player-facing change.
**Fix:** Commit the editor-saved state: Godot-minted UID in `bullet_preview_harness.tscn`, plus Godot's serializer property order in both harness scenes so future editor saves are diff-clean. Verified no other file references the old UID.
**Touched scenes:** `test/vfx_template/bullet_preview_harness.tscn`, `test/vfx_template/vfx_preview_harness.tscn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
